### PR TITLE
Fix Golang live tests on Python 3.11

### DIFF
--- a/dev/live_tests/live_test_golang.py
+++ b/dev/live_tests/live_test_golang.py
@@ -13,7 +13,7 @@ import sys
 import tempfile
 from typing import Optional, Pattern
 
-if sys.version_info <= (3, 11):
+if sys.version_info < (3, 12):
     import more_itertools as itertools
 else:
     import itertools


### PR DESCRIPTION
``sys.version_info <= (3, 11)`` is never true for an actual 3.11.x release, since ``sys.version_info`` is a 5-tuple and Python considers a longer tuple greater than its own shorter prefix. This meant the ``more_itertools.batched`` fallback never activated on Python 3.11, and the script crashed immediately.