### PR TITLE
Simplify JSON and XML de/serialization in C++

### DIFF
--- a/aas_core_codegen/cpp/lib/_generate_jsonization.py
+++ b/aas_core_codegen/cpp/lib/_generate_jsonization.py
@@ -911,6 +911,72 @@ std::pair<
     )
 
 
+def _generate_model_type_string_to_model_type(
+    symbol_table: intermediate.SymbolTable,
+) -> List[Stripped]:
+    """
+    Generate the mapping of the JSON ``modelType`` string to the model type.
+
+    This mirrors ``model_type_from_element_name`` on the XML side: a single
+    lookup covering *every* concrete class in the meta-model, generated once,
+    so that dispatch functions can convert the ``modelType`` string to a
+    ``types::ModelType`` and then ``switch`` on it (instead of routing through
+    a ``std::map<std::string, std::function<...>>`` keyed by string per
+    abstract class).
+    """
+    items = []  # type: List[Stripped]
+    for cls in symbol_table.concrete_classes:
+        literal_name = cpp_naming.enum_literal_name(cls.name)
+
+        model_type = naming.json_model_type(cls.name)
+
+        items.append(
+            Stripped(
+                f"""\
+{{
+{I}{cpp_common.string_literal(model_type)},
+{I}types::ModelType::{literal_name}
+}}"""
+            )
+        )
+
+    map_name = cpp_naming.constant_name(Identifier("model_type_string_to_model_type"))
+
+    items_joined = ",\n".join(items)
+
+    function_name = cpp_naming.function_name(
+        Identifier("model_type_from_model_type_string")
+    )
+
+    return [
+        Stripped(
+            f"""\
+/**
+ * Map JSON \\c modelType strings to model types.
+ */
+const std::unordered_map<
+{I}std::string,
+{I}types::ModelType
+> {map_name} = {{
+{I}{indent_but_first_line(items_joined, I)}
+}};"""
+        ),
+        Stripped(
+            f"""\
+common::optional<types::ModelType> {function_name}(
+{I}const std::string& model_type_str
+) {{
+{I}auto it = {map_name}.find(model_type_str);
+{I}if (it == {map_name}.end()) {{
+{II}return common::nullopt;
+{I}}}
+
+{I}return it->second;
+}}"""
+        ),
+    ]
+
+
 def _generate_deserialize_enumeration(
     enumeration: intermediate.Enumeration,
 ) -> Stripped:
@@ -1811,7 +1877,22 @@ std::set<std::string> {expected_properties} = {{
 def _generate_dispatch_deserialize_implementation(
     cls: intermediate.ClassUnion,
 ) -> List[Stripped]:
-    """Generate the impl. of the dispatching deserialization function for ``cls``."""
+    """
+    Generate the impl. of the dispatching deserialization function for ``cls``.
+
+    We convert the JSON ``modelType`` string to a ``types::ModelType`` via the
+    single, file-wide ``ModelTypeFromModelTypeString`` lookup (see
+    :py:func:`_generate_model_type_string_to_model_type`) and then ``switch``
+    on it -- mirroring how the XML side dispatches
+    (``model_type_from_element_name`` + a per-interface ``switch`` in
+    ``_generate_class_from_element``) -- instead of routing through a
+    ``std::map<std::string, std::function<...>>`` built fresh for every
+    abstract class. This lets us abort immediately either because the model
+    type is not recognized at all (the global lookup fails) or because it is
+    recognized but is not one of this interface's own concrete descendants
+    (the ``switch`` falls through to ``default``), without any runtime
+    indirection through ``std::function``.
+    """
     targets: Iterable[intermediate.ConcreteClass]
 
     if isinstance(cls, intermediate.ConcreteClass):
@@ -1823,61 +1904,34 @@ def _generate_dispatch_deserialize_implementation(
 
     interface_name = cpp_naming.interface_name(cls.name)
 
-    entries = []  # type: List[Stripped]
+    case_blocks = []  # type: List[Stripped]
     for target_cls in targets:
-        model_type = naming.json_model_type(target_cls.name)
+        literal_name = cpp_naming.enum_literal_name(target_cls.name)
 
         if len(target_cls.concrete_descendants) > 0:
-            target_function = Stripped(
-                cpp_naming.function_name(
-                    Identifier(f"concretely_deserialize_{target_cls.name}")
-                )
+            target_function = cpp_naming.function_name(
+                Identifier(f"concretely_deserialize_{target_cls.name}")
             )
         else:
-            target_function = Stripped(
-                cpp_naming.function_name(Identifier(f"deserialize_{target_cls.name}"))
+            target_function = cpp_naming.function_name(
+                Identifier(f"deserialize_{target_cls.name}")
             )
 
-        target_function = Stripped(
-            f"""\
-{target_function}<
-{I}types::{interface_name}
->"""
-        )
-
-        entries.append(
+        case_blocks.append(
             Stripped(
                 f"""\
-{{
-{I}{indent_but_first_line(cpp_common.string_literal(model_type), I)},
-{I}{indent_but_first_line(target_function, I)}
-}}"""
+case types::ModelType::{literal_name}:
+{I}return {target_function}<
+{II}types::{interface_name}
+{I}>(json, additional_properties);"""
             )
         )
 
-    entries_joined = ",\n".join(entries)
-
-    dispatch_name = cpp_naming.constant_name(
-        Identifier(f"deserialize_{cls.name}_by_model_type")
-    )
+    case_blocks_joined = "\n".join(case_blocks)
 
     function_name = cpp_naming.function_name(Identifier(f"deserialize_{cls.name}"))
 
     return [
-        Stripped(
-            f"""\
-std::map<
-{I}std::string,
-{I}std::function<
-{II}std::pair<
-{III}common::optional<std::shared_ptr<types::{interface_name}> >,
-{III}common::optional<DeserializationError>
-{II}>(const nlohmann::json&, bool)
-{I}>
-> {dispatch_name} = {{
-{I}{indent_but_first_line(entries_joined, I)}
-}};"""
-        ),
         Stripped(
             f"""\
 std::pair<
@@ -1889,11 +1943,11 @@ std::pair<
 {I}const nlohmann::json& json,
 {I}bool additional_properties
 ) {{
-{I}const std::string* model_type;
+{I}const std::string* model_type_str;
 {I}common::optional<DeserializationError> error;
 
 {I}std::tie(
-{II}model_type,
+{II}model_type_str,
 {II}error
 {I}) = GetModelTypeFrom(json);
 
@@ -1907,13 +1961,14 @@ std::pair<
 {II});
 {I}}}
 
-{I}const auto it = {dispatch_name}.find(*model_type);
-{I}if (it == {dispatch_name}.end()) {{
+{I}common::optional<types::ModelType> model_type(
+{II}ModelTypeFromModelTypeString(*model_type_str)
+{I});
+
+{I}if (!model_type.has_value()) {{
 {II}std::wstring message = common::Concat(
-{III}L"The dispatch to the JSON de-serialization of "
-{III}L"types::{interface_name} "
-{III}L"is not defined for model type: ",
-{III}common::Utf8ToWstring(*model_type)
+{III}L"The model type does not correspond to any known class: ",
+{III}common::Utf8ToWstring(*model_type_str)
 {II});
 
 {II}return std::make_pair<
@@ -1927,7 +1982,27 @@ std::pair<
 {II});
 {I}}}
 
-{I}return (it->second)(json, additional_properties);
+{I}switch (*model_type) {{
+{II}{indent_but_first_line(case_blocks_joined, II)}
+{II}default: {{
+{III}std::wstring message = common::Concat(
+{IIII}L"The dispatch to the JSON de-serialization of "
+{IIII}L"types::{interface_name} "
+{IIII}L"is not defined for model type: ",
+{IIII}common::Utf8ToWstring(*model_type_str)
+{III});
+
+{III}return std::make_pair<
+{IIII}common::optional<std::shared_ptr<types::{interface_name}> >,
+{IIII}common::optional<DeserializationError>
+{III}>(
+{IIII}common::nullopt,
+{IIII}common::make_optional<DeserializationError>(
+{IIIII}message
+{IIII})
+{III});
+{II}}}
+{I}}}
 }}"""
         ),
     ]
@@ -2082,6 +2157,46 @@ std::pair<
     )
 
 
+def _generate_serialize_bool() -> Stripped:
+    """
+    Generate the function to serialize a boolean to a JSON value.
+
+    Named to match ``DeserializeBool``, even though converting a C++ ``bool``
+    to a JSON value can not actually fail.
+    """
+    return Stripped(
+        f"""\
+/**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+{I}bool value
+) {{
+{I}return value;
+}}"""
+    )
+
+
+def _generate_serialize_double() -> Stripped:
+    """
+    Generate the function to serialize a double to a JSON value.
+
+    Named to match ``DeserializeDouble``, even though converting a C++
+    ``double`` to a JSON value can not actually fail.
+    """
+    return Stripped(
+        f"""\
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+{I}double value
+) {{
+{I}return value;
+}}"""
+    )
+
+
 def _generate_serialize_str() -> Stripped:
     """Generate the function to serialize a wide string to a JSON value."""
     return Stripped(
@@ -2210,20 +2325,6 @@ nlohmann::json SerializeListWithInfallible(
     )
 
 
-def _generate_identity() -> Stripped:
-    """Generate the function for identity serialization which we can pass to list serialization."""
-    return Stripped(
-        f"""\
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {{
-{I}return value;
-}}"""
-    )
-
-
 def _generate_serialize_iclass_definition() -> List[Stripped]:
     """Generate the definition of the main dispatch for serializing ``IClass``."""
     return [
@@ -2266,7 +2367,12 @@ def _generate_serialize_primitive_property(
     json_prop_name_literal = cpp_common.string_literal(json_name)
 
     if primitive_type is intermediate.PrimitiveType.BOOL:
-        return Stripped(f"result[{json_prop_name_literal}] = {getter_expr};")
+        return Stripped(
+            f"""\
+result[{json_prop_name_literal}] = SerializeBool(
+{I}{getter_expr}
+);"""
+        )
 
     elif primitive_type is intermediate.PrimitiveType.INT:
         serialized_var = cpp_naming.variable_name(Identifier(f"json_{property_name}"))
@@ -2302,7 +2408,9 @@ result[{json_prop_name_literal}] = std::move(
     elif primitive_type is intermediate.PrimitiveType.FLOAT:
         return Stripped(
             f"""\
-result[{json_prop_name_literal}] = {getter_expr};"""
+result[{json_prop_name_literal}] = SerializeDouble(
+{I}{getter_expr}
+);"""
         )
 
     elif primitive_type is intermediate.PrimitiveType.STR:
@@ -2352,7 +2460,7 @@ def _generate_serialize_list_property(
         if items_primitive_type is intermediate.PrimitiveType.BOOL:
             serialize_list = "SerializeListWithInfallible"
 
-            serialize_item_expr = Stripped("Identity<bool>")
+            serialize_item_expr = Stripped("SerializeBool")
 
         elif items_primitive_type is intermediate.PrimitiveType.INT:
             serialize_list = "SerializeListWithFallible"
@@ -2362,7 +2470,7 @@ def _generate_serialize_list_property(
         elif items_primitive_type is intermediate.PrimitiveType.FLOAT:
             serialize_list = "SerializeListWithInfallible"
 
-            serialize_item_expr = Stripped("Identity<double>")
+            serialize_item_expr = Stripped("SerializeDouble")
 
         elif items_primitive_type is intermediate.PrimitiveType.STR:
             serialize_list = "SerializeListWithInfallible"
@@ -2830,10 +2938,9 @@ def generate_implementation(
 #include "{include_prefix_path}/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)"""
         ),
         cpp_common.generate_namespace_opening(namespace),
@@ -2849,6 +2956,9 @@ def generate_implementation(
         _generate_deserialize_bytearray(),
         _generate_get_model_type(),
     ]
+
+    if any(len(cls.concrete_descendants) > 0 for cls in symbol_table.classes):
+        blocks.extend(_generate_model_type_string_to_model_type(symbol_table))
 
     if any(
         _type_annotation_contains_list(prop.type_annotation)
@@ -2927,12 +3037,13 @@ struct SerializationError {{
 }};  // struct SerializationError"""
             ),
             *_generate_serialization_exception_implementation(),
+            _generate_serialize_bool(),
             _generate_serialize_int(),
+            _generate_serialize_double(),
             _generate_serialize_str(),
             _generate_serialize_bytearray(),
             _generate_serialize_list_with_fallible_item_serialization(),
             _generate_serialize_list_with_infallible_item_serialization(),
-            _generate_identity(),
         ]
     )
 

--- a/aas_core_codegen/cpp/lib/_generate_xmlization.py
+++ b/aas_core_codegen/cpp/lib/_generate_xmlization.py
@@ -2808,7 +2808,11 @@ std::pair<
 
 
 def _generate_deserialize_atomic_value_from_v_element() -> Stripped:
-    """Generate the function to deserialize non-class atomic values from ``<v>``."""
+    """
+    Generate the function to deserialize non-class atomic values from a named
+    element such as ``<v>`` (for list items) or ``<v1>``, ``<v2>``, *etc.*
+    (for other fixed-position items).
+    """
     return Stripped(
         f"""\
 template <typename T, typename DeserializeT>
@@ -2817,7 +2821,8 @@ std::pair<
 {I}common::optional<DeserializationError>
 > DeserializeValueFromVElement(
 {I}ReaderMergingText& reader,
-{I}const DeserializeT& deserialize_content
+{I}const DeserializeT& deserialize_content,
+{I}const std::string& expected_name
 ) {{
 {I}#ifdef DEBUG
 {I}if (reader.node().kind() == NodeKind::Error) {{
@@ -2831,7 +2836,9 @@ std::pair<
 {I}if (reader.node().kind() != NodeKind::Start) {{
 {II}return NoInstanceAndDeserializationErrorWithCause<T>(
 {III}common::Concat(
-{IIII}L"Expected a start element <v> enclosing a value, but got ",
+{IIII}L"Expected a start element <",
+{IIII}common::Utf8ToWstring(expected_name),
+{IIII}L"> enclosing a value, but got ",
 {IIII}NodeToHumanReadableWstring(reader.node())
 {III})
 {II});
@@ -2843,17 +2850,19 @@ std::pair<
 {II}>(reader.node()).name
 {I});
 
-{I}if (start_name != "v") {{
+{I}if (start_name != expected_name) {{
 {II}return NoInstanceAndDeserializationErrorWithCause<T>(
 {III}common::Concat(
-{IIII}L"Expected a start element <v> enclosing a value, but got ",
+{IIII}L"Expected a start element <",
+{IIII}common::Utf8ToWstring(expected_name),
+{IIII}L"> enclosing a value, but got ",
 {IIII}NodeToHumanReadableWstring(reader.node())
 {III})
 {II});
 {I}}}
 
 {I}// NOTE (mristin):
-{I}// We consume the <v>.
+{I}// We consume the start element.
 {I}reader.Read();
 
 {I}if (reader.node().kind() == NodeKind::Error) {{
@@ -2869,7 +2878,9 @@ std::pair<
 
 {I}if (error.has_value()) {{
 {II}error->path.segments.emplace_front(
-{III}common::make_unique<ElementSegment>(L"v")
+{III}common::make_unique<ElementSegment>(
+{IIII}common::Utf8ToWstring(expected_name)
+{III})
 {II});
 
 {II}return NoInstanceAndDeserializationError<T>(
@@ -2880,7 +2891,9 @@ std::pair<
 {I}if (reader.node().kind() != NodeKind::Stop) {{
 {II}return NoInstanceAndDeserializationErrorWithCause<T>(
 {III}common::Concat(
-{IIII}L"Expected a closing element </v> closing a value, but got ",
+{IIII}L"Expected a closing element </",
+{IIII}common::Utf8ToWstring(expected_name),
+{IIII}L"> closing a value, but got ",
 {IIII}NodeToHumanReadableWstring(reader.node())
 {III})
 {II});
@@ -2893,17 +2906,19 @@ std::pair<
 {I});
 
 
-{I}if (stop_name != "v") {{
+{I}if (stop_name != expected_name) {{
 {II}return NoInstanceAndDeserializationErrorWithCause<T>(
 {III}common::Concat(
-{IIII}L"Expected a stop element </v> closing a value, but got ",
+{IIII}L"Expected a closing element </",
+{IIII}common::Utf8ToWstring(expected_name),
+{IIII}L"> closing a value, but got ",
 {IIII}NodeToHumanReadableWstring(reader.node())
 {III})
 {II});
 {I}}}
 
 {I}// NOTE (mristin):
-{I}// We consume the </v>.
+{I}// We consume the closing element.
 {I}reader.Read();
 
 {I}if (reader.node().kind() == NodeKind::Error) {{
@@ -3169,6 +3184,84 @@ const std::unordered_map<
     return result
 
 
+def _xml_deserialize_item_expr(
+    item_type_anno: intermediate.AtomicTypeAnnotation,
+    item_type: Stripped,
+    v_element_name: str,
+) -> Stripped:
+    """
+    Generate the expression of the callable to de-serialize an atomic item from XML.
+
+    The ``v_element_name`` denotes the wrapping element expected for a non-class
+    atomic value (*e.g.*, ``v`` for a list item). Class items ignore
+    ``v_element_name`` as they are de-serialized directly from their own element.
+    """
+    items_primitive_type = intermediate.try_primitive_type(item_type_anno)
+
+    if items_primitive_type is not None:
+        deserialize_text = _PRIMITIVE_TYPE_TO_DESERIALIZE[items_primitive_type]
+
+        v_element_name_literal = cpp_common.string_literal(v_element_name)
+
+        return Stripped(
+            f"""\
+[](ReaderMergingText& a_reader) {{
+{I}return DeserializeValueFromVElement<
+{II}{indent_but_first_line(item_type, II)}
+{I}>(
+{II}a_reader,
+{II}{deserialize_text},
+{II}{v_element_name_literal}
+{I});
+}}"""
+        )
+
+    if isinstance(item_type_anno, intermediate.PrimitiveTypeAnnotation):
+        raise AssertionError("Expected to handle this case before")
+
+    elif isinstance(item_type_anno, intermediate.OurTypeAnnotation):
+        if isinstance(item_type_anno.our_type, intermediate.Enumeration):
+            deserialize_text = cpp_naming.function_name(
+                Identifier(f"deserialize_{item_type_anno.our_type.name}")
+            )
+
+            v_element_name_literal = cpp_common.string_literal(v_element_name)
+
+            return Stripped(
+                f"""\
+[](ReaderMergingText& a_reader) {{
+{I}return DeserializeValueFromVElement<
+{II}{indent_but_first_line(item_type, II)}
+{I}>(
+{II}a_reader,
+{II}{deserialize_text},
+{II}{v_element_name_literal}
+{I});
+}}"""
+            )
+
+        elif isinstance(item_type_anno.our_type, intermediate.ConstrainedPrimitive):
+            raise AssertionError("Expected to handle this case before")
+
+        elif isinstance(
+            item_type_anno.our_type,
+            (intermediate.AbstractClass, intermediate.ConcreteClass),
+        ):
+            return cpp_naming.function_name(
+                Identifier(f"{item_type_anno.our_type.name}_from_element")
+            )
+
+        else:
+            # noinspection PyTypeChecker
+            assert_never(item_type_anno.our_type)
+
+    else:
+        # noinspection PyTypeChecker
+        assert_never(item_type_anno)
+
+    raise AssertionError("Should not have gotten here")
+
+
 def _generate_deserialize_list_property(
     prop: intermediate.Property,
 ) -> Stripped:
@@ -3190,70 +3283,16 @@ def _generate_deserialize_list_property(
         type_annotation=type_anno.items, types_namespace=cpp_common.TYPES_NAMESPACE
     )
 
-    deserialize_item_expr: Stripped
-
-    items_primitive_type = intermediate.try_primitive_type(type_anno.items)
-
-    if items_primitive_type is not None:
-        deserialize_text = _PRIMITIVE_TYPE_TO_DESERIALIZE[items_primitive_type]
-
-        deserialize_item_expr = Stripped(
-            f"""\
-[](ReaderMergingText& a_reader) {{
-{I}return DeserializeValueFromVElement<
-{II}{indent_but_first_line(item_type, II)}
-{I}>(
-{II}a_reader,
-{II}{deserialize_text}
-{I});
-}}"""
+    if not isinstance(type_anno.items, intermediate.AtomicTypeAnnotationAsTuple):
+        raise NotImplementedError(
+            "NOTE (mristin): We currently generate XML de-serialization only for "
+            f"the lists of atomic values, but we got: {prop.type_annotation}. "
+            f"Please contact the developers if you need this feature."
         )
 
-    else:
-        if isinstance(type_anno.items, intermediate.PrimitiveTypeAnnotation):
-            raise AssertionError("Expected to handle this case before")
-
-        elif isinstance(type_anno.items, intermediate.OurTypeAnnotation):
-            if isinstance(type_anno.items.our_type, intermediate.Enumeration):
-                deserialize_text = cpp_naming.function_name(
-                    Identifier(f"deserialize_{type_anno.items.our_type.name}")
-                )
-
-                deserialize_item_expr = Stripped(
-                    f"""\
-[](ReaderMergingText& a_reader) {{
-{I}return DeserializeValueFromVElement<
-{II}{indent_but_first_line(item_type, II)}
-{I}>(
-{II}a_reader,
-{II}{deserialize_text}
-{I});
-}}"""
-                )
-
-            elif isinstance(
-                type_anno.items.our_type, intermediate.ConstrainedPrimitive
-            ):
-                raise AssertionError("Expected to handle this case before")
-
-            elif isinstance(
-                type_anno.items.our_type,
-                (intermediate.AbstractClass, intermediate.ConcreteClass),
-            ):
-                deserialize_item_expr = cpp_naming.function_name(
-                    Identifier(f"{type_anno.items.our_type.name}_from_element")
-                )
-
-            else:
-                # noinspection PyTypeChecker
-                assert_never(type_anno.items.our_type)
-
-        else:
-            raise NotImplementedError(
-                "NOTE (mristin): We currently generate XML de-serialization only for "
-                f"the lists of atomic values, but we got: {prop.type_annotation}. "
-                f"Please contact the developers if you need this feature."
-            )
+    deserialize_item_expr = _xml_deserialize_item_expr(
+        item_type_anno=type_anno.items, item_type=item_type, v_element_name="v"
+    )
 
     return Stripped(
         f"""\
@@ -3462,9 +3501,10 @@ common::optional<
         case_blocks.append(
             Stripped(
                 f"""\
-case properties::{prop_enum_name}::{prop_literal}:
+case properties::{prop_enum_name}::{prop_literal}: {{
 {I}{indent_but_first_line(code, I)}
-{I}break;"""
+{I}break;
+}}"""
             )
         )
 
@@ -4814,28 +4854,72 @@ common::optional<SerializationError> {function_name}(
     )
 
 
-def _generate_serialize_list_property(
-    item_type_annotation: intermediate.TypeAnnotationUnion, getter_expr: Stripped
-) -> Stripped:
-    """Serialize the list at ``var_name``."""
-    # NOTE (mristin):
-    # We separated this logic from the _generate_serialize_property function since it
-    # grew too large to comprehend and debug -- Python does not support scopes, so we
-    # could not make sure that the variables are not re-used.
+def _generate_serialize_property_as_element() -> Stripped:
+    """
+    Generate the generic function to serialize a property wrapped in its own
+    named XML element.
 
+    This factors out the ``StartElement``/serialize-call/``StopElement``
+    skeleton shared by every property regardless of kind (primitive, enum,
+    class or list), so that :py:func:`_generate_serialize_property` only
+    needs to supply the element name, the value and a value-specific
+    ``serialize_value`` callable.
+    """
+    return Stripped(
+        f"""\
+/**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+{I}const std::string& name,
+{I}const T& value,
+{I}SelfClosingWriter& writer,
+{I}iteration::Property property,
+{I}const SerializeT& serialize_value
+) {{
+{I}writer.StartElement(name);
+{I}if (writer.error().has_value()) {{
+{II}return writer.move_error();
+{I}}}
+
+{I}common::optional<SerializationError> error = serialize_value(value, writer);
+{I}if (error.has_value()) {{
+{II}error->path.segments.emplace_front(
+{III}common::make_unique<iteration::PropertySegment>(property)
+{II});
+{II}return error;
+{I}}}
+
+{I}writer.StopElement(name);
+{I}if (writer.error().has_value()) {{
+{II}error = writer.move_error();
+{II}error->path.segments.emplace_front(
+{III}common::make_unique<iteration::PropertySegment>(property)
+{II});
+{II}return error;
+{I}}}
+
+{I}return common::nullopt;
+}}"""
+    )
+
+
+def _xml_serialize_list_value_expr(
+    item_type_annotation: intermediate.TypeAnnotationUnion, item_type: Stripped
+) -> Stripped:
+    """
+    Build the ``(list, writer) -> optional<SerializationError>`` callable for
+    a list-typed property, to be plugged into ``SerializePropertyAsElement``.
+    """
     items_primitive_type = intermediate.try_primitive_type(item_type_annotation)
 
-    if items_primitive_type is not None:
-        serialize_function = _PRIMITIVE_TYPE_TO_SERIALIZE[items_primitive_type]
+    list_helper: str
+    serialize_item: str
 
-        return Stripped(
-            f"""\
-error = SerializeListOfVElements(
-{I}{indent_but_first_line(getter_expr, I)},
-{I}writer,
-{I}{serialize_function}
-);"""
-        )
+    if items_primitive_type is not None:
+        serialize_item = _PRIMITIVE_TYPE_TO_SERIALIZE[items_primitive_type]
+        list_helper = "SerializeListOfVElements"
 
     else:
         if isinstance(item_type_annotation, intermediate.PrimitiveTypeAnnotation):
@@ -4843,18 +4927,10 @@ error = SerializeListOfVElements(
 
         elif isinstance(item_type_annotation, intermediate.OurTypeAnnotation):
             if isinstance(item_type_annotation.our_type, intermediate.Enumeration):
-                serialize_function = cpp_naming.function_name(
+                serialize_item = cpp_naming.function_name(
                     Identifier(f"serialize_{item_type_annotation.our_type.name}")
                 )
-
-                return Stripped(
-                    f"""\
-error = SerializeListOfVElements(
-{I}{indent_but_first_line(getter_expr, I)},
-{I}writer,
-{I}{serialize_function}
-);"""
-                )
+                list_helper = "SerializeListOfVElements"
 
             elif isinstance(
                 item_type_annotation.our_type, intermediate.ConstrainedPrimitive
@@ -4865,24 +4941,16 @@ error = SerializeListOfVElements(
                 item_type_annotation.our_type,
                 (intermediate.AbstractClass, intermediate.ConcreteClass),
             ):
-                serialize_function = cpp_naming.function_name(
+                serialize_item = cpp_naming.function_name(
                     Identifier(
                         f"serialize_{item_type_annotation.our_type.name}_ptr_as_element"
                     )
                 )
-
-                return Stripped(
-                    f"""\
-error = SerializeListOfInstances(
-{I}{indent_but_first_line(getter_expr, I)},
-{I}writer,
-{I}{serialize_function}
-);"""
-                )
+                list_helper = "SerializeListOfInstances"
 
             else:
                 # noinspection PyTypeChecker
-                assert_never(item_type_annotation)
+                assert_never(item_type_annotation.our_type)
 
         else:
             raise NotImplementedError(
@@ -4892,11 +4960,26 @@ error = SerializeListOfInstances(
                 f"Please contact the developers if you need this feature."
             )
 
+    return Stripped(
+        f"""\
+[](
+{I}const std::vector<{indent_but_first_line(item_type, I)}>& a_list,
+{I}SelfClosingWriter& a_writer
+) {{
+{I}return {list_helper}(a_list, a_writer, {serialize_item});
+}}"""
+    )
+
 
 def _generate_serialize_property(prop: intermediate.Property) -> Stripped:
-    """Generate code to serialize a property."""
-    blocks = []  # type: List[Stripped]
+    """
+    Generate code to serialize a property.
 
+    The property is wrapped in its own named XML element via the generic
+    :py:func:`_generate_serialize_property_as_element`; this function only
+    needs to determine the value expression and the value-specific
+    ``serialize_value`` callable for the property's kind.
+    """
     getter_name = cpp_naming.getter_name(prop.name)
 
     getter_expr: Stripped
@@ -4908,50 +4991,28 @@ def _generate_serialize_property(prop: intermediate.Property) -> Stripped:
 
     xml_name_literal = cpp_common.string_literal(prop.xml_name)
 
-    blocks.append(
-        Stripped(
-            f"""\
-writer.StartElement(
-{I}{xml_name_literal}
-);
-if (writer.error().has_value()) {{
-{I}return writer.move_error();
-}}"""
-        )
-    )
-
-    code: Stripped
-
     type_anno = intermediate.beneath_optional(prop.type_annotation)
 
     primitive_type = intermediate.try_primitive_type(type_anno)
 
-    if primitive_type is not None:
-        serialize_function = _PRIMITIVE_TYPE_TO_SERIALIZE[primitive_type]
+    value_expr: Stripped
+    serialize_value_expr: Stripped
 
-        code = Stripped(
-            f"""\
-error = {serialize_function}(
-{I}{getter_expr},
-{I}writer
-);"""
-        )
+    if primitive_type is not None:
+        value_expr = getter_expr
+        serialize_value_expr = Stripped(_PRIMITIVE_TYPE_TO_SERIALIZE[primitive_type])
+
     else:
         if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
             raise AssertionError("Expected to handle this case before")
 
         elif isinstance(type_anno, intermediate.OurTypeAnnotation):
             if isinstance(type_anno.our_type, intermediate.Enumeration):
-                serialize_function = cpp_naming.function_name(
-                    Identifier(f"serialize_{type_anno.our_type.name}")
-                )
-
-                code = Stripped(
-                    f"""\
-error = {serialize_function}(
-{I}{getter_expr},
-{I}writer
-);"""
+                value_expr = getter_expr
+                serialize_value_expr = Stripped(
+                    cpp_naming.function_name(
+                        Identifier(f"serialize_{type_anno.our_type.name}")
+                    )
                 )
 
             elif isinstance(type_anno.our_type, intermediate.ConstrainedPrimitive):
@@ -4961,74 +5022,58 @@ error = {serialize_function}(
                 type_anno.our_type,
                 (intermediate.AbstractClass, intermediate.ConcreteClass),
             ):
+                value_expr = Stripped(f"*({getter_expr})")
+
                 if len(type_anno.our_type.concrete_descendants) == 0:
-                    serialize_function = cpp_naming.function_name(
-                        Identifier(f"serialize_{type_anno.our_type.name}_as_sequence")
+                    serialize_value_expr = Stripped(
+                        cpp_naming.function_name(
+                            Identifier(
+                                f"serialize_{type_anno.our_type.name}_as_sequence"
+                            )
+                        )
                     )
                 else:
-                    serialize_function = cpp_naming.function_name(
-                        Identifier(f"serialize_{type_anno.our_type.name}_as_element")
+                    serialize_value_expr = Stripped(
+                        cpp_naming.function_name(
+                            Identifier(
+                                f"serialize_{type_anno.our_type.name}_as_element"
+                            )
+                        )
                     )
-
-                code = Stripped(
-                    f"""\
-error = {serialize_function}(
-{I}*({getter_expr}),
-{I}writer
-);"""
-                )
             else:
                 # noinspection PyTypeChecker
                 assert_never(type_anno.our_type)
 
         elif isinstance(type_anno, intermediate.ListTypeAnnotation):
-            code = _generate_serialize_list_property(
-                item_type_annotation=type_anno.items, getter_expr=getter_expr
+            value_expr = getter_expr
+
+            item_type = cpp_common.generate_type(
+                type_annotation=type_anno.items,
+                types_namespace=cpp_common.TYPES_NAMESPACE,
+            )
+            serialize_value_expr = _xml_serialize_list_value_expr(
+                item_type_annotation=type_anno.items, item_type=item_type
             )
 
         else:
             # noinspection PyTypeChecker
             assert_never(type_anno)
 
-    blocks.append(code)
-
     prop_literal = cpp_naming.enum_literal_name(prop.name)
-    blocks.append(
-        Stripped(
-            f"""\
-if (error.has_value()) {{
-{I}error->path.segments.emplace_front(
-{II}common::make_unique<iteration::PropertySegment>(
-{III}iteration::Property::{prop_literal}
-{II})
-{I});
 
-{I}return error;
-}}"""
-        )
-    )
-
-    blocks.append(
-        Stripped(
-            f"""\
-writer.StopElement(
-{I}{xml_name_literal}
+    code = Stripped(
+        f"""\
+error = SerializePropertyAsElement(
+{I}{xml_name_literal},
+{I}{indent_but_first_line(value_expr, I)},
+{I}writer,
+{I}iteration::Property::{prop_literal},
+{I}{indent_but_first_line(serialize_value_expr, I)}
 );
-if (writer.error().has_value()) {{
-{I}error = writer.move_error();
-
-{I}error->path.segments.emplace_front(
-{II}common::make_unique<iteration::PropertySegment>(
-{III}iteration::Property::{prop_literal}
-{II})
-{I});
-
+if (error.has_value()) {{
 {I}return error;
 }}"""
-        )
     )
-
-    code = Stripped("\n".join(blocks))
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
         code = Stripped(
@@ -5913,6 +5958,9 @@ common::optional<SerializationError> CheckOstreamState(
             *_generate_serialize_primitives(),
         ]
     )
+
+    if any(len(cls.properties) > 0 for cls in symbol_table.concrete_classes):
+        blocks.append(_generate_serialize_property_as_element())
 
     if any(
         _type_annotation_contains_list_of_atomic_non_class_values(prop.type_annotation)

--- a/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "aas_core/aas_3_0/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace aas_core {
@@ -490,6 +489,178 @@ std::pair<
     model_type,
     common::nullopt
   );
+}
+
+/**
+ * Map JSON \c modelType strings to model types.
+ */
+const std::unordered_map<
+  std::string,
+  types::ModelType
+> kModelTypeStringToModelType = {
+  {
+    "Extension",
+    types::ModelType::kExtension
+  },
+  {
+    "AdministrativeInformation",
+    types::ModelType::kAdministrativeInformation
+  },
+  {
+    "Qualifier",
+    types::ModelType::kQualifier
+  },
+  {
+    "AssetAdministrationShell",
+    types::ModelType::kAssetAdministrationShell
+  },
+  {
+    "AssetInformation",
+    types::ModelType::kAssetInformation
+  },
+  {
+    "Resource",
+    types::ModelType::kResource
+  },
+  {
+    "SpecificAssetId",
+    types::ModelType::kSpecificAssetId
+  },
+  {
+    "Submodel",
+    types::ModelType::kSubmodel
+  },
+  {
+    "RelationshipElement",
+    types::ModelType::kRelationshipElement
+  },
+  {
+    "SubmodelElementList",
+    types::ModelType::kSubmodelElementList
+  },
+  {
+    "SubmodelElementCollection",
+    types::ModelType::kSubmodelElementCollection
+  },
+  {
+    "Property",
+    types::ModelType::kProperty
+  },
+  {
+    "MultiLanguageProperty",
+    types::ModelType::kMultiLanguageProperty
+  },
+  {
+    "Range",
+    types::ModelType::kRange
+  },
+  {
+    "ReferenceElement",
+    types::ModelType::kReferenceElement
+  },
+  {
+    "Blob",
+    types::ModelType::kBlob
+  },
+  {
+    "File",
+    types::ModelType::kFile
+  },
+  {
+    "AnnotatedRelationshipElement",
+    types::ModelType::kAnnotatedRelationshipElement
+  },
+  {
+    "Entity",
+    types::ModelType::kEntity
+  },
+  {
+    "EventPayload",
+    types::ModelType::kEventPayload
+  },
+  {
+    "BasicEventElement",
+    types::ModelType::kBasicEventElement
+  },
+  {
+    "Operation",
+    types::ModelType::kOperation
+  },
+  {
+    "OperationVariable",
+    types::ModelType::kOperationVariable
+  },
+  {
+    "Capability",
+    types::ModelType::kCapability
+  },
+  {
+    "ConceptDescription",
+    types::ModelType::kConceptDescription
+  },
+  {
+    "Reference",
+    types::ModelType::kReference
+  },
+  {
+    "Key",
+    types::ModelType::kKey
+  },
+  {
+    "LangStringNameType",
+    types::ModelType::kLangStringNameType
+  },
+  {
+    "LangStringTextType",
+    types::ModelType::kLangStringTextType
+  },
+  {
+    "Environment",
+    types::ModelType::kEnvironment
+  },
+  {
+    "EmbeddedDataSpecification",
+    types::ModelType::kEmbeddedDataSpecification
+  },
+  {
+    "LevelType",
+    types::ModelType::kLevelType
+  },
+  {
+    "ValueReferencePair",
+    types::ModelType::kValueReferencePair
+  },
+  {
+    "ValueList",
+    types::ModelType::kValueList
+  },
+  {
+    "LangStringPreferredNameTypeIec61360",
+    types::ModelType::kLangStringPreferredNameTypeIec61360
+  },
+  {
+    "LangStringShortNameTypeIec61360",
+    types::ModelType::kLangStringShortNameTypeIec61360
+  },
+  {
+    "LangStringDefinitionTypeIec61360",
+    types::ModelType::kLangStringDefinitionTypeIec61360
+  },
+  {
+    "DataSpecificationIec61360",
+    types::ModelType::kDataSpecificationIec61360
+  }
+};
+
+common::optional<types::ModelType> ModelTypeFromModelTypeString(
+  const std::string& model_type_str
+) {
+  auto it = kModelTypeStringToModelType.find(model_type_str);
+  if (it == kModelTypeStringToModelType.end()) {
+    return common::nullopt;
+  }
+
+  return it->second;
 }
 
 template <typename T, typename DeserializeItemT>
@@ -2297,125 +2468,6 @@ std::pair<
   bool additional_properties
 );
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IHasSemantics> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeHasSemanticsByModelType = {
-  {
-    "RelationshipElement",
-    ConcretelyDeserializeRelationshipElement<
-      types::IHasSemantics
-    >
-  },
-  {
-    "AnnotatedRelationshipElement",
-    DeserializeAnnotatedRelationshipElement<
-      types::IHasSemantics
-    >
-  },
-  {
-    "BasicEventElement",
-    DeserializeBasicEventElement<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Blob",
-    DeserializeBlob<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Capability",
-    DeserializeCapability<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Entity",
-    DeserializeEntity<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Extension",
-    DeserializeExtension<
-      types::IHasSemantics
-    >
-  },
-  {
-    "File",
-    DeserializeFile<
-      types::IHasSemantics
-    >
-  },
-  {
-    "MultiLanguageProperty",
-    DeserializeMultiLanguageProperty<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Operation",
-    DeserializeOperation<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Property",
-    DeserializeProperty<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Qualifier",
-    DeserializeQualifier<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Range",
-    DeserializeRange<
-      types::IHasSemantics
-    >
-  },
-  {
-    "ReferenceElement",
-    DeserializeReferenceElement<
-      types::IHasSemantics
-    >
-  },
-  {
-    "SpecificAssetId",
-    DeserializeSpecificAssetId<
-      types::IHasSemantics
-    >
-  },
-  {
-    "Submodel",
-    DeserializeSubmodel<
-      types::IHasSemantics
-    >
-  },
-  {
-    "SubmodelElementCollection",
-    DeserializeSubmodelElementCollection<
-      types::IHasSemantics
-    >
-  },
-  {
-    "SubmodelElementList",
-    DeserializeSubmodelElementList<
-      types::IHasSemantics
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IHasSemantics>
@@ -2425,11 +2477,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -2443,13 +2495,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeHasSemanticsByModelType.find(*model_type);
-  if (it == kDeserializeHasSemanticsByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IHasSemantics "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -2463,7 +2516,98 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kRelationshipElement:
+      return ConcretelyDeserializeRelationshipElement<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kAnnotatedRelationshipElement:
+      return DeserializeAnnotatedRelationshipElement<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kBasicEventElement:
+      return DeserializeBasicEventElement<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kBlob:
+      return DeserializeBlob<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kCapability:
+      return DeserializeCapability<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kEntity:
+      return DeserializeEntity<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kExtension:
+      return DeserializeExtension<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kFile:
+      return DeserializeFile<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kMultiLanguageProperty:
+      return DeserializeMultiLanguageProperty<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kOperation:
+      return DeserializeOperation<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kProperty:
+      return DeserializeProperty<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kQualifier:
+      return DeserializeQualifier<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kRange:
+      return DeserializeRange<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kReferenceElement:
+      return DeserializeReferenceElement<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kSpecificAssetId:
+      return DeserializeSpecificAssetId<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kSubmodel:
+      return DeserializeSubmodel<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementCollection:
+      return DeserializeSubmodelElementCollection<
+        types::IHasSemantics
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementList:
+      return DeserializeSubmodelElementList<
+        types::IHasSemantics
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IHasSemantics "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IHasSemantics> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInExtension = {
@@ -2772,119 +2916,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IHasExtensions> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeHasExtensionsByModelType = {
-  {
-    "RelationshipElement",
-    ConcretelyDeserializeRelationshipElement<
-      types::IHasExtensions
-    >
-  },
-  {
-    "AnnotatedRelationshipElement",
-    DeserializeAnnotatedRelationshipElement<
-      types::IHasExtensions
-    >
-  },
-  {
-    "AssetAdministrationShell",
-    DeserializeAssetAdministrationShell<
-      types::IHasExtensions
-    >
-  },
-  {
-    "BasicEventElement",
-    DeserializeBasicEventElement<
-      types::IHasExtensions
-    >
-  },
-  {
-    "Blob",
-    DeserializeBlob<
-      types::IHasExtensions
-    >
-  },
-  {
-    "Capability",
-    DeserializeCapability<
-      types::IHasExtensions
-    >
-  },
-  {
-    "ConceptDescription",
-    DeserializeConceptDescription<
-      types::IHasExtensions
-    >
-  },
-  {
-    "Entity",
-    DeserializeEntity<
-      types::IHasExtensions
-    >
-  },
-  {
-    "File",
-    DeserializeFile<
-      types::IHasExtensions
-    >
-  },
-  {
-    "MultiLanguageProperty",
-    DeserializeMultiLanguageProperty<
-      types::IHasExtensions
-    >
-  },
-  {
-    "Operation",
-    DeserializeOperation<
-      types::IHasExtensions
-    >
-  },
-  {
-    "Property",
-    DeserializeProperty<
-      types::IHasExtensions
-    >
-  },
-  {
-    "Range",
-    DeserializeRange<
-      types::IHasExtensions
-    >
-  },
-  {
-    "ReferenceElement",
-    DeserializeReferenceElement<
-      types::IHasExtensions
-    >
-  },
-  {
-    "Submodel",
-    DeserializeSubmodel<
-      types::IHasExtensions
-    >
-  },
-  {
-    "SubmodelElementCollection",
-    DeserializeSubmodelElementCollection<
-      types::IHasExtensions
-    >
-  },
-  {
-    "SubmodelElementList",
-    DeserializeSubmodelElementList<
-      types::IHasExtensions
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IHasExtensions>
@@ -2894,11 +2925,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -2912,13 +2943,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeHasExtensionsByModelType.find(*model_type);
-  if (it == kDeserializeHasExtensionsByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IHasExtensions "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -2932,121 +2964,95 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
-}
+  switch (*model_type) {
+    case types::ModelType::kRelationshipElement:
+      return ConcretelyDeserializeRelationshipElement<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kAnnotatedRelationshipElement:
+      return DeserializeAnnotatedRelationshipElement<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kAssetAdministrationShell:
+      return DeserializeAssetAdministrationShell<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kBasicEventElement:
+      return DeserializeBasicEventElement<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kBlob:
+      return DeserializeBlob<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kCapability:
+      return DeserializeCapability<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kConceptDescription:
+      return DeserializeConceptDescription<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kEntity:
+      return DeserializeEntity<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kFile:
+      return DeserializeFile<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kMultiLanguageProperty:
+      return DeserializeMultiLanguageProperty<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kOperation:
+      return DeserializeOperation<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kProperty:
+      return DeserializeProperty<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kRange:
+      return DeserializeRange<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kReferenceElement:
+      return DeserializeReferenceElement<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kSubmodel:
+      return DeserializeSubmodel<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementCollection:
+      return DeserializeSubmodelElementCollection<
+        types::IHasExtensions
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementList:
+      return DeserializeSubmodelElementList<
+        types::IHasExtensions
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IHasExtensions "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IReferable> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeReferableByModelType = {
-  {
-    "RelationshipElement",
-    ConcretelyDeserializeRelationshipElement<
-      types::IReferable
-    >
-  },
-  {
-    "AnnotatedRelationshipElement",
-    DeserializeAnnotatedRelationshipElement<
-      types::IReferable
-    >
-  },
-  {
-    "AssetAdministrationShell",
-    DeserializeAssetAdministrationShell<
-      types::IReferable
-    >
-  },
-  {
-    "BasicEventElement",
-    DeserializeBasicEventElement<
-      types::IReferable
-    >
-  },
-  {
-    "Blob",
-    DeserializeBlob<
-      types::IReferable
-    >
-  },
-  {
-    "Capability",
-    DeserializeCapability<
-      types::IReferable
-    >
-  },
-  {
-    "ConceptDescription",
-    DeserializeConceptDescription<
-      types::IReferable
-    >
-  },
-  {
-    "Entity",
-    DeserializeEntity<
-      types::IReferable
-    >
-  },
-  {
-    "File",
-    DeserializeFile<
-      types::IReferable
-    >
-  },
-  {
-    "MultiLanguageProperty",
-    DeserializeMultiLanguageProperty<
-      types::IReferable
-    >
-  },
-  {
-    "Operation",
-    DeserializeOperation<
-      types::IReferable
-    >
-  },
-  {
-    "Property",
-    DeserializeProperty<
-      types::IReferable
-    >
-  },
-  {
-    "Range",
-    DeserializeRange<
-      types::IReferable
-    >
-  },
-  {
-    "ReferenceElement",
-    DeserializeReferenceElement<
-      types::IReferable
-    >
-  },
-  {
-    "Submodel",
-    DeserializeSubmodel<
-      types::IReferable
-    >
-  },
-  {
-    "SubmodelElementCollection",
-    DeserializeSubmodelElementCollection<
-      types::IReferable
-    >
-  },
-  {
-    "SubmodelElementList",
-    DeserializeSubmodelElementList<
-      types::IReferable
-    >
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IHasExtensions> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
   }
-};
+}
 
 std::pair<
   common::optional<
@@ -3057,11 +3063,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -3075,13 +3081,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeReferableByModelType.find(*model_type);
-  if (it == kDeserializeReferableByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IReferable "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -3095,37 +3102,95 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
-}
+  switch (*model_type) {
+    case types::ModelType::kRelationshipElement:
+      return ConcretelyDeserializeRelationshipElement<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kAnnotatedRelationshipElement:
+      return DeserializeAnnotatedRelationshipElement<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kAssetAdministrationShell:
+      return DeserializeAssetAdministrationShell<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kBasicEventElement:
+      return DeserializeBasicEventElement<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kBlob:
+      return DeserializeBlob<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kCapability:
+      return DeserializeCapability<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kConceptDescription:
+      return DeserializeConceptDescription<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kEntity:
+      return DeserializeEntity<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kFile:
+      return DeserializeFile<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kMultiLanguageProperty:
+      return DeserializeMultiLanguageProperty<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kOperation:
+      return DeserializeOperation<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kProperty:
+      return DeserializeProperty<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kRange:
+      return DeserializeRange<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kReferenceElement:
+      return DeserializeReferenceElement<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kSubmodel:
+      return DeserializeSubmodel<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementCollection:
+      return DeserializeSubmodelElementCollection<
+        types::IReferable
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementList:
+      return DeserializeSubmodelElementList<
+        types::IReferable
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IReferable "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IIdentifiable> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeIdentifiableByModelType = {
-  {
-    "AssetAdministrationShell",
-    DeserializeAssetAdministrationShell<
-      types::IIdentifiable
-    >
-  },
-  {
-    "ConceptDescription",
-    DeserializeConceptDescription<
-      types::IIdentifiable
-    >
-  },
-  {
-    "Submodel",
-    DeserializeSubmodel<
-      types::IIdentifiable
-    >
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IReferable> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
   }
-};
+}
 
 std::pair<
   common::optional<
@@ -3136,11 +3201,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -3154,13 +3219,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeIdentifiableByModelType.find(*model_type);
-  if (it == kDeserializeIdentifiableByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IIdentifiable "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -3174,25 +3240,39 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
-}
+  switch (*model_type) {
+    case types::ModelType::kAssetAdministrationShell:
+      return DeserializeAssetAdministrationShell<
+        types::IIdentifiable
+      >(json, additional_properties);
+    case types::ModelType::kConceptDescription:
+      return DeserializeConceptDescription<
+        types::IIdentifiable
+      >(json, additional_properties);
+    case types::ModelType::kSubmodel:
+      return DeserializeSubmodel<
+        types::IIdentifiable
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IIdentifiable "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IHasKind> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeHasKindByModelType = {
-  {
-    "Submodel",
-    DeserializeSubmodel<
-      types::IHasKind
-    >
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IIdentifiable> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
   }
-};
+}
 
 std::pair<
   common::optional<
@@ -3203,11 +3283,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -3221,13 +3301,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeHasKindByModelType.find(*model_type);
-  if (it == kDeserializeHasKindByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IHasKind "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -3241,127 +3322,31 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
-}
+  switch (*model_type) {
+    case types::ModelType::kSubmodel:
+      return DeserializeSubmodel<
+        types::IHasKind
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IHasKind "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IHasDataSpecification> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeHasDataSpecificationByModelType = {
-  {
-    "AdministrativeInformation",
-    DeserializeAdministrativeInformation<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "RelationshipElement",
-    ConcretelyDeserializeRelationshipElement<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "AnnotatedRelationshipElement",
-    DeserializeAnnotatedRelationshipElement<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "AssetAdministrationShell",
-    DeserializeAssetAdministrationShell<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "BasicEventElement",
-    DeserializeBasicEventElement<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "Blob",
-    DeserializeBlob<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "Capability",
-    DeserializeCapability<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "ConceptDescription",
-    DeserializeConceptDescription<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "Entity",
-    DeserializeEntity<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "File",
-    DeserializeFile<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "MultiLanguageProperty",
-    DeserializeMultiLanguageProperty<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "Operation",
-    DeserializeOperation<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "Property",
-    DeserializeProperty<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "Range",
-    DeserializeRange<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "ReferenceElement",
-    DeserializeReferenceElement<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "Submodel",
-    DeserializeSubmodel<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "SubmodelElementCollection",
-    DeserializeSubmodelElementCollection<
-      types::IHasDataSpecification
-    >
-  },
-  {
-    "SubmodelElementList",
-    DeserializeSubmodelElementList<
-      types::IHasDataSpecification
-    >
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IHasKind> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
   }
-};
+}
 
 std::pair<
   common::optional<
@@ -3372,11 +3357,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -3390,13 +3375,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeHasDataSpecificationByModelType.find(*model_type);
-  if (it == kDeserializeHasDataSpecificationByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IHasDataSpecification "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -3410,7 +3396,98 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kAdministrativeInformation:
+      return DeserializeAdministrativeInformation<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kRelationshipElement:
+      return ConcretelyDeserializeRelationshipElement<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kAnnotatedRelationshipElement:
+      return DeserializeAnnotatedRelationshipElement<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kAssetAdministrationShell:
+      return DeserializeAssetAdministrationShell<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kBasicEventElement:
+      return DeserializeBasicEventElement<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kBlob:
+      return DeserializeBlob<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kCapability:
+      return DeserializeCapability<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kConceptDescription:
+      return DeserializeConceptDescription<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kEntity:
+      return DeserializeEntity<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kFile:
+      return DeserializeFile<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kMultiLanguageProperty:
+      return DeserializeMultiLanguageProperty<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kOperation:
+      return DeserializeOperation<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kProperty:
+      return DeserializeProperty<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kRange:
+      return DeserializeRange<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kReferenceElement:
+      return DeserializeReferenceElement<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kSubmodel:
+      return DeserializeSubmodel<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementCollection:
+      return DeserializeSubmodelElementCollection<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementList:
+      return DeserializeSubmodelElementList<
+        types::IHasDataSpecification
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IHasDataSpecification "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IHasDataSpecification> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInAdministrativeInformation = {
@@ -3665,107 +3742,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IQualifiable> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeQualifiableByModelType = {
-  {
-    "RelationshipElement",
-    ConcretelyDeserializeRelationshipElement<
-      types::IQualifiable
-    >
-  },
-  {
-    "AnnotatedRelationshipElement",
-    DeserializeAnnotatedRelationshipElement<
-      types::IQualifiable
-    >
-  },
-  {
-    "BasicEventElement",
-    DeserializeBasicEventElement<
-      types::IQualifiable
-    >
-  },
-  {
-    "Blob",
-    DeserializeBlob<
-      types::IQualifiable
-    >
-  },
-  {
-    "Capability",
-    DeserializeCapability<
-      types::IQualifiable
-    >
-  },
-  {
-    "Entity",
-    DeserializeEntity<
-      types::IQualifiable
-    >
-  },
-  {
-    "File",
-    DeserializeFile<
-      types::IQualifiable
-    >
-  },
-  {
-    "MultiLanguageProperty",
-    DeserializeMultiLanguageProperty<
-      types::IQualifiable
-    >
-  },
-  {
-    "Operation",
-    DeserializeOperation<
-      types::IQualifiable
-    >
-  },
-  {
-    "Property",
-    DeserializeProperty<
-      types::IQualifiable
-    >
-  },
-  {
-    "Range",
-    DeserializeRange<
-      types::IQualifiable
-    >
-  },
-  {
-    "ReferenceElement",
-    DeserializeReferenceElement<
-      types::IQualifiable
-    >
-  },
-  {
-    "Submodel",
-    DeserializeSubmodel<
-      types::IQualifiable
-    >
-  },
-  {
-    "SubmodelElementCollection",
-    DeserializeSubmodelElementCollection<
-      types::IQualifiable
-    >
-  },
-  {
-    "SubmodelElementList",
-    DeserializeSubmodelElementList<
-      types::IQualifiable
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IQualifiable>
@@ -3775,11 +3751,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -3793,13 +3769,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeQualifiableByModelType.find(*model_type);
-  if (it == kDeserializeQualifiableByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IQualifiable "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -3813,7 +3790,86 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kRelationshipElement:
+      return ConcretelyDeserializeRelationshipElement<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kAnnotatedRelationshipElement:
+      return DeserializeAnnotatedRelationshipElement<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kBasicEventElement:
+      return DeserializeBasicEventElement<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kBlob:
+      return DeserializeBlob<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kCapability:
+      return DeserializeCapability<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kEntity:
+      return DeserializeEntity<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kFile:
+      return DeserializeFile<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kMultiLanguageProperty:
+      return DeserializeMultiLanguageProperty<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kOperation:
+      return DeserializeOperation<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kProperty:
+      return DeserializeProperty<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kRange:
+      return DeserializeRange<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kReferenceElement:
+      return DeserializeReferenceElement<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kSubmodel:
+      return DeserializeSubmodel<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementCollection:
+      return DeserializeSubmodelElementCollection<
+        types::IQualifiable
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementList:
+      return DeserializeSubmodelElementList<
+        types::IQualifiable
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IQualifiable "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IQualifiable> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInQualifier = {
@@ -6086,101 +6142,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::ISubmodelElement> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeSubmodelElementByModelType = {
-  {
-    "RelationshipElement",
-    ConcretelyDeserializeRelationshipElement<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "AnnotatedRelationshipElement",
-    DeserializeAnnotatedRelationshipElement<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "BasicEventElement",
-    DeserializeBasicEventElement<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "Blob",
-    DeserializeBlob<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "Capability",
-    DeserializeCapability<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "Entity",
-    DeserializeEntity<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "File",
-    DeserializeFile<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "MultiLanguageProperty",
-    DeserializeMultiLanguageProperty<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "Operation",
-    DeserializeOperation<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "Property",
-    DeserializeProperty<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "Range",
-    DeserializeRange<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "ReferenceElement",
-    DeserializeReferenceElement<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "SubmodelElementCollection",
-    DeserializeSubmodelElementCollection<
-      types::ISubmodelElement
-    >
-  },
-  {
-    "SubmodelElementList",
-    DeserializeSubmodelElementList<
-      types::ISubmodelElement
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::ISubmodelElement>
@@ -6190,11 +6151,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -6208,13 +6169,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeSubmodelElementByModelType.find(*model_type);
-  if (it == kDeserializeSubmodelElementByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::ISubmodelElement "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -6228,7 +6190,82 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kRelationshipElement:
+      return ConcretelyDeserializeRelationshipElement<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kAnnotatedRelationshipElement:
+      return DeserializeAnnotatedRelationshipElement<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kBasicEventElement:
+      return DeserializeBasicEventElement<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kBlob:
+      return DeserializeBlob<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kCapability:
+      return DeserializeCapability<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kEntity:
+      return DeserializeEntity<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kFile:
+      return DeserializeFile<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kMultiLanguageProperty:
+      return DeserializeMultiLanguageProperty<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kOperation:
+      return DeserializeOperation<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kProperty:
+      return DeserializeProperty<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kRange:
+      return DeserializeRange<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kReferenceElement:
+      return DeserializeReferenceElement<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementCollection:
+      return DeserializeSubmodelElementCollection<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    case types::ModelType::kSubmodelElementList:
+      return DeserializeSubmodelElementList<
+        types::ISubmodelElement
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::ISubmodelElement "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::ISubmodelElement> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInRelationshipElement = {
@@ -6815,29 +6852,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IRelationshipElement> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeRelationshipElementByModelType = {
-  {
-    "RelationshipElement",
-    ConcretelyDeserializeRelationshipElement<
-      types::IRelationshipElement
-    >
-  },
-  {
-    "AnnotatedRelationshipElement",
-    DeserializeAnnotatedRelationshipElement<
-      types::IRelationshipElement
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IRelationshipElement>
@@ -6847,11 +6861,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -6865,13 +6879,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeRelationshipElementByModelType.find(*model_type);
-  if (it == kDeserializeRelationshipElementByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IRelationshipElement "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -6885,7 +6900,34 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kRelationshipElement:
+      return ConcretelyDeserializeRelationshipElement<
+        types::IRelationshipElement
+      >(json, additional_properties);
+    case types::ModelType::kAnnotatedRelationshipElement:
+      return DeserializeAnnotatedRelationshipElement<
+        types::IRelationshipElement
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IRelationshipElement "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IRelationshipElement> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInSubmodelElementList = {
@@ -8105,53 +8147,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IDataElement> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeDataElementByModelType = {
-  {
-    "Blob",
-    DeserializeBlob<
-      types::IDataElement
-    >
-  },
-  {
-    "File",
-    DeserializeFile<
-      types::IDataElement
-    >
-  },
-  {
-    "MultiLanguageProperty",
-    DeserializeMultiLanguageProperty<
-      types::IDataElement
-    >
-  },
-  {
-    "Property",
-    DeserializeProperty<
-      types::IDataElement
-    >
-  },
-  {
-    "Range",
-    DeserializeRange<
-      types::IDataElement
-    >
-  },
-  {
-    "ReferenceElement",
-    DeserializeReferenceElement<
-      types::IDataElement
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IDataElement>
@@ -8161,11 +8156,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -8179,13 +8174,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeDataElementByModelType.find(*model_type);
-  if (it == kDeserializeDataElementByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IDataElement "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -8199,7 +8195,50 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kBlob:
+      return DeserializeBlob<
+        types::IDataElement
+      >(json, additional_properties);
+    case types::ModelType::kFile:
+      return DeserializeFile<
+        types::IDataElement
+      >(json, additional_properties);
+    case types::ModelType::kMultiLanguageProperty:
+      return DeserializeMultiLanguageProperty<
+        types::IDataElement
+      >(json, additional_properties);
+    case types::ModelType::kProperty:
+      return DeserializeProperty<
+        types::IDataElement
+      >(json, additional_properties);
+    case types::ModelType::kRange:
+      return DeserializeRange<
+        types::IDataElement
+      >(json, additional_properties);
+    case types::ModelType::kReferenceElement:
+      return DeserializeReferenceElement<
+        types::IDataElement
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IDataElement "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IDataElement> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInProperty = {
@@ -13329,23 +13368,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IEventElement> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeEventElementByModelType = {
-  {
-    "BasicEventElement",
-    DeserializeBasicEventElement<
-      types::IEventElement
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IEventElement>
@@ -13355,11 +13377,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -13373,13 +13395,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeEventElementByModelType.find(*model_type);
-  if (it == kDeserializeEventElementByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IEventElement "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -13393,7 +13416,30 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kBasicEventElement:
+      return DeserializeBasicEventElement<
+        types::IEventElement
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IEventElement "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IEventElement> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInBasicEventElement = {
@@ -16291,47 +16337,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IAbstractLangString> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeAbstractLangStringByModelType = {
-  {
-    "LangStringDefinitionTypeIec61360",
-    DeserializeLangStringDefinitionTypeIec61360<
-      types::IAbstractLangString
-    >
-  },
-  {
-    "LangStringNameType",
-    DeserializeLangStringNameType<
-      types::IAbstractLangString
-    >
-  },
-  {
-    "LangStringPreferredNameTypeIec61360",
-    DeserializeLangStringPreferredNameTypeIec61360<
-      types::IAbstractLangString
-    >
-  },
-  {
-    "LangStringShortNameTypeIec61360",
-    DeserializeLangStringShortNameTypeIec61360<
-      types::IAbstractLangString
-    >
-  },
-  {
-    "LangStringTextType",
-    DeserializeLangStringTextType<
-      types::IAbstractLangString
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IAbstractLangString>
@@ -16341,11 +16346,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -16359,13 +16364,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeAbstractLangStringByModelType.find(*model_type);
-  if (it == kDeserializeAbstractLangStringByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IAbstractLangString "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -16379,7 +16385,46 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kLangStringDefinitionTypeIec61360:
+      return DeserializeLangStringDefinitionTypeIec61360<
+        types::IAbstractLangString
+      >(json, additional_properties);
+    case types::ModelType::kLangStringNameType:
+      return DeserializeLangStringNameType<
+        types::IAbstractLangString
+      >(json, additional_properties);
+    case types::ModelType::kLangStringPreferredNameTypeIec61360:
+      return DeserializeLangStringPreferredNameTypeIec61360<
+        types::IAbstractLangString
+      >(json, additional_properties);
+    case types::ModelType::kLangStringShortNameTypeIec61360:
+      return DeserializeLangStringShortNameTypeIec61360<
+        types::IAbstractLangString
+      >(json, additional_properties);
+    case types::ModelType::kLangStringTextType:
+      return DeserializeLangStringTextType<
+        types::IAbstractLangString
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IAbstractLangString "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IAbstractLangString> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInLangStringNameType = {
@@ -16915,23 +16960,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IDataSpecificationContent> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeDataSpecificationContentByModelType = {
-  {
-    "DataSpecificationIec61360",
-    DeserializeDataSpecificationIec61360<
-      types::IDataSpecificationContent
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IDataSpecificationContent>
@@ -16941,11 +16969,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -16959,13 +16987,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeDataSpecificationContentByModelType.find(*model_type);
-  if (it == kDeserializeDataSpecificationContentByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IDataSpecificationContent "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -16979,7 +17008,30 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kDataSpecificationIec61360:
+      return DeserializeDataSpecificationIec61360<
+        types::IDataSpecificationContent
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IDataSpecificationContent "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IDataSpecificationContent> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInEmbeddedDataSpecification = {
@@ -20648,6 +20700,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -20687,6 +20748,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -20791,14 +20861,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<
@@ -22846,7 +22908,9 @@ std::pair<
     that.order_relevant()
   );
   if (that.order_relevant().has_value()) {
-    result["orderRelevant"] = *maybe_order_relevant;
+    result["orderRelevant"] = SerializeBool(
+      *maybe_order_relevant
+    );
   }
 
   const common::optional<
@@ -28001,13 +28065,21 @@ std::pair<
 ) {
   nlohmann::json result = nlohmann::json::object();
 
-  result["min"] = that.min();
+  result["min"] = SerializeBool(
+    that.min()
+  );
 
-  result["nom"] = that.nom();
+  result["nom"] = SerializeBool(
+    that.nom()
+  );
 
-  result["typ"] = that.typ();
+  result["typ"] = SerializeBool(
+    that.typ()
+  );
 
-  result["max"] = that.max();
+  result["max"] = SerializeBool(
+    that.max()
+  );
 
   return std::make_pair<
     common::optional<nlohmann::json>,

--- a/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/aas_core_meta.v3/expected_output/src/xmlization.cpp
@@ -8333,7 +8333,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfExtension::kSemanticId:
+      case properties::OfExtension::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -8341,7 +8341,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfExtension::kSupplementalSemanticIds:
+      }
+      case properties::OfExtension::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -8352,25 +8353,29 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfExtension::kName:
+      }
+      case properties::OfExtension::kName: {
         std::tie(
           the_name,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfExtension::kValueType:
+      }
+      case properties::OfExtension::kValueType: {
         std::tie(
           the_value_type,
           error
         ) = DeserializeDataTypeDefXsd(reader);
         break;
-      case properties::OfExtension::kValue:
+      }
+      case properties::OfExtension::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfExtension::kRefersTo:
+      }
+      case properties::OfExtension::kRefersTo: {
         std::tie(
           the_refers_to,
           error
@@ -8381,6 +8386,7 @@ std::pair<
           ReferenceFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -8622,7 +8628,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfAdministrativeInformation::kEmbeddedDataSpecifications:
+      case properties::OfAdministrativeInformation::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -8633,19 +8639,22 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfAdministrativeInformation::kVersion:
+      }
+      case properties::OfAdministrativeInformation::kVersion: {
         std::tie(
           the_version,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAdministrativeInformation::kRevision:
+      }
+      case properties::OfAdministrativeInformation::kRevision: {
         std::tie(
           the_revision,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAdministrativeInformation::kCreator:
+      }
+      case properties::OfAdministrativeInformation::kCreator: {
         std::tie(
           the_creator,
           error
@@ -8653,12 +8662,14 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfAdministrativeInformation::kTemplateId:
+      }
+      case properties::OfAdministrativeInformation::kTemplateId: {
         std::tie(
           the_template_id,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -8893,7 +8904,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfQualifier::kSemanticId:
+      case properties::OfQualifier::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -8901,7 +8912,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfQualifier::kSupplementalSemanticIds:
+      }
+      case properties::OfQualifier::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -8912,31 +8924,36 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfQualifier::kKind:
+      }
+      case properties::OfQualifier::kKind: {
         std::tie(
           the_kind,
           error
         ) = DeserializeQualifierKind(reader);
         break;
-      case properties::OfQualifier::kType:
+      }
+      case properties::OfQualifier::kType: {
         std::tie(
           the_type,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfQualifier::kValueType:
+      }
+      case properties::OfQualifier::kValueType: {
         std::tie(
           the_value_type,
           error
         ) = DeserializeDataTypeDefXsd(reader);
         break;
-      case properties::OfQualifier::kValue:
+      }
+      case properties::OfQualifier::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfQualifier::kValueId:
+      }
+      case properties::OfQualifier::kValueId: {
         std::tie(
           the_value_id,
           error
@@ -8944,6 +8961,7 @@ std::pair<
           types::IReference
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -9224,7 +9242,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfAssetAdministrationShell::kExtensions:
+      case properties::OfAssetAdministrationShell::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -9235,19 +9253,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfAssetAdministrationShell::kCategory:
+      }
+      case properties::OfAssetAdministrationShell::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAssetAdministrationShell::kIdShort:
+      }
+      case properties::OfAssetAdministrationShell::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAssetAdministrationShell::kDisplayName:
+      }
+      case properties::OfAssetAdministrationShell::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -9258,7 +9279,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfAssetAdministrationShell::kDescription:
+      }
+      case properties::OfAssetAdministrationShell::kDescription: {
         std::tie(
           the_description,
           error
@@ -9269,7 +9291,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfAssetAdministrationShell::kAdministration:
+      }
+      case properties::OfAssetAdministrationShell::kAdministration: {
         std::tie(
           the_administration,
           error
@@ -9277,13 +9300,15 @@ std::pair<
           types::IAdministrativeInformation
         >(reader);
         break;
-      case properties::OfAssetAdministrationShell::kId:
+      }
+      case properties::OfAssetAdministrationShell::kId: {
         std::tie(
           the_id,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAssetAdministrationShell::kEmbeddedDataSpecifications:
+      }
+      case properties::OfAssetAdministrationShell::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -9294,7 +9319,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfAssetAdministrationShell::kDerivedFrom:
+      }
+      case properties::OfAssetAdministrationShell::kDerivedFrom: {
         std::tie(
           the_derived_from,
           error
@@ -9302,7 +9328,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfAssetAdministrationShell::kAssetInformation:
+      }
+      case properties::OfAssetAdministrationShell::kAssetInformation: {
         std::tie(
           the_asset_information,
           error
@@ -9310,7 +9337,8 @@ std::pair<
           types::IAssetInformation
         >(reader);
         break;
-      case properties::OfAssetAdministrationShell::kSubmodels:
+      }
+      case properties::OfAssetAdministrationShell::kSubmodels: {
         std::tie(
           the_submodels,
           error
@@ -9321,6 +9349,7 @@ std::pair<
           ReferenceFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -9575,19 +9604,21 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfAssetInformation::kAssetKind:
+      case properties::OfAssetInformation::kAssetKind: {
         std::tie(
           the_asset_kind,
           error
         ) = DeserializeAssetKind(reader);
         break;
-      case properties::OfAssetInformation::kGlobalAssetId:
+      }
+      case properties::OfAssetInformation::kGlobalAssetId: {
         std::tie(
           the_global_asset_id,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAssetInformation::kSpecificAssetIds:
+      }
+      case properties::OfAssetInformation::kSpecificAssetIds: {
         std::tie(
           the_specific_asset_ids,
           error
@@ -9598,13 +9629,15 @@ std::pair<
           SpecificAssetIdFromElement
         );
         break;
-      case properties::OfAssetInformation::kAssetType:
+      }
+      case properties::OfAssetInformation::kAssetType: {
         std::tie(
           the_asset_type,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAssetInformation::kDefaultThumbnail:
+      }
+      case properties::OfAssetInformation::kDefaultThumbnail: {
         std::tie(
           the_default_thumbnail,
           error
@@ -9612,6 +9645,7 @@ std::pair<
           types::IResource
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -9840,18 +9874,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfResource::kPath:
+      case properties::OfResource::kPath: {
         std::tie(
           the_path,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfResource::kContentType:
+      }
+      case properties::OfResource::kContentType: {
         std::tie(
           the_content_type,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -10091,7 +10127,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSpecificAssetId::kSemanticId:
+      case properties::OfSpecificAssetId::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -10099,7 +10135,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfSpecificAssetId::kSupplementalSemanticIds:
+      }
+      case properties::OfSpecificAssetId::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -10110,19 +10147,22 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfSpecificAssetId::kName:
+      }
+      case properties::OfSpecificAssetId::kName: {
         std::tie(
           the_name,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSpecificAssetId::kValue:
+      }
+      case properties::OfSpecificAssetId::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSpecificAssetId::kExternalSubjectId:
+      }
+      case properties::OfSpecificAssetId::kExternalSubjectId: {
         std::tie(
           the_external_subject_id,
           error
@@ -10130,6 +10170,7 @@ std::pair<
           types::IReference
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -10420,7 +10461,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSubmodel::kExtensions:
+      case properties::OfSubmodel::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -10431,19 +10472,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfSubmodel::kCategory:
+      }
+      case properties::OfSubmodel::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSubmodel::kIdShort:
+      }
+      case properties::OfSubmodel::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSubmodel::kDisplayName:
+      }
+      case properties::OfSubmodel::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -10454,7 +10498,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfSubmodel::kDescription:
+      }
+      case properties::OfSubmodel::kDescription: {
         std::tie(
           the_description,
           error
@@ -10465,7 +10510,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfSubmodel::kAdministration:
+      }
+      case properties::OfSubmodel::kAdministration: {
         std::tie(
           the_administration,
           error
@@ -10473,19 +10519,22 @@ std::pair<
           types::IAdministrativeInformation
         >(reader);
         break;
-      case properties::OfSubmodel::kId:
+      }
+      case properties::OfSubmodel::kId: {
         std::tie(
           the_id,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSubmodel::kKind:
+      }
+      case properties::OfSubmodel::kKind: {
         std::tie(
           the_kind,
           error
         ) = DeserializeModellingKind(reader);
         break;
-      case properties::OfSubmodel::kSemanticId:
+      }
+      case properties::OfSubmodel::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -10493,7 +10542,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfSubmodel::kSupplementalSemanticIds:
+      }
+      case properties::OfSubmodel::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -10504,7 +10554,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfSubmodel::kQualifiers:
+      }
+      case properties::OfSubmodel::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -10515,7 +10566,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfSubmodel::kEmbeddedDataSpecifications:
+      }
+      case properties::OfSubmodel::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -10526,7 +10578,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfSubmodel::kSubmodelElements:
+      }
+      case properties::OfSubmodel::kSubmodelElements: {
         std::tie(
           the_submodel_elements,
           error
@@ -10537,6 +10590,7 @@ std::pair<
           SubmodelElementFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -10817,7 +10871,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfRelationshipElement::kExtensions:
+      case properties::OfRelationshipElement::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -10828,19 +10882,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfRelationshipElement::kCategory:
+      }
+      case properties::OfRelationshipElement::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfRelationshipElement::kIdShort:
+      }
+      case properties::OfRelationshipElement::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfRelationshipElement::kDisplayName:
+      }
+      case properties::OfRelationshipElement::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -10851,7 +10908,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfRelationshipElement::kDescription:
+      }
+      case properties::OfRelationshipElement::kDescription: {
         std::tie(
           the_description,
           error
@@ -10862,7 +10920,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfRelationshipElement::kSemanticId:
+      }
+      case properties::OfRelationshipElement::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -10870,7 +10929,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfRelationshipElement::kSupplementalSemanticIds:
+      }
+      case properties::OfRelationshipElement::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -10881,7 +10941,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfRelationshipElement::kQualifiers:
+      }
+      case properties::OfRelationshipElement::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -10892,7 +10953,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfRelationshipElement::kEmbeddedDataSpecifications:
+      }
+      case properties::OfRelationshipElement::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -10903,7 +10965,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfRelationshipElement::kFirst:
+      }
+      case properties::OfRelationshipElement::kFirst: {
         std::tie(
           the_first,
           error
@@ -10911,7 +10974,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfRelationshipElement::kSecond:
+      }
+      case properties::OfRelationshipElement::kSecond: {
         std::tie(
           the_second,
           error
@@ -10919,6 +10983,7 @@ std::pair<
           types::IReference
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -11217,7 +11282,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSubmodelElementList::kExtensions:
+      case properties::OfSubmodelElementList::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -11228,19 +11293,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfSubmodelElementList::kCategory:
+      }
+      case properties::OfSubmodelElementList::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSubmodelElementList::kIdShort:
+      }
+      case properties::OfSubmodelElementList::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSubmodelElementList::kDisplayName:
+      }
+      case properties::OfSubmodelElementList::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -11251,7 +11319,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfSubmodelElementList::kDescription:
+      }
+      case properties::OfSubmodelElementList::kDescription: {
         std::tie(
           the_description,
           error
@@ -11262,7 +11331,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfSubmodelElementList::kSemanticId:
+      }
+      case properties::OfSubmodelElementList::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -11270,7 +11340,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfSubmodelElementList::kSupplementalSemanticIds:
+      }
+      case properties::OfSubmodelElementList::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -11281,7 +11352,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfSubmodelElementList::kQualifiers:
+      }
+      case properties::OfSubmodelElementList::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -11292,7 +11364,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfSubmodelElementList::kEmbeddedDataSpecifications:
+      }
+      case properties::OfSubmodelElementList::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -11303,13 +11376,15 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfSubmodelElementList::kOrderRelevant:
+      }
+      case properties::OfSubmodelElementList::kOrderRelevant: {
         std::tie(
           the_order_relevant,
           error
         ) = DeserializeBool(reader);
         break;
-      case properties::OfSubmodelElementList::kSemanticIdListElement:
+      }
+      case properties::OfSubmodelElementList::kSemanticIdListElement: {
         std::tie(
           the_semantic_id_list_element,
           error
@@ -11317,19 +11392,22 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfSubmodelElementList::kTypeValueListElement:
+      }
+      case properties::OfSubmodelElementList::kTypeValueListElement: {
         std::tie(
           the_type_value_list_element,
           error
         ) = DeserializeAasSubmodelElements(reader);
         break;
-      case properties::OfSubmodelElementList::kValueTypeListElement:
+      }
+      case properties::OfSubmodelElementList::kValueTypeListElement: {
         std::tie(
           the_value_type_list_element,
           error
         ) = DeserializeDataTypeDefXsd(reader);
         break;
-      case properties::OfSubmodelElementList::kValue:
+      }
+      case properties::OfSubmodelElementList::kValue: {
         std::tie(
           the_value,
           error
@@ -11340,6 +11418,7 @@ std::pair<
           SubmodelElementFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -11623,7 +11702,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSubmodelElementCollection::kExtensions:
+      case properties::OfSubmodelElementCollection::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -11634,19 +11713,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfSubmodelElementCollection::kCategory:
+      }
+      case properties::OfSubmodelElementCollection::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSubmodelElementCollection::kIdShort:
+      }
+      case properties::OfSubmodelElementCollection::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSubmodelElementCollection::kDisplayName:
+      }
+      case properties::OfSubmodelElementCollection::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -11657,7 +11739,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfSubmodelElementCollection::kDescription:
+      }
+      case properties::OfSubmodelElementCollection::kDescription: {
         std::tie(
           the_description,
           error
@@ -11668,7 +11751,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfSubmodelElementCollection::kSemanticId:
+      }
+      case properties::OfSubmodelElementCollection::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -11676,7 +11760,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfSubmodelElementCollection::kSupplementalSemanticIds:
+      }
+      case properties::OfSubmodelElementCollection::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -11687,7 +11772,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfSubmodelElementCollection::kQualifiers:
+      }
+      case properties::OfSubmodelElementCollection::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -11698,7 +11784,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfSubmodelElementCollection::kEmbeddedDataSpecifications:
+      }
+      case properties::OfSubmodelElementCollection::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -11709,7 +11796,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfSubmodelElementCollection::kValue:
+      }
+      case properties::OfSubmodelElementCollection::kValue: {
         std::tie(
           the_value,
           error
@@ -11720,6 +11808,7 @@ std::pair<
           SubmodelElementFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -11989,7 +12078,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfProperty::kExtensions:
+      case properties::OfProperty::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -12000,19 +12089,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfProperty::kCategory:
+      }
+      case properties::OfProperty::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfProperty::kIdShort:
+      }
+      case properties::OfProperty::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfProperty::kDisplayName:
+      }
+      case properties::OfProperty::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -12023,7 +12115,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfProperty::kDescription:
+      }
+      case properties::OfProperty::kDescription: {
         std::tie(
           the_description,
           error
@@ -12034,7 +12127,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfProperty::kSemanticId:
+      }
+      case properties::OfProperty::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -12042,7 +12136,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfProperty::kSupplementalSemanticIds:
+      }
+      case properties::OfProperty::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -12053,7 +12148,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfProperty::kQualifiers:
+      }
+      case properties::OfProperty::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -12064,7 +12160,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfProperty::kEmbeddedDataSpecifications:
+      }
+      case properties::OfProperty::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -12075,19 +12172,22 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfProperty::kValueType:
+      }
+      case properties::OfProperty::kValueType: {
         std::tie(
           the_value_type,
           error
         ) = DeserializeDataTypeDefXsd(reader);
         break;
-      case properties::OfProperty::kValue:
+      }
+      case properties::OfProperty::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfProperty::kValueId:
+      }
+      case properties::OfProperty::kValueId: {
         std::tie(
           the_value_id,
           error
@@ -12095,6 +12195,7 @@ std::pair<
           types::IReference
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -12380,7 +12481,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfMultiLanguageProperty::kExtensions:
+      case properties::OfMultiLanguageProperty::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -12391,19 +12492,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfMultiLanguageProperty::kCategory:
+      }
+      case properties::OfMultiLanguageProperty::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfMultiLanguageProperty::kIdShort:
+      }
+      case properties::OfMultiLanguageProperty::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfMultiLanguageProperty::kDisplayName:
+      }
+      case properties::OfMultiLanguageProperty::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -12414,7 +12518,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfMultiLanguageProperty::kDescription:
+      }
+      case properties::OfMultiLanguageProperty::kDescription: {
         std::tie(
           the_description,
           error
@@ -12425,7 +12530,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfMultiLanguageProperty::kSemanticId:
+      }
+      case properties::OfMultiLanguageProperty::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -12433,7 +12539,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfMultiLanguageProperty::kSupplementalSemanticIds:
+      }
+      case properties::OfMultiLanguageProperty::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -12444,7 +12551,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfMultiLanguageProperty::kQualifiers:
+      }
+      case properties::OfMultiLanguageProperty::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -12455,7 +12563,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfMultiLanguageProperty::kEmbeddedDataSpecifications:
+      }
+      case properties::OfMultiLanguageProperty::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -12466,7 +12575,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfMultiLanguageProperty::kValue:
+      }
+      case properties::OfMultiLanguageProperty::kValue: {
         std::tie(
           the_value,
           error
@@ -12477,7 +12587,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfMultiLanguageProperty::kValueId:
+      }
+      case properties::OfMultiLanguageProperty::kValueId: {
         std::tie(
           the_value_id,
           error
@@ -12485,6 +12596,7 @@ std::pair<
           types::IReference
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -12753,7 +12865,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfRange::kExtensions:
+      case properties::OfRange::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -12764,19 +12876,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfRange::kCategory:
+      }
+      case properties::OfRange::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfRange::kIdShort:
+      }
+      case properties::OfRange::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfRange::kDisplayName:
+      }
+      case properties::OfRange::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -12787,7 +12902,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfRange::kDescription:
+      }
+      case properties::OfRange::kDescription: {
         std::tie(
           the_description,
           error
@@ -12798,7 +12914,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfRange::kSemanticId:
+      }
+      case properties::OfRange::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -12806,7 +12923,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfRange::kSupplementalSemanticIds:
+      }
+      case properties::OfRange::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -12817,7 +12935,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfRange::kQualifiers:
+      }
+      case properties::OfRange::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -12828,7 +12947,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfRange::kEmbeddedDataSpecifications:
+      }
+      case properties::OfRange::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -12839,24 +12959,28 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfRange::kValueType:
+      }
+      case properties::OfRange::kValueType: {
         std::tie(
           the_value_type,
           error
         ) = DeserializeDataTypeDefXsd(reader);
         break;
-      case properties::OfRange::kMin:
+      }
+      case properties::OfRange::kMin: {
         std::tie(
           the_min,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfRange::kMax:
+      }
+      case properties::OfRange::kMax: {
         std::tie(
           the_max,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -13136,7 +13260,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfReferenceElement::kExtensions:
+      case properties::OfReferenceElement::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -13147,19 +13271,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfReferenceElement::kCategory:
+      }
+      case properties::OfReferenceElement::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfReferenceElement::kIdShort:
+      }
+      case properties::OfReferenceElement::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfReferenceElement::kDisplayName:
+      }
+      case properties::OfReferenceElement::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -13170,7 +13297,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfReferenceElement::kDescription:
+      }
+      case properties::OfReferenceElement::kDescription: {
         std::tie(
           the_description,
           error
@@ -13181,7 +13309,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfReferenceElement::kSemanticId:
+      }
+      case properties::OfReferenceElement::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -13189,7 +13318,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfReferenceElement::kSupplementalSemanticIds:
+      }
+      case properties::OfReferenceElement::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -13200,7 +13330,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfReferenceElement::kQualifiers:
+      }
+      case properties::OfReferenceElement::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -13211,7 +13342,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfReferenceElement::kEmbeddedDataSpecifications:
+      }
+      case properties::OfReferenceElement::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -13222,7 +13354,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfReferenceElement::kValue:
+      }
+      case properties::OfReferenceElement::kValue: {
         std::tie(
           the_value,
           error
@@ -13230,6 +13363,7 @@ std::pair<
           types::IReference
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -13497,7 +13631,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfBlob::kExtensions:
+      case properties::OfBlob::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -13508,19 +13642,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfBlob::kCategory:
+      }
+      case properties::OfBlob::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBlob::kIdShort:
+      }
+      case properties::OfBlob::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBlob::kDisplayName:
+      }
+      case properties::OfBlob::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -13531,7 +13668,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfBlob::kDescription:
+      }
+      case properties::OfBlob::kDescription: {
         std::tie(
           the_description,
           error
@@ -13542,7 +13680,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfBlob::kSemanticId:
+      }
+      case properties::OfBlob::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -13550,7 +13689,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfBlob::kSupplementalSemanticIds:
+      }
+      case properties::OfBlob::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -13561,7 +13701,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfBlob::kQualifiers:
+      }
+      case properties::OfBlob::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -13572,7 +13713,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfBlob::kEmbeddedDataSpecifications:
+      }
+      case properties::OfBlob::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -13583,18 +13725,21 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfBlob::kValue:
+      }
+      case properties::OfBlob::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeByteArray(reader);
         break;
-      case properties::OfBlob::kContentType:
+      }
+      case properties::OfBlob::kContentType: {
         std::tie(
           the_content_type,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -13873,7 +14018,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfFile::kExtensions:
+      case properties::OfFile::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -13884,19 +14029,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfFile::kCategory:
+      }
+      case properties::OfFile::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfFile::kIdShort:
+      }
+      case properties::OfFile::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfFile::kDisplayName:
+      }
+      case properties::OfFile::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -13907,7 +14055,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfFile::kDescription:
+      }
+      case properties::OfFile::kDescription: {
         std::tie(
           the_description,
           error
@@ -13918,7 +14067,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfFile::kSemanticId:
+      }
+      case properties::OfFile::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -13926,7 +14076,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfFile::kSupplementalSemanticIds:
+      }
+      case properties::OfFile::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -13937,7 +14088,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfFile::kQualifiers:
+      }
+      case properties::OfFile::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -13948,7 +14100,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfFile::kEmbeddedDataSpecifications:
+      }
+      case properties::OfFile::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -13959,18 +14112,21 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfFile::kValue:
+      }
+      case properties::OfFile::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfFile::kContentType:
+      }
+      case properties::OfFile::kContentType: {
         std::tie(
           the_content_type,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -14255,7 +14411,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfAnnotatedRelationshipElement::kExtensions:
+      case properties::OfAnnotatedRelationshipElement::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -14266,19 +14422,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfAnnotatedRelationshipElement::kCategory:
+      }
+      case properties::OfAnnotatedRelationshipElement::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAnnotatedRelationshipElement::kIdShort:
+      }
+      case properties::OfAnnotatedRelationshipElement::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfAnnotatedRelationshipElement::kDisplayName:
+      }
+      case properties::OfAnnotatedRelationshipElement::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -14289,7 +14448,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfAnnotatedRelationshipElement::kDescription:
+      }
+      case properties::OfAnnotatedRelationshipElement::kDescription: {
         std::tie(
           the_description,
           error
@@ -14300,7 +14460,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfAnnotatedRelationshipElement::kSemanticId:
+      }
+      case properties::OfAnnotatedRelationshipElement::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -14308,7 +14469,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfAnnotatedRelationshipElement::kSupplementalSemanticIds:
+      }
+      case properties::OfAnnotatedRelationshipElement::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -14319,7 +14481,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfAnnotatedRelationshipElement::kQualifiers:
+      }
+      case properties::OfAnnotatedRelationshipElement::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -14330,7 +14493,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfAnnotatedRelationshipElement::kEmbeddedDataSpecifications:
+      }
+      case properties::OfAnnotatedRelationshipElement::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -14341,7 +14505,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfAnnotatedRelationshipElement::kFirst:
+      }
+      case properties::OfAnnotatedRelationshipElement::kFirst: {
         std::tie(
           the_first,
           error
@@ -14349,7 +14514,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfAnnotatedRelationshipElement::kSecond:
+      }
+      case properties::OfAnnotatedRelationshipElement::kSecond: {
         std::tie(
           the_second,
           error
@@ -14357,7 +14523,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfAnnotatedRelationshipElement::kAnnotations:
+      }
+      case properties::OfAnnotatedRelationshipElement::kAnnotations: {
         std::tie(
           the_annotations,
           error
@@ -14368,6 +14535,7 @@ std::pair<
           DataElementFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -14667,7 +14835,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfEntity::kExtensions:
+      case properties::OfEntity::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -14678,19 +14846,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfEntity::kCategory:
+      }
+      case properties::OfEntity::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfEntity::kIdShort:
+      }
+      case properties::OfEntity::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfEntity::kDisplayName:
+      }
+      case properties::OfEntity::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -14701,7 +14872,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfEntity::kDescription:
+      }
+      case properties::OfEntity::kDescription: {
         std::tie(
           the_description,
           error
@@ -14712,7 +14884,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfEntity::kSemanticId:
+      }
+      case properties::OfEntity::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -14720,7 +14893,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfEntity::kSupplementalSemanticIds:
+      }
+      case properties::OfEntity::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -14731,7 +14905,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfEntity::kQualifiers:
+      }
+      case properties::OfEntity::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -14742,7 +14917,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfEntity::kEmbeddedDataSpecifications:
+      }
+      case properties::OfEntity::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -14753,7 +14929,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfEntity::kStatements:
+      }
+      case properties::OfEntity::kStatements: {
         std::tie(
           the_statements,
           error
@@ -14764,19 +14941,22 @@ std::pair<
           SubmodelElementFromElement
         );
         break;
-      case properties::OfEntity::kEntityType:
+      }
+      case properties::OfEntity::kEntityType: {
         std::tie(
           the_entity_type,
           error
         ) = DeserializeEntityType(reader);
         break;
-      case properties::OfEntity::kGlobalAssetId:
+      }
+      case properties::OfEntity::kGlobalAssetId: {
         std::tie(
           the_global_asset_id,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfEntity::kSpecificAssetIds:
+      }
+      case properties::OfEntity::kSpecificAssetIds: {
         std::tie(
           the_specific_asset_ids,
           error
@@ -14787,6 +14967,7 @@ std::pair<
           SpecificAssetIdFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -15043,7 +15224,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfEventPayload::kSource:
+      case properties::OfEventPayload::kSource: {
         std::tie(
           the_source,
           error
@@ -15051,7 +15232,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfEventPayload::kSourceSemanticId:
+      }
+      case properties::OfEventPayload::kSourceSemanticId: {
         std::tie(
           the_source_semantic_id,
           error
@@ -15059,7 +15241,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfEventPayload::kObservableReference:
+      }
+      case properties::OfEventPayload::kObservableReference: {
         std::tie(
           the_observable_reference,
           error
@@ -15067,7 +15250,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfEventPayload::kObservableSemanticId:
+      }
+      case properties::OfEventPayload::kObservableSemanticId: {
         std::tie(
           the_observable_semantic_id,
           error
@@ -15075,13 +15259,15 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfEventPayload::kTopic:
+      }
+      case properties::OfEventPayload::kTopic: {
         std::tie(
           the_topic,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfEventPayload::kSubjectId:
+      }
+      case properties::OfEventPayload::kSubjectId: {
         std::tie(
           the_subject_id,
           error
@@ -15089,18 +15275,21 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfEventPayload::kTimeStamp:
+      }
+      case properties::OfEventPayload::kTimeStamp: {
         std::tie(
           the_time_stamp,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfEventPayload::kPayload:
+      }
+      case properties::OfEventPayload::kPayload: {
         std::tie(
           the_payload,
           error
         ) = DeserializeByteArray(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -15406,7 +15595,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfBasicEventElement::kExtensions:
+      case properties::OfBasicEventElement::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -15417,19 +15606,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfBasicEventElement::kCategory:
+      }
+      case properties::OfBasicEventElement::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBasicEventElement::kIdShort:
+      }
+      case properties::OfBasicEventElement::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBasicEventElement::kDisplayName:
+      }
+      case properties::OfBasicEventElement::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -15440,7 +15632,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfBasicEventElement::kDescription:
+      }
+      case properties::OfBasicEventElement::kDescription: {
         std::tie(
           the_description,
           error
@@ -15451,7 +15644,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfBasicEventElement::kSemanticId:
+      }
+      case properties::OfBasicEventElement::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -15459,7 +15653,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfBasicEventElement::kSupplementalSemanticIds:
+      }
+      case properties::OfBasicEventElement::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -15470,7 +15665,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfBasicEventElement::kQualifiers:
+      }
+      case properties::OfBasicEventElement::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -15481,7 +15677,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfBasicEventElement::kEmbeddedDataSpecifications:
+      }
+      case properties::OfBasicEventElement::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -15492,7 +15689,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfBasicEventElement::kObserved:
+      }
+      case properties::OfBasicEventElement::kObserved: {
         std::tie(
           the_observed,
           error
@@ -15500,25 +15698,29 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfBasicEventElement::kDirection:
+      }
+      case properties::OfBasicEventElement::kDirection: {
         std::tie(
           the_direction,
           error
         ) = DeserializeDirection(reader);
         break;
-      case properties::OfBasicEventElement::kState:
+      }
+      case properties::OfBasicEventElement::kState: {
         std::tie(
           the_state,
           error
         ) = DeserializeStateOfEvent(reader);
         break;
-      case properties::OfBasicEventElement::kMessageTopic:
+      }
+      case properties::OfBasicEventElement::kMessageTopic: {
         std::tie(
           the_message_topic,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBasicEventElement::kMessageBroker:
+      }
+      case properties::OfBasicEventElement::kMessageBroker: {
         std::tie(
           the_message_broker,
           error
@@ -15526,24 +15728,28 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfBasicEventElement::kLastUpdate:
+      }
+      case properties::OfBasicEventElement::kLastUpdate: {
         std::tie(
           the_last_update,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBasicEventElement::kMinInterval:
+      }
+      case properties::OfBasicEventElement::kMinInterval: {
         std::tie(
           the_min_interval,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBasicEventElement::kMaxInterval:
+      }
+      case properties::OfBasicEventElement::kMaxInterval: {
         std::tie(
           the_max_interval,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -15858,7 +16064,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfOperation::kExtensions:
+      case properties::OfOperation::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -15869,19 +16075,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfOperation::kCategory:
+      }
+      case properties::OfOperation::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfOperation::kIdShort:
+      }
+      case properties::OfOperation::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfOperation::kDisplayName:
+      }
+      case properties::OfOperation::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -15892,7 +16101,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfOperation::kDescription:
+      }
+      case properties::OfOperation::kDescription: {
         std::tie(
           the_description,
           error
@@ -15903,7 +16113,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfOperation::kSemanticId:
+      }
+      case properties::OfOperation::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -15911,7 +16122,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfOperation::kSupplementalSemanticIds:
+      }
+      case properties::OfOperation::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -15922,7 +16134,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfOperation::kQualifiers:
+      }
+      case properties::OfOperation::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -15933,7 +16146,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfOperation::kEmbeddedDataSpecifications:
+      }
+      case properties::OfOperation::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -15944,7 +16158,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfOperation::kInputVariables:
+      }
+      case properties::OfOperation::kInputVariables: {
         std::tie(
           the_input_variables,
           error
@@ -15955,7 +16170,8 @@ std::pair<
           OperationVariableFromElement
         );
         break;
-      case properties::OfOperation::kOutputVariables:
+      }
+      case properties::OfOperation::kOutputVariables: {
         std::tie(
           the_output_variables,
           error
@@ -15966,7 +16182,8 @@ std::pair<
           OperationVariableFromElement
         );
         break;
-      case properties::OfOperation::kInoutputVariables:
+      }
+      case properties::OfOperation::kInoutputVariables: {
         std::tie(
           the_inoutput_variables,
           error
@@ -15977,6 +16194,7 @@ std::pair<
           OperationVariableFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -16198,12 +16416,13 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfOperationVariable::kValue:
+      case properties::OfOperationVariable::kValue: {
         std::tie(
           the_value,
           error
         ) = SubmodelElementFromElement(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -16468,7 +16687,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfCapability::kExtensions:
+      case properties::OfCapability::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -16479,19 +16698,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfCapability::kCategory:
+      }
+      case properties::OfCapability::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfCapability::kIdShort:
+      }
+      case properties::OfCapability::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfCapability::kDisplayName:
+      }
+      case properties::OfCapability::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -16502,7 +16724,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfCapability::kDescription:
+      }
+      case properties::OfCapability::kDescription: {
         std::tie(
           the_description,
           error
@@ -16513,7 +16736,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfCapability::kSemanticId:
+      }
+      case properties::OfCapability::kSemanticId: {
         std::tie(
           the_semantic_id,
           error
@@ -16521,7 +16745,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfCapability::kSupplementalSemanticIds:
+      }
+      case properties::OfCapability::kSupplementalSemanticIds: {
         std::tie(
           the_supplemental_semantic_ids,
           error
@@ -16532,7 +16757,8 @@ std::pair<
           ReferenceFromElement
         );
         break;
-      case properties::OfCapability::kQualifiers:
+      }
+      case properties::OfCapability::kQualifiers: {
         std::tie(
           the_qualifiers,
           error
@@ -16543,7 +16769,8 @@ std::pair<
           QualifierFromElement
         );
         break;
-      case properties::OfCapability::kEmbeddedDataSpecifications:
+      }
+      case properties::OfCapability::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -16554,6 +16781,7 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -16810,7 +17038,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfConceptDescription::kExtensions:
+      case properties::OfConceptDescription::kExtensions: {
         std::tie(
           the_extensions,
           error
@@ -16821,19 +17049,22 @@ std::pair<
           ExtensionFromElement
         );
         break;
-      case properties::OfConceptDescription::kCategory:
+      }
+      case properties::OfConceptDescription::kCategory: {
         std::tie(
           the_category,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfConceptDescription::kIdShort:
+      }
+      case properties::OfConceptDescription::kIdShort: {
         std::tie(
           the_id_short,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfConceptDescription::kDisplayName:
+      }
+      case properties::OfConceptDescription::kDisplayName: {
         std::tie(
           the_display_name,
           error
@@ -16844,7 +17075,8 @@ std::pair<
           LangStringNameTypeFromElement
         );
         break;
-      case properties::OfConceptDescription::kDescription:
+      }
+      case properties::OfConceptDescription::kDescription: {
         std::tie(
           the_description,
           error
@@ -16855,7 +17087,8 @@ std::pair<
           LangStringTextTypeFromElement
         );
         break;
-      case properties::OfConceptDescription::kAdministration:
+      }
+      case properties::OfConceptDescription::kAdministration: {
         std::tie(
           the_administration,
           error
@@ -16863,13 +17096,15 @@ std::pair<
           types::IAdministrativeInformation
         >(reader);
         break;
-      case properties::OfConceptDescription::kId:
+      }
+      case properties::OfConceptDescription::kId: {
         std::tie(
           the_id,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfConceptDescription::kEmbeddedDataSpecifications:
+      }
+      case properties::OfConceptDescription::kEmbeddedDataSpecifications: {
         std::tie(
           the_embedded_data_specifications,
           error
@@ -16880,7 +17115,8 @@ std::pair<
           EmbeddedDataSpecificationFromElement
         );
         break;
-      case properties::OfConceptDescription::kIsCaseOf:
+      }
+      case properties::OfConceptDescription::kIsCaseOf: {
         std::tie(
           the_is_case_of,
           error
@@ -16891,6 +17127,7 @@ std::pair<
           ReferenceFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -17131,13 +17368,14 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfReference::kType:
+      case properties::OfReference::kType: {
         std::tie(
           the_type,
           error
         ) = DeserializeReferenceTypes(reader);
         break;
-      case properties::OfReference::kReferredSemanticId:
+      }
+      case properties::OfReference::kReferredSemanticId: {
         std::tie(
           the_referred_semantic_id,
           error
@@ -17145,7 +17383,8 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfReference::kKeys:
+      }
+      case properties::OfReference::kKeys: {
         std::tie(
           the_keys,
           error
@@ -17156,6 +17395,7 @@ std::pair<
           KeyFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -17390,18 +17630,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfKey::kType:
+      case properties::OfKey::kType: {
         std::tie(
           the_type,
           error
         ) = DeserializeKeyTypes(reader);
         break;
-      case properties::OfKey::kValue:
+      }
+      case properties::OfKey::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -17635,18 +17877,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfLangStringNameType::kLanguage:
+      case properties::OfLangStringNameType::kLanguage: {
         std::tie(
           the_language,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfLangStringNameType::kText:
+      }
+      case properties::OfLangStringNameType::kText: {
         std::tie(
           the_text,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -17880,18 +18124,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfLangStringTextType::kLanguage:
+      case properties::OfLangStringTextType::kLanguage: {
         std::tie(
           the_language,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfLangStringTextType::kText:
+      }
+      case properties::OfLangStringTextType::kText: {
         std::tie(
           the_text,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -18139,7 +18385,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfEnvironment::kAssetAdministrationShells:
+      case properties::OfEnvironment::kAssetAdministrationShells: {
         std::tie(
           the_asset_administration_shells,
           error
@@ -18150,7 +18396,8 @@ std::pair<
           AssetAdministrationShellFromElement
         );
         break;
-      case properties::OfEnvironment::kSubmodels:
+      }
+      case properties::OfEnvironment::kSubmodels: {
         std::tie(
           the_submodels,
           error
@@ -18161,7 +18408,8 @@ std::pair<
           SubmodelFromElement
         );
         break;
-      case properties::OfEnvironment::kConceptDescriptions:
+      }
+      case properties::OfEnvironment::kConceptDescriptions: {
         std::tie(
           the_concept_descriptions,
           error
@@ -18172,6 +18420,7 @@ std::pair<
           ConceptDescriptionFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -18386,7 +18635,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfEmbeddedDataSpecification::kDataSpecification:
+      case properties::OfEmbeddedDataSpecification::kDataSpecification: {
         std::tie(
           the_data_specification,
           error
@@ -18394,12 +18643,14 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfEmbeddedDataSpecification::kDataSpecificationContent:
+      }
+      case properties::OfEmbeddedDataSpecification::kDataSpecificationContent: {
         std::tie(
           the_data_specification_content,
           error
         ) = DataSpecificationContentFromElement(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -18637,30 +18888,34 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfLevelType::kMin:
+      case properties::OfLevelType::kMin: {
         std::tie(
           the_min,
           error
         ) = DeserializeBool(reader);
         break;
-      case properties::OfLevelType::kNom:
+      }
+      case properties::OfLevelType::kNom: {
         std::tie(
           the_nom,
           error
         ) = DeserializeBool(reader);
         break;
-      case properties::OfLevelType::kTyp:
+      }
+      case properties::OfLevelType::kTyp: {
         std::tie(
           the_typ,
           error
         ) = DeserializeBool(reader);
         break;
-      case properties::OfLevelType::kMax:
+      }
+      case properties::OfLevelType::kMax: {
         std::tie(
           the_max,
           error
         ) = DeserializeBool(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -18912,13 +19167,14 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfValueReferencePair::kValue:
+      case properties::OfValueReferencePair::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfValueReferencePair::kValueId:
+      }
+      case properties::OfValueReferencePair::kValueId: {
         std::tie(
           the_value_id,
           error
@@ -18926,6 +19182,7 @@ std::pair<
           types::IReference
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -19161,7 +19418,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfValueList::kValueReferencePairs:
+      case properties::OfValueList::kValueReferencePairs: {
         std::tie(
           the_value_reference_pairs,
           error
@@ -19172,6 +19429,7 @@ std::pair<
           ValueReferencePairFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -19396,18 +19654,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfLangStringPreferredNameTypeIec61360::kLanguage:
+      case properties::OfLangStringPreferredNameTypeIec61360::kLanguage: {
         std::tie(
           the_language,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfLangStringPreferredNameTypeIec61360::kText:
+      }
+      case properties::OfLangStringPreferredNameTypeIec61360::kText: {
         std::tie(
           the_text,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -19641,18 +19901,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfLangStringShortNameTypeIec61360::kLanguage:
+      case properties::OfLangStringShortNameTypeIec61360::kLanguage: {
         std::tie(
           the_language,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfLangStringShortNameTypeIec61360::kText:
+      }
+      case properties::OfLangStringShortNameTypeIec61360::kText: {
         std::tie(
           the_text,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -19886,18 +20148,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfLangStringDefinitionTypeIec61360::kLanguage:
+      case properties::OfLangStringDefinitionTypeIec61360::kLanguage: {
         std::tie(
           the_language,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfLangStringDefinitionTypeIec61360::kText:
+      }
+      case properties::OfLangStringDefinitionTypeIec61360::kText: {
         std::tie(
           the_text,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -20169,7 +20433,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfDataSpecificationIec61360::kPreferredName:
+      case properties::OfDataSpecificationIec61360::kPreferredName: {
         std::tie(
           the_preferred_name,
           error
@@ -20180,7 +20444,8 @@ std::pair<
           LangStringPreferredNameTypeIec61360FromElement
         );
         break;
-      case properties::OfDataSpecificationIec61360::kShortName:
+      }
+      case properties::OfDataSpecificationIec61360::kShortName: {
         std::tie(
           the_short_name,
           error
@@ -20191,13 +20456,15 @@ std::pair<
           LangStringShortNameTypeIec61360FromElement
         );
         break;
-      case properties::OfDataSpecificationIec61360::kUnit:
+      }
+      case properties::OfDataSpecificationIec61360::kUnit: {
         std::tie(
           the_unit,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kUnitId:
+      }
+      case properties::OfDataSpecificationIec61360::kUnitId: {
         std::tie(
           the_unit_id,
           error
@@ -20205,25 +20472,29 @@ std::pair<
           types::IReference
         >(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kSourceOfDefinition:
+      }
+      case properties::OfDataSpecificationIec61360::kSourceOfDefinition: {
         std::tie(
           the_source_of_definition,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kSymbol:
+      }
+      case properties::OfDataSpecificationIec61360::kSymbol: {
         std::tie(
           the_symbol,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kDataType:
+      }
+      case properties::OfDataSpecificationIec61360::kDataType: {
         std::tie(
           the_data_type,
           error
         ) = DeserializeDataTypeIec61360(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kDefinition:
+      }
+      case properties::OfDataSpecificationIec61360::kDefinition: {
         std::tie(
           the_definition,
           error
@@ -20234,13 +20505,15 @@ std::pair<
           LangStringDefinitionTypeIec61360FromElement
         );
         break;
-      case properties::OfDataSpecificationIec61360::kValueFormat:
+      }
+      case properties::OfDataSpecificationIec61360::kValueFormat: {
         std::tie(
           the_value_format,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kValueList:
+      }
+      case properties::OfDataSpecificationIec61360::kValueList: {
         std::tie(
           the_value_list,
           error
@@ -20248,13 +20521,15 @@ std::pair<
           types::IValueList
         >(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kValue:
+      }
+      case properties::OfDataSpecificationIec61360::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfDataSpecificationIec61360::kLevelType:
+      }
+      case properties::OfDataSpecificationIec61360::kLevelType: {
         std::tie(
           the_level_type,
           error
@@ -20262,6 +20537,7 @@ std::pair<
           types::ILevelType
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -23758,6 +24034,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * Serialize a list of instances.
  */
 template <typename T, typename SerializeT>
@@ -25617,217 +25929,87 @@ common::optional<SerializationError> SerializeExtensionAsSequence(
   common::optional<SerializationError> error;
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "name",
     that.name(),
-    writer
+    writer,
+    iteration::Property::kName,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
     return error;
   }
 
   if (that.value_type().has_value()) {
-    writer.StartElement(
-      "valueType"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeDataTypeDefXsd(
+    error = SerializePropertyAsElement(
+      "valueType",
       *(that.value_type()),
-      writer
+      writer,
+      iteration::Property::kValueType,
+      SerializeDataTypeDefXsd
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueType
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "valueType"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueType
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
-      writer
+      writer,
+      iteration::Property::kValue,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
 
   if (that.refers_to().has_value()) {
-    writer.StartElement(
-      "refersTo"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "refersTo",
       *(that.refers_to()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kRefersTo,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kRefersTo
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "refersTo"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kRefersTo
-        )
-      );
-
       return error;
     }
   }
@@ -26421,182 +26603,71 @@ common::optional<SerializationError> SerializeAdministrativeInformationAsSequenc
   common::optional<SerializationError> error;
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.version().has_value()) {
-    writer.StartElement(
-      "version"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "version",
       *(that.version()),
-      writer
+      writer,
+      iteration::Property::kVersion,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kVersion
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "version"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kVersion
-        )
-      );
-
       return error;
     }
   }
 
   if (that.revision().has_value()) {
-    writer.StartElement(
-      "revision"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "revision",
       *(that.revision()),
-      writer
+      writer,
+      iteration::Property::kRevision,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kRevision
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "revision"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kRevision
-        )
-      );
-
       return error;
     }
   }
 
   if (that.creator().has_value()) {
-    writer.StartElement(
-      "creator"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "creator",
       *(*(that.creator())),
-      writer
+      writer,
+      iteration::Property::kCreator,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCreator
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "creator"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCreator
-        )
-      );
-
       return error;
     }
   }
 
   if (that.template_id().has_value()) {
-    writer.StartElement(
-      "templateId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "templateId",
       *(that.template_id()),
-      writer
+      writer,
+      iteration::Property::kTemplateId,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kTemplateId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "templateId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kTemplateId
-        )
-      );
-
       return error;
     }
   }
@@ -26799,250 +26870,93 @@ common::optional<SerializationError> SerializeQualifierAsSequence(
   common::optional<SerializationError> error;
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.kind().has_value()) {
-    writer.StartElement(
-      "kind"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeQualifierKind(
+    error = SerializePropertyAsElement(
+      "kind",
       *(that.kind()),
-      writer
+      writer,
+      iteration::Property::kKind,
+      SerializeQualifierKind
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kKind
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "kind"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kKind
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "type",
     that.type(),
-    writer
+    writer,
+    iteration::Property::kType,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "valueType"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDataTypeDefXsd(
+  error = SerializePropertyAsElement(
+    "valueType",
     that.value_type(),
-    writer
+    writer,
+    iteration::Property::kValueType,
+    SerializeDataTypeDefXsd
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "valueType"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueType
-      )
-    );
-
     return error;
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
-      writer
+      writer,
+      iteration::Property::kValue,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value_id().has_value()) {
-    writer.StartElement(
-      "valueId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "valueId",
       *(*(that.value_id())),
-      writer
+      writer,
+      iteration::Property::kValueId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "valueId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueId
-        )
-      );
-
       return error;
     }
   }
@@ -27114,398 +27028,165 @@ common::optional<SerializationError> SerializeAssetAdministrationShellAsSequence
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.administration().has_value()) {
-    writer.StartElement(
-      "administration"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeAdministrativeInformationAsSequence(
+    error = SerializePropertyAsElement(
+      "administration",
       *(*(that.administration())),
-      writer
+      writer,
+      iteration::Property::kAdministration,
+      SerializeAdministrativeInformationAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAdministration
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "administration"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAdministration
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "id"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "id",
     that.id(),
-    writer
+    writer,
+    iteration::Property::kId,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kId
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "id"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kId
-      )
-    );
-
     return error;
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.derived_from().has_value()) {
-    writer.StartElement(
-      "derivedFrom"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "derivedFrom",
       *(*(that.derived_from())),
-      writer
+      writer,
+      iteration::Property::kDerivedFrom,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDerivedFrom
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "derivedFrom"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDerivedFrom
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "assetInformation"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeAssetInformationAsSequence(
+  error = SerializePropertyAsElement(
+    "assetInformation",
     *(that.asset_information()),
-    writer
+    writer,
+    iteration::Property::kAssetInformation,
+    SerializeAssetInformationAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kAssetInformation
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "assetInformation"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kAssetInformation
-      )
-    );
-
     return error;
   }
 
   if (that.submodels().has_value()) {
-    writer.StartElement(
-      "submodels"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "submodels",
       *(that.submodels()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSubmodels,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubmodels
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "submodels"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubmodels
-        )
-      );
-
       return error;
     }
   }
@@ -27576,181 +27257,70 @@ common::optional<SerializationError> SerializeAssetInformationAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "assetKind"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeAssetKind(
+  error = SerializePropertyAsElement(
+    "assetKind",
     that.asset_kind(),
-    writer
+    writer,
+    iteration::Property::kAssetKind,
+    SerializeAssetKind
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kAssetKind
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "assetKind"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kAssetKind
-      )
-    );
-
     return error;
   }
 
   if (that.global_asset_id().has_value()) {
-    writer.StartElement(
-      "globalAssetId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "globalAssetId",
       *(that.global_asset_id()),
-      writer
+      writer,
+      iteration::Property::kGlobalAssetId,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kGlobalAssetId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "globalAssetId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kGlobalAssetId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.specific_asset_ids().has_value()) {
-    writer.StartElement(
-      "specificAssetIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "specificAssetIds",
       *(that.specific_asset_ids()),
       writer,
-      SerializeSpecificAssetIdPtrAsElement
+      iteration::Property::kSpecificAssetIds,
+      [](
+        const std::vector<std::shared_ptr<types::ISpecificAssetId>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeSpecificAssetIdPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSpecificAssetIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "specificAssetIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSpecificAssetIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.asset_type().has_value()) {
-    writer.StartElement(
-      "assetType"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "assetType",
       *(that.asset_type()),
-      writer
+      writer,
+      iteration::Property::kAssetType,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAssetType
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "assetType"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAssetType
-        )
-      );
-
       return error;
     }
   }
 
   if (that.default_thumbnail().has_value()) {
-    writer.StartElement(
-      "defaultThumbnail"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeResourceAsSequence(
+    error = SerializePropertyAsElement(
+      "defaultThumbnail",
       *(*(that.default_thumbnail())),
-      writer
+      writer,
+      iteration::Property::kDefaultThumbnail,
+      SerializeResourceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDefaultThumbnail
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "defaultThumbnail"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDefaultThumbnail
-        )
-      );
-
       return error;
     }
   }
@@ -27821,72 +27391,26 @@ common::optional<SerializationError> SerializeResourceAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "path"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "path",
     that.path(),
-    writer
+    writer,
+    iteration::Property::kPath,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kPath
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "path"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kPath
-      )
-    );
-
     return error;
   }
 
   if (that.content_type().has_value()) {
-    writer.StartElement(
-      "contentType"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "contentType",
       *(that.content_type()),
-      writer
+      writer,
+      iteration::Property::kContentType,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kContentType
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "contentType"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kContentType
-        )
-      );
-
       return error;
     }
   }
@@ -27958,178 +27482,67 @@ common::optional<SerializationError> SerializeSpecificAssetIdAsSequence(
   common::optional<SerializationError> error;
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "name",
     that.name(),
-    writer
+    writer,
+    iteration::Property::kName,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "value",
     that.value(),
-    writer
+    writer,
+    iteration::Property::kValue,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
     return error;
   }
 
   if (that.external_subject_id().has_value()) {
-    writer.StartElement(
-      "externalSubjectId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "externalSubjectId",
       *(*(that.external_subject_id())),
-      writer
+      writer,
+      iteration::Property::kExternalSubjectId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExternalSubjectId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "externalSubjectId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExternalSubjectId
-        )
-      );
-
       return error;
     }
   }
@@ -28201,474 +27614,203 @@ common::optional<SerializationError> SerializeSubmodelAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.administration().has_value()) {
-    writer.StartElement(
-      "administration"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeAdministrativeInformationAsSequence(
+    error = SerializePropertyAsElement(
+      "administration",
       *(*(that.administration())),
-      writer
+      writer,
+      iteration::Property::kAdministration,
+      SerializeAdministrativeInformationAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAdministration
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "administration"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAdministration
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "id"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "id",
     that.id(),
-    writer
+    writer,
+    iteration::Property::kId,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kId
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "id"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kId
-      )
-    );
-
     return error;
   }
 
   if (that.kind().has_value()) {
-    writer.StartElement(
-      "kind"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeModellingKind(
+    error = SerializePropertyAsElement(
+      "kind",
       *(that.kind()),
-      writer
+      writer,
+      iteration::Property::kKind,
+      SerializeModellingKind
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kKind
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "kind"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kKind
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.submodel_elements().has_value()) {
-    writer.StartElement(
-      "submodelElements"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "submodelElements",
       *(that.submodel_elements()),
       writer,
-      SerializeSubmodelElementPtrAsElement
+      iteration::Property::kSubmodelElements,
+      [](
+        const std::vector<std::shared_ptr<types::ISubmodelElement>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeSubmodelElementPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubmodelElements
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "submodelElements"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubmodelElements
-        )
-      );
-
       return error;
     }
   }
@@ -28864,400 +28006,171 @@ common::optional<SerializationError> SerializeRelationshipElementAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "first"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "first",
     *(that.first()),
-    writer
+    writer,
+    iteration::Property::kFirst,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kFirst
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "first"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kFirst
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "second"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "second",
     *(that.second()),
-    writer
+    writer,
+    iteration::Property::kSecond,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSecond
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "second"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSecond
-      )
-    );
-
     return error;
   }
 
@@ -29370,510 +28283,216 @@ common::optional<SerializationError> SerializeSubmodelElementListAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.order_relevant().has_value()) {
-    writer.StartElement(
-      "orderRelevant"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeBool(
+    error = SerializePropertyAsElement(
+      "orderRelevant",
       *(that.order_relevant()),
-      writer
+      writer,
+      iteration::Property::kOrderRelevant,
+      SerializeBool
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kOrderRelevant
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "orderRelevant"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kOrderRelevant
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id_list_element().has_value()) {
-    writer.StartElement(
-      "semanticIdListElement"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticIdListElement",
       *(*(that.semantic_id_list_element())),
-      writer
+      writer,
+      iteration::Property::kSemanticIdListElement,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticIdListElement
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticIdListElement"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticIdListElement
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "typeValueListElement"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeAasSubmodelElements(
+  error = SerializePropertyAsElement(
+    "typeValueListElement",
     that.type_value_list_element(),
-    writer
+    writer,
+    iteration::Property::kTypeValueListElement,
+    SerializeAasSubmodelElements
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kTypeValueListElement
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "typeValueListElement"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kTypeValueListElement
-      )
-    );
-
     return error;
   }
 
   if (that.value_type_list_element().has_value()) {
-    writer.StartElement(
-      "valueTypeListElement"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeDataTypeDefXsd(
+    error = SerializePropertyAsElement(
+      "valueTypeListElement",
       *(that.value_type_list_element()),
-      writer
+      writer,
+      iteration::Property::kValueTypeListElement,
+      SerializeDataTypeDefXsd
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueTypeListElement
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "valueTypeListElement"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueTypeListElement
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
       writer,
-      SerializeSubmodelElementPtrAsElement
+      iteration::Property::kValue,
+      [](
+        const std::vector<std::shared_ptr<types::ISubmodelElement>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeSubmodelElementPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
@@ -29945,368 +28564,166 @@ common::optional<SerializationError> SerializeSubmodelElementCollectionAsSequenc
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
       writer,
-      SerializeSubmodelElementPtrAsElement
+      iteration::Property::kValue,
+      [](
+        const std::vector<std::shared_ptr<types::ISubmodelElement>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeSubmodelElementPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
@@ -30446,437 +28863,185 @@ common::optional<SerializationError> SerializePropertyAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "valueType"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDataTypeDefXsd(
+  error = SerializePropertyAsElement(
+    "valueType",
     that.value_type(),
-    writer
+    writer,
+    iteration::Property::kValueType,
+    SerializeDataTypeDefXsd
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "valueType"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueType
-      )
-    );
-
     return error;
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
-      writer
+      writer,
+      iteration::Property::kValue,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value_id().has_value()) {
-    writer.StartElement(
-      "valueId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "valueId",
       *(*(that.value_id())),
-      writer
+      writer,
+      iteration::Property::kValueId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "valueId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueId
-        )
-      );
-
       return error;
     }
   }
@@ -30948,404 +29113,179 @@ common::optional<SerializationError> SerializeMultiLanguagePropertyAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kValue,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value_id().has_value()) {
-    writer.StartElement(
-      "valueId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "valueId",
       *(*(that.value_id())),
-      writer
+      writer,
+      iteration::Property::kValueId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "valueId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueId
-        )
-      );
-
       return error;
     }
   }
@@ -31417,437 +29357,185 @@ common::optional<SerializationError> SerializeRangeAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "valueType"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDataTypeDefXsd(
+  error = SerializePropertyAsElement(
+    "valueType",
     that.value_type(),
-    writer
+    writer,
+    iteration::Property::kValueType,
+    SerializeDataTypeDefXsd
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "valueType"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueType
-      )
-    );
-
     return error;
   }
 
   if (that.min().has_value()) {
-    writer.StartElement(
-      "min"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "min",
       *(that.min()),
-      writer
+      writer,
+      iteration::Property::kMin,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMin
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "min"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMin
-        )
-      );
-
       return error;
     }
   }
 
   if (that.max().has_value()) {
-    writer.StartElement(
-      "max"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "max",
       *(that.max()),
-      writer
+      writer,
+      iteration::Property::kMax,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMax
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "max"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMax
-        )
-      );
-
       return error;
     }
   }
@@ -31919,367 +29607,161 @@ common::optional<SerializationError> SerializeReferenceElementAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "value",
       *(*(that.value())),
-      writer
+      writer,
+      iteration::Property::kValue,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
@@ -32351,402 +29833,173 @@ common::optional<SerializationError> SerializeBlobAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeByteArray(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
-      writer
+      writer,
+      iteration::Property::kValue,
+      SerializeByteArray
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "contentType"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "contentType",
     that.content_type(),
-    writer
+    writer,
+    iteration::Property::kContentType,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kContentType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "contentType"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kContentType
-      )
-    );
-
     return error;
   }
 
@@ -32817,402 +30070,173 @@ common::optional<SerializationError> SerializeFileAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
-      writer
+      writer,
+      iteration::Property::kValue,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "contentType"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "contentType",
     that.content_type(),
-    writer
+    writer,
+    iteration::Property::kContentType,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kContentType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "contentType"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kContentType
-      )
-    );
-
     return error;
   }
 
@@ -33283,436 +30307,188 @@ common::optional<SerializationError> SerializeAnnotatedRelationshipElementAsSequ
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "first"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "first",
     *(that.first()),
-    writer
+    writer,
+    iteration::Property::kFirst,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kFirst
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "first"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kFirst
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "second"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "second",
     *(that.second()),
-    writer
+    writer,
+    iteration::Property::kSecond,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSecond
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "second"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSecond
-      )
-    );
-
     return error;
   }
 
   if (that.annotations().has_value()) {
-    writer.StartElement(
-      "annotations"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "annotations",
       *(that.annotations()),
       writer,
-      SerializeDataElementPtrAsElement
+      iteration::Property::kAnnotations,
+      [](
+        const std::vector<std::shared_ptr<types::IDataElement>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeDataElementPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAnnotations
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "annotations"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAnnotations
-        )
-      );
-
       return error;
     }
   }
@@ -33784,475 +30560,208 @@ common::optional<SerializationError> SerializeEntityAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.statements().has_value()) {
-    writer.StartElement(
-      "statements"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "statements",
       *(that.statements()),
       writer,
-      SerializeSubmodelElementPtrAsElement
+      iteration::Property::kStatements,
+      [](
+        const std::vector<std::shared_ptr<types::ISubmodelElement>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeSubmodelElementPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kStatements
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "statements"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kStatements
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "entityType"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeEntityType(
+  error = SerializePropertyAsElement(
+    "entityType",
     that.entity_type(),
-    writer
+    writer,
+    iteration::Property::kEntityType,
+    SerializeEntityType
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kEntityType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "entityType"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kEntityType
-      )
-    );
-
     return error;
   }
 
   if (that.global_asset_id().has_value()) {
-    writer.StartElement(
-      "globalAssetId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "globalAssetId",
       *(that.global_asset_id()),
-      writer
+      writer,
+      iteration::Property::kGlobalAssetId,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kGlobalAssetId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "globalAssetId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kGlobalAssetId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.specific_asset_ids().has_value()) {
-    writer.StartElement(
-      "specificAssetIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "specificAssetIds",
       *(that.specific_asset_ids()),
       writer,
-      SerializeSpecificAssetIdPtrAsElement
+      iteration::Property::kSpecificAssetIds,
+      [](
+        const std::vector<std::shared_ptr<types::ISpecificAssetId>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeSpecificAssetIdPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSpecificAssetIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "specificAssetIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSpecificAssetIds
-        )
-      );
-
       return error;
     }
   }
@@ -34323,284 +30832,100 @@ common::optional<SerializationError> SerializeEventPayloadAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "source"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "source",
     *(that.source()),
-    writer
+    writer,
+    iteration::Property::kSource,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSource
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "source"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSource
-      )
-    );
-
     return error;
   }
 
   if (that.source_semantic_id().has_value()) {
-    writer.StartElement(
-      "sourceSemanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "sourceSemanticId",
       *(*(that.source_semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSourceSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSourceSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "sourceSemanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSourceSemanticId
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "observableReference"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "observableReference",
     *(that.observable_reference()),
-    writer
+    writer,
+    iteration::Property::kObservableReference,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kObservableReference
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "observableReference"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kObservableReference
-      )
-    );
-
     return error;
   }
 
   if (that.observable_semantic_id().has_value()) {
-    writer.StartElement(
-      "observableSemanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "observableSemanticId",
       *(*(that.observable_semantic_id())),
-      writer
+      writer,
+      iteration::Property::kObservableSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kObservableSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "observableSemanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kObservableSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.topic().has_value()) {
-    writer.StartElement(
-      "topic"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "topic",
       *(that.topic()),
-      writer
+      writer,
+      iteration::Property::kTopic,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kTopic
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "topic"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kTopic
-        )
-      );
-
       return error;
     }
   }
 
   if (that.subject_id().has_value()) {
-    writer.StartElement(
-      "subjectId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "subjectId",
       *(*(that.subject_id())),
-      writer
+      writer,
+      iteration::Property::kSubjectId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubjectId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "subjectId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubjectId
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "timeStamp"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "timeStamp",
     that.time_stamp(),
-    writer
+    writer,
+    iteration::Property::kTimeStamp,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kTimeStamp
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "timeStamp"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kTimeStamp
-      )
-    );
-
     return error;
   }
 
   if (that.payload().has_value()) {
-    writer.StartElement(
-      "payload"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeByteArray(
+    error = SerializePropertyAsElement(
+      "payload",
       *(that.payload()),
-      writer
+      writer,
+      iteration::Property::kPayload,
+      SerializeByteArray
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kPayload
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "payload"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kPayload
-        )
-      );
-
       return error;
     }
   }
@@ -34705,613 +31030,246 @@ common::optional<SerializationError> SerializeBasicEventElementAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "observed"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "observed",
     *(that.observed()),
-    writer
+    writer,
+    iteration::Property::kObserved,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kObserved
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "observed"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kObserved
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "direction"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDirection(
+  error = SerializePropertyAsElement(
+    "direction",
     that.direction(),
-    writer
+    writer,
+    iteration::Property::kDirection,
+    SerializeDirection
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDirection
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "direction"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDirection
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "state"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeStateOfEvent(
+  error = SerializePropertyAsElement(
+    "state",
     that.state(),
-    writer
+    writer,
+    iteration::Property::kState,
+    SerializeStateOfEvent
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kState
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "state"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kState
-      )
-    );
-
     return error;
   }
 
   if (that.message_topic().has_value()) {
-    writer.StartElement(
-      "messageTopic"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "messageTopic",
       *(that.message_topic()),
-      writer
+      writer,
+      iteration::Property::kMessageTopic,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMessageTopic
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "messageTopic"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMessageTopic
-        )
-      );
-
       return error;
     }
   }
 
   if (that.message_broker().has_value()) {
-    writer.StartElement(
-      "messageBroker"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "messageBroker",
       *(*(that.message_broker())),
-      writer
+      writer,
+      iteration::Property::kMessageBroker,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMessageBroker
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "messageBroker"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMessageBroker
-        )
-      );
-
       return error;
     }
   }
 
   if (that.last_update().has_value()) {
-    writer.StartElement(
-      "lastUpdate"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "lastUpdate",
       *(that.last_update()),
-      writer
+      writer,
+      iteration::Property::kLastUpdate,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kLastUpdate
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "lastUpdate"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kLastUpdate
-        )
-      );
-
       return error;
     }
   }
 
   if (that.min_interval().has_value()) {
-    writer.StartElement(
-      "minInterval"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "minInterval",
       *(that.min_interval()),
-      writer
+      writer,
+      iteration::Property::kMinInterval,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMinInterval
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "minInterval"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMinInterval
-        )
-      );
-
       return error;
     }
   }
 
   if (that.max_interval().has_value()) {
-    writer.StartElement(
-      "maxInterval"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "maxInterval",
       *(that.max_interval()),
-      writer
+      writer,
+      iteration::Property::kMaxInterval,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMaxInterval
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "maxInterval"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kMaxInterval
-        )
-      );
-
       return error;
     }
   }
@@ -35383,442 +31341,202 @@ common::optional<SerializationError> SerializeOperationAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.input_variables().has_value()) {
-    writer.StartElement(
-      "inputVariables"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "inputVariables",
       *(that.input_variables()),
       writer,
-      SerializeOperationVariablePtrAsElement
+      iteration::Property::kInputVariables,
+      [](
+        const std::vector<std::shared_ptr<types::IOperationVariable>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeOperationVariablePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kInputVariables
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "inputVariables"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kInputVariables
-        )
-      );
-
       return error;
     }
   }
 
   if (that.output_variables().has_value()) {
-    writer.StartElement(
-      "outputVariables"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "outputVariables",
       *(that.output_variables()),
       writer,
-      SerializeOperationVariablePtrAsElement
+      iteration::Property::kOutputVariables,
+      [](
+        const std::vector<std::shared_ptr<types::IOperationVariable>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeOperationVariablePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kOutputVariables
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "outputVariables"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kOutputVariables
-        )
-      );
-
       return error;
     }
   }
 
   if (that.inoutput_variables().has_value()) {
-    writer.StartElement(
-      "inoutputVariables"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "inoutputVariables",
       *(that.inoutput_variables()),
       writer,
-      SerializeOperationVariablePtrAsElement
+      iteration::Property::kInoutputVariables,
+      [](
+        const std::vector<std::shared_ptr<types::IOperationVariable>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeOperationVariablePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kInoutputVariables
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "inoutputVariables"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kInoutputVariables
-        )
-      );
-
       return error;
     }
   }
@@ -35889,37 +31607,14 @@ common::optional<SerializationError> SerializeOperationVariableAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeSubmodelElementAsElement(
+  error = SerializePropertyAsElement(
+    "value",
     *(that.value()),
-    writer
+    writer,
+    iteration::Property::kValue,
+    SerializeSubmodelElementAsElement
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
     return error;
   }
 
@@ -35990,331 +31685,148 @@ common::optional<SerializationError> SerializeCapabilityAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.semantic_id().has_value()) {
-    writer.StartElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "semanticId",
       *(*(that.semantic_id())),
-      writer
+      writer,
+      iteration::Property::kSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "semanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSemanticId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.supplemental_semantic_ids().has_value()) {
-    writer.StartElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "supplementalSemanticIds",
       *(that.supplemental_semantic_ids()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kSupplementalSemanticIds,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "supplementalSemanticIds"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSupplementalSemanticIds
-        )
-      );
-
       return error;
     }
   }
 
   if (that.qualifiers().has_value()) {
-    writer.StartElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "qualifiers",
       *(that.qualifiers()),
       writer,
-      SerializeQualifierPtrAsElement
+      iteration::Property::kQualifiers,
+      [](
+        const std::vector<std::shared_ptr<types::IQualifier>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeQualifierPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "qualifiers"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kQualifiers
-        )
-      );
-
       return error;
     }
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
@@ -36386,328 +31898,141 @@ common::optional<SerializationError> SerializeConceptDescriptionAsSequence(
   common::optional<SerializationError> error;
 
   if (that.extensions().has_value()) {
-    writer.StartElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "extensions",
       *(that.extensions()),
       writer,
-      SerializeExtensionPtrAsElement
+      iteration::Property::kExtensions,
+      [](
+        const std::vector<std::shared_ptr<types::IExtension>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeExtensionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "extensions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kExtensions
-        )
-      );
-
       return error;
     }
   }
 
   if (that.category().has_value()) {
-    writer.StartElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "category",
       *(that.category()),
-      writer
+      writer,
+      iteration::Property::kCategory,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "category"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kCategory
-        )
-      );
-
       return error;
     }
   }
 
   if (that.id_short().has_value()) {
-    writer.StartElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "idShort",
       *(that.id_short()),
-      writer
+      writer,
+      iteration::Property::kIdShort,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "idShort"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIdShort
-        )
-      );
-
       return error;
     }
   }
 
   if (that.display_name().has_value()) {
-    writer.StartElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "displayName",
       *(that.display_name()),
       writer,
-      SerializeLangStringNameTypePtrAsElement
+      iteration::Property::kDisplayName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringNameType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringNameTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "displayName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDisplayName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.description().has_value()) {
-    writer.StartElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "description",
       *(that.description()),
       writer,
-      SerializeLangStringTextTypePtrAsElement
+      iteration::Property::kDescription,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringTextType>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringTextTypePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "description"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDescription
-        )
-      );
-
       return error;
     }
   }
 
   if (that.administration().has_value()) {
-    writer.StartElement(
-      "administration"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeAdministrativeInformationAsSequence(
+    error = SerializePropertyAsElement(
+      "administration",
       *(*(that.administration())),
-      writer
+      writer,
+      iteration::Property::kAdministration,
+      SerializeAdministrativeInformationAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAdministration
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "administration"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAdministration
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "id"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "id",
     that.id(),
-    writer
+    writer,
+    iteration::Property::kId,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kId
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "id"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kId
-      )
-    );
-
     return error;
   }
 
   if (that.embedded_data_specifications().has_value()) {
-    writer.StartElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "embeddedDataSpecifications",
       *(that.embedded_data_specifications()),
       writer,
-      SerializeEmbeddedDataSpecificationPtrAsElement
+      iteration::Property::kEmbeddedDataSpecifications,
+      [](
+        const std::vector<std::shared_ptr<types::IEmbeddedDataSpecification>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeEmbeddedDataSpecificationPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "embeddedDataSpecifications"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEmbeddedDataSpecifications
-        )
-      );
-
       return error;
     }
   }
 
   if (that.is_case_of().has_value()) {
-    writer.StartElement(
-      "isCaseOf"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "isCaseOf",
       *(that.is_case_of()),
       writer,
-      SerializeReferencePtrAsElement
+      iteration::Property::kIsCaseOf,
+      [](
+        const std::vector<std::shared_ptr<types::IReference>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeReferencePtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIsCaseOf
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "isCaseOf"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kIsCaseOf
-        )
-      );
-
       return error;
     }
   }
@@ -36778,108 +32103,43 @@ common::optional<SerializationError> SerializeReferenceAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceTypes(
+  error = SerializePropertyAsElement(
+    "type",
     that.type(),
-    writer
+    writer,
+    iteration::Property::kType,
+    SerializeReferenceTypes
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
     return error;
   }
 
   if (that.referred_semantic_id().has_value()) {
-    writer.StartElement(
-      "referredSemanticId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "referredSemanticId",
       *(*(that.referred_semantic_id())),
-      writer
+      writer,
+      iteration::Property::kReferredSemanticId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kReferredSemanticId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "referredSemanticId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kReferredSemanticId
-        )
-      );
-
       return error;
     }
   }
 
-  writer.StartElement(
-    "keys"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfInstances(
+  error = SerializePropertyAsElement(
+    "keys",
     that.keys(),
     writer,
-    SerializeKeyPtrAsElement
+    iteration::Property::kKeys,
+    [](
+      const std::vector<std::shared_ptr<types::IKey>>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfInstances(a_list, a_writer, SerializeKeyPtrAsElement);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kKeys
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "keys"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kKeys
-      )
-    );
-
     return error;
   }
 
@@ -36949,71 +32209,25 @@ common::optional<SerializationError> SerializeKeyAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeKeyTypes(
+  error = SerializePropertyAsElement(
+    "type",
     that.type(),
-    writer
+    writer,
+    iteration::Property::kType,
+    SerializeKeyTypes
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "value",
     that.value(),
-    writer
+    writer,
+    iteration::Property::kValue,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
     return error;
   }
 
@@ -37144,71 +32358,25 @@ common::optional<SerializationError> SerializeLangStringNameTypeAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "language",
     that.language(),
-    writer
+    writer,
+    iteration::Property::kLanguage,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "text",
     that.text(),
-    writer
+    writer,
+    iteration::Property::kText,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
     return error;
   }
 
@@ -37278,71 +32446,25 @@ common::optional<SerializationError> SerializeLangStringTextTypeAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "language",
     that.language(),
-    writer
+    writer,
+    iteration::Property::kLanguage,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "text",
     that.text(),
-    writer
+    writer,
+    iteration::Property::kText,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
     return error;
   }
 
@@ -37413,112 +32535,55 @@ common::optional<SerializationError> SerializeEnvironmentAsSequence(
   common::optional<SerializationError> error;
 
   if (that.asset_administration_shells().has_value()) {
-    writer.StartElement(
-      "assetAdministrationShells"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "assetAdministrationShells",
       *(that.asset_administration_shells()),
       writer,
-      SerializeAssetAdministrationShellPtrAsElement
+      iteration::Property::kAssetAdministrationShells,
+      [](
+        const std::vector<std::shared_ptr<types::IAssetAdministrationShell>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeAssetAdministrationShellPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAssetAdministrationShells
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "assetAdministrationShells"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kAssetAdministrationShells
-        )
-      );
-
       return error;
     }
   }
 
   if (that.submodels().has_value()) {
-    writer.StartElement(
-      "submodels"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "submodels",
       *(that.submodels()),
       writer,
-      SerializeSubmodelPtrAsElement
+      iteration::Property::kSubmodels,
+      [](
+        const std::vector<std::shared_ptr<types::ISubmodel>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeSubmodelPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubmodels
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "submodels"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSubmodels
-        )
-      );
-
       return error;
     }
   }
 
   if (that.concept_descriptions().has_value()) {
-    writer.StartElement(
-      "conceptDescriptions"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "conceptDescriptions",
       *(that.concept_descriptions()),
       writer,
-      SerializeConceptDescriptionPtrAsElement
+      iteration::Property::kConceptDescriptions,
+      [](
+        const std::vector<std::shared_ptr<types::IConceptDescription>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeConceptDescriptionPtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kConceptDescriptions
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "conceptDescriptions"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kConceptDescriptions
-        )
-      );
-
       return error;
     }
   }
@@ -37622,71 +32687,25 @@ common::optional<SerializationError> SerializeEmbeddedDataSpecificationAsSequenc
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "dataSpecification"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "dataSpecification",
     *(that.data_specification()),
-    writer
+    writer,
+    iteration::Property::kDataSpecification,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecification
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "dataSpecification"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecification
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "dataSpecificationContent"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDataSpecificationContentAsElement(
+  error = SerializePropertyAsElement(
+    "dataSpecificationContent",
     *(that.data_specification_content()),
-    writer
+    writer,
+    iteration::Property::kDataSpecificationContent,
+    SerializeDataSpecificationContentAsElement
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecificationContent
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "dataSpecificationContent"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDataSpecificationContent
-      )
-    );
-
     return error;
   }
 
@@ -37756,139 +32775,47 @@ common::optional<SerializationError> SerializeLevelTypeAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "min"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeBool(
+  error = SerializePropertyAsElement(
+    "min",
     that.min(),
-    writer
+    writer,
+    iteration::Property::kMin,
+    SerializeBool
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kMin
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "min"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kMin
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "nom"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeBool(
+  error = SerializePropertyAsElement(
+    "nom",
     that.nom(),
-    writer
+    writer,
+    iteration::Property::kNom,
+    SerializeBool
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kNom
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "nom"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kNom
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "typ"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeBool(
+  error = SerializePropertyAsElement(
+    "typ",
     that.typ(),
-    writer
+    writer,
+    iteration::Property::kTyp,
+    SerializeBool
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kTyp
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "typ"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kTyp
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "max"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeBool(
+  error = SerializePropertyAsElement(
+    "max",
     that.max(),
-    writer
+    writer,
+    iteration::Property::kMax,
+    SerializeBool
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kMax
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "max"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kMax
-      )
-    );
-
     return error;
   }
 
@@ -37958,71 +32885,25 @@ common::optional<SerializationError> SerializeValueReferencePairAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "value",
     that.value(),
-    writer
+    writer,
+    iteration::Property::kValue,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "valueId"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeReferenceAsSequence(
+  error = SerializePropertyAsElement(
+    "valueId",
     *(that.value_id()),
-    writer
+    writer,
+    iteration::Property::kValueId,
+    SerializeReferenceAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueId
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "valueId"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueId
-      )
-    );
-
     return error;
   }
 
@@ -38092,38 +32973,19 @@ common::optional<SerializationError> SerializeValueListAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "valueReferencePairs"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfInstances(
+  error = SerializePropertyAsElement(
+    "valueReferencePairs",
     that.value_reference_pairs(),
     writer,
-    SerializeValueReferencePairPtrAsElement
+    iteration::Property::kValueReferencePairs,
+    [](
+      const std::vector<std::shared_ptr<types::IValueReferencePair>>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfInstances(a_list, a_writer, SerializeValueReferencePairPtrAsElement);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueReferencePairs
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "valueReferencePairs"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValueReferencePairs
-      )
-    );
-
     return error;
   }
 
@@ -38193,71 +33055,25 @@ common::optional<SerializationError> SerializeLangStringPreferredNameTypeIec6136
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "language",
     that.language(),
-    writer
+    writer,
+    iteration::Property::kLanguage,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "text",
     that.text(),
-    writer
+    writer,
+    iteration::Property::kText,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
     return error;
   }
 
@@ -38327,71 +33143,25 @@ common::optional<SerializationError> SerializeLangStringShortNameTypeIec61360AsS
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "language",
     that.language(),
-    writer
+    writer,
+    iteration::Property::kLanguage,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "text",
     that.text(),
-    writer
+    writer,
+    iteration::Property::kText,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
     return error;
   }
 
@@ -38461,71 +33231,25 @@ common::optional<SerializationError> SerializeLangStringDefinitionTypeIec61360As
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "language",
     that.language(),
-    writer
+    writer,
+    iteration::Property::kLanguage,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "language"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kLanguage
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "text",
     that.text(),
-    writer
+    writer,
+    iteration::Property::kText,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "text"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kText
-      )
-    );
-
     return error;
   }
 
@@ -38595,435 +33319,171 @@ common::optional<SerializationError> SerializeDataSpecificationIec61360AsSequenc
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "preferredName"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfInstances(
+  error = SerializePropertyAsElement(
+    "preferredName",
     that.preferred_name(),
     writer,
-    SerializeLangStringPreferredNameTypeIec61360PtrAsElement
+    iteration::Property::kPreferredName,
+    [](
+      const std::vector<std::shared_ptr<types::ILangStringPreferredNameTypeIec61360>>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfInstances(a_list, a_writer, SerializeLangStringPreferredNameTypeIec61360PtrAsElement);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kPreferredName
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "preferredName"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kPreferredName
-      )
-    );
-
     return error;
   }
 
   if (that.short_name().has_value()) {
-    writer.StartElement(
-      "shortName"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "shortName",
       *(that.short_name()),
       writer,
-      SerializeLangStringShortNameTypeIec61360PtrAsElement
+      iteration::Property::kShortName,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringShortNameTypeIec61360>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringShortNameTypeIec61360PtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kShortName
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "shortName"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kShortName
-        )
-      );
-
       return error;
     }
   }
 
   if (that.unit().has_value()) {
-    writer.StartElement(
-      "unit"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "unit",
       *(that.unit()),
-      writer
+      writer,
+      iteration::Property::kUnit,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kUnit
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "unit"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kUnit
-        )
-      );
-
       return error;
     }
   }
 
   if (that.unit_id().has_value()) {
-    writer.StartElement(
-      "unitId"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeReferenceAsSequence(
+    error = SerializePropertyAsElement(
+      "unitId",
       *(*(that.unit_id())),
-      writer
+      writer,
+      iteration::Property::kUnitId,
+      SerializeReferenceAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kUnitId
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "unitId"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kUnitId
-        )
-      );
-
       return error;
     }
   }
 
   if (that.source_of_definition().has_value()) {
-    writer.StartElement(
-      "sourceOfDefinition"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "sourceOfDefinition",
       *(that.source_of_definition()),
-      writer
+      writer,
+      iteration::Property::kSourceOfDefinition,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSourceOfDefinition
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "sourceOfDefinition"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSourceOfDefinition
-        )
-      );
-
       return error;
     }
   }
 
   if (that.symbol().has_value()) {
-    writer.StartElement(
-      "symbol"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "symbol",
       *(that.symbol()),
-      writer
+      writer,
+      iteration::Property::kSymbol,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSymbol
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "symbol"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kSymbol
-        )
-      );
-
       return error;
     }
   }
 
   if (that.data_type().has_value()) {
-    writer.StartElement(
-      "dataType"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeDataTypeIec61360(
+    error = SerializePropertyAsElement(
+      "dataType",
       *(that.data_type()),
-      writer
+      writer,
+      iteration::Property::kDataType,
+      SerializeDataTypeIec61360
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDataType
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "dataType"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDataType
-        )
-      );
-
       return error;
     }
   }
 
   if (that.definition().has_value()) {
-    writer.StartElement(
-      "definition"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeListOfInstances(
+    error = SerializePropertyAsElement(
+      "definition",
       *(that.definition()),
       writer,
-      SerializeLangStringDefinitionTypeIec61360PtrAsElement
+      iteration::Property::kDefinition,
+      [](
+        const std::vector<std::shared_ptr<types::ILangStringDefinitionTypeIec61360>>& a_list,
+        SelfClosingWriter& a_writer
+      ) {
+        return SerializeListOfInstances(a_list, a_writer, SerializeLangStringDefinitionTypeIec61360PtrAsElement);
+      }
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDefinition
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "definition"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kDefinition
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value_format().has_value()) {
-    writer.StartElement(
-      "valueFormat"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "valueFormat",
       *(that.value_format()),
-      writer
+      writer,
+      iteration::Property::kValueFormat,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueFormat
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "valueFormat"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueFormat
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value_list().has_value()) {
-    writer.StartElement(
-      "valueList"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeValueListAsSequence(
+    error = SerializePropertyAsElement(
+      "valueList",
       *(*(that.value_list())),
-      writer
+      writer,
+      iteration::Property::kValueList,
+      SerializeValueListAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueList
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "valueList"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValueList
-        )
-      );
-
       return error;
     }
   }
 
   if (that.value().has_value()) {
-    writer.StartElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "value",
       *(that.value()),
-      writer
+      writer,
+      iteration::Property::kValue,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "value"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kValue
-        )
-      );
-
       return error;
     }
   }
 
   if (that.level_type().has_value()) {
-    writer.StartElement(
-      "levelType"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeLevelTypeAsSequence(
+    error = SerializePropertyAsElement(
+      "levelType",
       *(*(that.level_type())),
-      writer
+      writer,
+      iteration::Property::kLevelType,
+      SerializeLevelTypeAsSequence
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kLevelType
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "levelType"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kLevelType
-        )
-      );
-
       return error;
     }
   }

--- a/dev/test_data/main/cpp/expected/constrained_primitives/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/constrained_primitives/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -907,6 +906,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -946,6 +954,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -1052,14 +1069,6 @@ nlohmann::json SerializeListWithInfallible(
   return serialized;
 }
 
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
-}
-
 std::pair<
   common::optional<nlohmann::json>,
   common::optional<SerializationError>
@@ -1084,7 +1093,9 @@ std::pair<
 
   common::optional<SerializationError> error;
 
-  result["someBool"] = that.some_bool();
+  result["someBool"] = SerializeBool(
+    that.some_bool()
+  );
 
   common::optional<nlohmann::json> json_some_int;
   std::tie(
@@ -1113,7 +1124,9 @@ std::pair<
     json_some_int.value()
   );
 
-  result["someFloat"] = that.some_float();
+  result["someFloat"] = SerializeDouble(
+    that.some_float()
+  );
 
   result["someString"] = SerializeWstring(
     that.some_string()

--- a/dev/test_data/main/cpp/expected/constrained_primitives/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/constrained_primitives/expected_output/src/xmlization.cpp
@@ -2342,36 +2342,41 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeBool:
+      case properties::OfSomething::kSomeBool: {
         std::tie(
           the_some_bool,
           error
         ) = DeserializeBool(reader);
         break;
-      case properties::OfSomething::kSomeInt:
+      }
+      case properties::OfSomething::kSomeInt: {
         std::tie(
           the_some_int,
           error
         ) = DeserializeInt64(reader);
         break;
-      case properties::OfSomething::kSomeFloat:
+      }
+      case properties::OfSomething::kSomeFloat: {
         std::tie(
           the_some_float,
           error
         ) = DeserializeDouble(reader);
         break;
-      case properties::OfSomething::kSomeString:
+      }
+      case properties::OfSomething::kSomeString: {
         std::tie(
           the_some_string,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSomething::kSomeBytes:
+      }
+      case properties::OfSomething::kSomeBytes: {
         std::tie(
           the_some_bytes,
           error
         ) = DeserializeByteArray(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3443,6 +3448,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * \brief Serialize \p that instance as a sequence of XML elements.
  *
  * Each XML element corresponds to a property.
@@ -3489,173 +3530,58 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someBool"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeBool(
+  error = SerializePropertyAsElement(
+    "someBool",
     that.some_bool(),
-    writer
+    writer,
+    iteration::Property::kSomeBool,
+    SerializeBool
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBool
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someBool"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBool
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someInt"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeInt64(
+  error = SerializePropertyAsElement(
+    "someInt",
     that.some_int(),
-    writer
+    writer,
+    iteration::Property::kSomeInt,
+    SerializeInt64
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeInt
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someInt"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeInt
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someFloat"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDouble(
+  error = SerializePropertyAsElement(
+    "someFloat",
     that.some_float(),
-    writer
+    writer,
+    iteration::Property::kSomeFloat,
+    SerializeDouble
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeFloat
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someFloat"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeFloat
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someString"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "someString",
     that.some_string(),
-    writer
+    writer,
+    iteration::Property::kSomeString,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeString
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someString"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeString
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someBytes"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeByteArray(
+  error = SerializePropertyAsElement(
+    "someBytes",
     that.some_bytes(),
-    writer
+    writer,
+    iteration::Property::kSomeBytes,
+    SerializeByteArray
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBytes
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someBytes"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBytes
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/custom_serialization_names/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/custom_serialization_names/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -754,6 +753,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -793,6 +801,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -897,14 +914,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/custom_serialization_names/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/custom_serialization_names/expected_output/src/xmlization.cpp
@@ -2321,18 +2321,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfQueryCondition::kEq:
+      case properties::OfQueryCondition::kEq: {
         std::tie(
           the_eq,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfQueryCondition::kNotEq:
+      }
+      case properties::OfQueryCondition::kNotEq: {
         std::tie(
           the_not_eq,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3357,6 +3359,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * \brief Serialize \p that instance as a sequence of XML elements.
  *
  * Each XML element corresponds to a property.
@@ -3404,73 +3442,27 @@ common::optional<SerializationError> SerializeQueryConditionAsSequence(
   common::optional<SerializationError> error;
 
   if (that.eq().has_value()) {
-    writer.StartElement(
-      "eq"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "eq",
       *(that.eq()),
-      writer
+      writer,
+      iteration::Property::kEq,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEq
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "eq"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kEq
-        )
-      );
-
       return error;
     }
   }
 
   if (that.not_eQ().has_value()) {
-    writer.StartElement(
-      "not-eq"
-    );
-    if (writer.error().has_value()) {
-      return writer.move_error();
-    }
-    error = SerializeWstring(
+    error = SerializePropertyAsElement(
+      "not-eq",
       *(that.not_eQ()),
-      writer
+      writer,
+      iteration::Property::kNotEq,
+      SerializeWstring
     );
     if (error.has_value()) {
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kNotEq
-        )
-      );
-
-      return error;
-    }
-    writer.StopElement(
-      "not-eq"
-    );
-    if (writer.error().has_value()) {
-      error = writer.move_error();
-
-      error->path.segments.emplace_front(
-        common::make_unique<iteration::PropertySegment>(
-          iteration::Property::kNotEq
-        )
-      );
-
       return error;
     }
   }

--- a/dev/test_data/main/cpp/expected/deep_class_hierarchy/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/deep_class_hierarchy/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -492,6 +491,46 @@ std::pair<
 }
 
 /**
+ * Map JSON \c modelType strings to model types.
+ */
+const std::unordered_map<
+  std::string,
+  types::ModelType
+> kModelTypeStringToModelType = {
+  {
+    "Branch",
+    types::ModelType::kBranch
+  },
+  {
+    "Leaf",
+    types::ModelType::kLeaf
+  },
+  {
+    "Blossom",
+    types::ModelType::kBlossom
+  },
+  {
+    "Something",
+    types::ModelType::kSomething
+  },
+  {
+    "Container",
+    types::ModelType::kContainer
+  }
+};
+
+common::optional<types::ModelType> ModelTypeFromModelTypeString(
+  const std::string& model_type_str
+) {
+  auto it = kModelTypeStringToModelType.find(model_type_str);
+  if (it == kModelTypeStringToModelType.end()) {
+    return common::nullopt;
+  }
+
+  return it->second;
+}
+
+/**
  * \brief Dispatch the deserialization for an instance
  * of types::INode.
  *
@@ -655,35 +694,6 @@ std::pair<
   bool additional_properties
 );
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::INode> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeNodeByModelType = {
-  {
-    "Branch",
-    ConcretelyDeserializeBranch<
-      types::INode
-    >
-  },
-  {
-    "Leaf",
-    ConcretelyDeserializeLeaf<
-      types::INode
-    >
-  },
-  {
-    "Blossom",
-    DeserializeBlossom<
-      types::INode
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::INode>
@@ -693,11 +703,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -711,13 +721,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeNodeByModelType.find(*model_type);
-  if (it == kDeserializeNodeByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::INode "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -731,7 +742,38 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kBranch:
+      return ConcretelyDeserializeBranch<
+        types::INode
+      >(json, additional_properties);
+    case types::ModelType::kLeaf:
+      return ConcretelyDeserializeLeaf<
+        types::INode
+      >(json, additional_properties);
+    case types::ModelType::kBlossom:
+      return DeserializeBlossom<
+        types::INode
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::INode "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::INode> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInBranch = {
@@ -966,35 +1008,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IBranch> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeBranchByModelType = {
-  {
-    "Branch",
-    ConcretelyDeserializeBranch<
-      types::IBranch
-    >
-  },
-  {
-    "Leaf",
-    ConcretelyDeserializeLeaf<
-      types::IBranch
-    >
-  },
-  {
-    "Blossom",
-    DeserializeBlossom<
-      types::IBranch
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IBranch>
@@ -1004,11 +1017,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -1022,13 +1035,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeBranchByModelType.find(*model_type);
-  if (it == kDeserializeBranchByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IBranch "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -1042,7 +1056,38 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kBranch:
+      return ConcretelyDeserializeBranch<
+        types::IBranch
+      >(json, additional_properties);
+    case types::ModelType::kLeaf:
+      return ConcretelyDeserializeLeaf<
+        types::IBranch
+      >(json, additional_properties);
+    case types::ModelType::kBlossom:
+      return DeserializeBlossom<
+        types::IBranch
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IBranch "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IBranch> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInLeaf = {
@@ -1320,29 +1365,6 @@ std::pair<
   );
 }
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::ILeaf> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeLeafByModelType = {
-  {
-    "Leaf",
-    ConcretelyDeserializeLeaf<
-      types::ILeaf
-    >
-  },
-  {
-    "Blossom",
-    DeserializeBlossom<
-      types::ILeaf
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::ILeaf>
@@ -1352,11 +1374,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -1370,13 +1392,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeLeafByModelType.find(*model_type);
-  if (it == kDeserializeLeafByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::ILeaf "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -1390,7 +1413,34 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kLeaf:
+      return ConcretelyDeserializeLeaf<
+        types::ILeaf
+      >(json, additional_properties);
+    case types::ModelType::kBlossom:
+      return DeserializeBlossom<
+        types::ILeaf
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::ILeaf "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::ILeaf> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInBlossom = {
@@ -2323,6 +2373,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -2362,6 +2421,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -2466,14 +2534,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/deep_class_hierarchy/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/deep_class_hierarchy/expected_output/src/xmlization.cpp
@@ -2761,18 +2761,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfBranch::kIdentifier:
+      case properties::OfBranch::kIdentifier: {
         std::tie(
           the_identifier,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBranch::kDescription:
+      }
+      case properties::OfBranch::kDescription: {
         std::tie(
           the_description,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3008,24 +3010,27 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfLeaf::kIdentifier:
+      case properties::OfLeaf::kIdentifier: {
         std::tie(
           the_identifier,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfLeaf::kDescription:
+      }
+      case properties::OfLeaf::kDescription: {
         std::tie(
           the_description,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfLeaf::kValue:
+      }
+      case properties::OfLeaf::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeInt64(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3272,30 +3277,34 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfBlossom::kIdentifier:
+      case properties::OfBlossom::kIdentifier: {
         std::tie(
           the_identifier,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBlossom::kDescription:
+      }
+      case properties::OfBlossom::kDescription: {
         std::tie(
           the_description,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfBlossom::kValue:
+      }
+      case properties::OfBlossom::kValue: {
         std::tie(
           the_value,
           error
         ) = DeserializeInt64(reader);
         break;
-      case properties::OfBlossom::kDetails:
+      }
+      case properties::OfBlossom::kDetails: {
         std::tie(
           the_details,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3547,18 +3556,20 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeChoice:
+      case properties::OfSomething::kSomeChoice: {
         std::tie(
           the_some_choice,
           error
         ) = NodeFromElement(reader);
         break;
-      case properties::OfSomething::kSomethingWithoutChoice:
+      }
+      case properties::OfSomething::kSomethingWithoutChoice: {
         std::tie(
           the_something_without_choice,
           error
         ) = BranchFromElement(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3792,13 +3803,14 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfContainer::kNode:
+      case properties::OfContainer::kNode: {
         std::tie(
           the_node,
           error
         ) = NodeFromElement(reader);
         break;
-      case properties::OfContainer::kSomething:
+      }
+      case properties::OfContainer::kSomething: {
         std::tie(
           the_something,
           error
@@ -3806,6 +3818,7 @@ std::pair<
           types::ISomething
         >(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -5100,6 +5113,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * \brief Serialize \p that instance by dispatching to the appropriate concrete
  * serialization function.
  *
@@ -5342,71 +5391,25 @@ common::optional<SerializationError> SerializeBranchAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "identifier"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "identifier",
     that.identifier(),
-    writer
+    writer,
+    iteration::Property::kIdentifier,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kIdentifier
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "identifier"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kIdentifier
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "description"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "description",
     that.description(),
-    writer
+    writer,
+    iteration::Property::kDescription,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDescription
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "description"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDescription
-      )
-    );
-
     return error;
   }
 
@@ -5525,105 +5528,36 @@ common::optional<SerializationError> SerializeLeafAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "identifier"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "identifier",
     that.identifier(),
-    writer
+    writer,
+    iteration::Property::kIdentifier,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kIdentifier
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "identifier"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kIdentifier
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "description"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "description",
     that.description(),
-    writer
+    writer,
+    iteration::Property::kDescription,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDescription
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "description"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDescription
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeInt64(
+  error = SerializePropertyAsElement(
+    "value",
     that.value(),
-    writer
+    writer,
+    iteration::Property::kValue,
+    SerializeInt64
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
     return error;
   }
 
@@ -5735,139 +5669,47 @@ common::optional<SerializationError> SerializeBlossomAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "identifier"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "identifier",
     that.identifier(),
-    writer
+    writer,
+    iteration::Property::kIdentifier,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kIdentifier
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "identifier"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kIdentifier
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "description"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "description",
     that.description(),
-    writer
+    writer,
+    iteration::Property::kDescription,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDescription
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "description"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDescription
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeInt64(
+  error = SerializePropertyAsElement(
+    "value",
     that.value(),
-    writer
+    writer,
+    iteration::Property::kValue,
+    SerializeInt64
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "value"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kValue
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "details"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "details",
     that.details(),
-    writer
+    writer,
+    iteration::Property::kDetails,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDetails
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "details"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kDetails
-      )
-    );
-
     return error;
   }
 
@@ -5937,71 +5779,25 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someChoice"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeNodeAsElement(
+  error = SerializePropertyAsElement(
+    "someChoice",
     *(that.some_choice()),
-    writer
+    writer,
+    iteration::Property::kSomeChoice,
+    SerializeNodeAsElement
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeChoice
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someChoice"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeChoice
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "somethingWithoutChoice"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeBranchAsElement(
+  error = SerializePropertyAsElement(
+    "somethingWithoutChoice",
     *(that.something_without_choice()),
-    writer
+    writer,
+    iteration::Property::kSomethingWithoutChoice,
+    SerializeBranchAsElement
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomethingWithoutChoice
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "somethingWithoutChoice"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomethingWithoutChoice
-      )
-    );
-
     return error;
   }
 
@@ -6071,71 +5867,25 @@ common::optional<SerializationError> SerializeContainerAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "node"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeNodeAsElement(
+  error = SerializePropertyAsElement(
+    "node",
     *(that.node()),
-    writer
+    writer,
+    iteration::Property::kNode,
+    SerializeNodeAsElement
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kNode
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "node"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kNode
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "something"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeSomethingAsSequence(
+  error = SerializePropertyAsElement(
+    "something",
     *(that.something()),
-    writer
+    writer,
+    iteration::Property::kSomething,
+    SerializeSomethingAsSequence
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomething
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "something"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomething
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/empty_class/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/empty_class/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -682,6 +681,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -721,6 +729,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -825,14 +842,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/enum/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/enum/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -795,6 +794,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -834,6 +842,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -938,14 +955,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/enum/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/enum/expected_output/src/xmlization.cpp
@@ -2368,12 +2368,13 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeResult:
+      case properties::OfSomething::kSomeResult: {
         std::tie(
           the_some_result,
           error
         ) = DeserializeResult(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3409,6 +3410,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * Serialize the literal of Result
  * to XML text.
  */
@@ -3475,37 +3512,14 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someResult"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeResult(
+  error = SerializePropertyAsElement(
+    "someResult",
     that.some_result(),
-    writer
+    writer,
+    iteration::Property::kSomeResult,
+    SerializeResult
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeResult
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someResult"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeResult
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/list_of_classes/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_classes/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -491,6 +490,42 @@ std::pair<
   );
 }
 
+/**
+ * Map JSON \c modelType strings to model types.
+ */
+const std::unordered_map<
+  std::string,
+  types::ModelType
+> kModelTypeStringToModelType = {
+  {
+    "SomeItem",
+    types::ModelType::kSomeItem
+  },
+  {
+    "AnotherItem",
+    types::ModelType::kAnotherItem
+  },
+  {
+    "Simple",
+    types::ModelType::kSimple
+  },
+  {
+    "Something",
+    types::ModelType::kSomething
+  }
+};
+
+common::optional<types::ModelType> ModelTypeFromModelTypeString(
+  const std::string& model_type_str
+) {
+  auto it = kModelTypeStringToModelType.find(model_type_str);
+  if (it == kModelTypeStringToModelType.end()) {
+    return common::nullopt;
+  }
+
+  return it->second;
+}
+
 template <typename T, typename DeserializeItemT>
 std::pair<
   common::optional<std::vector<T> >,
@@ -662,29 +697,6 @@ std::pair<
   bool additional_properties
 );
 
-std::map<
-  std::string,
-  std::function<
-    std::pair<
-      common::optional<std::shared_ptr<types::IAbstractItem> >,
-      common::optional<DeserializationError>
-    >(const nlohmann::json&, bool)
-  >
-> kDeserializeAbstractItemByModelType = {
-  {
-    "AnotherItem",
-    DeserializeAnotherItem<
-      types::IAbstractItem
-    >
-  },
-  {
-    "SomeItem",
-    DeserializeSomeItem<
-      types::IAbstractItem
-    >
-  }
-};
-
 std::pair<
   common::optional<
     std::shared_ptr<types::IAbstractItem>
@@ -694,11 +706,11 @@ std::pair<
   const nlohmann::json& json,
   bool additional_properties
 ) {
-  const std::string* model_type;
+  const std::string* model_type_str;
   common::optional<DeserializationError> error;
 
   std::tie(
-    model_type,
+    model_type_str,
     error
   ) = GetModelTypeFrom(json);
 
@@ -712,13 +724,14 @@ std::pair<
     );
   }
 
-  const auto it = kDeserializeAbstractItemByModelType.find(*model_type);
-  if (it == kDeserializeAbstractItemByModelType.end()) {
+  common::optional<types::ModelType> model_type(
+    ModelTypeFromModelTypeString(*model_type_str)
+  );
+
+  if (!model_type.has_value()) {
     std::wstring message = common::Concat(
-      L"The dispatch to the JSON de-serialization of "
-      L"types::IAbstractItem "
-      L"is not defined for model type: ",
-      common::Utf8ToWstring(*model_type)
+      L"The model type does not correspond to any known class: ",
+      common::Utf8ToWstring(*model_type_str)
     );
 
     return std::make_pair<
@@ -732,7 +745,34 @@ std::pair<
     );
   }
 
-  return (it->second)(json, additional_properties);
+  switch (*model_type) {
+    case types::ModelType::kAnotherItem:
+      return DeserializeAnotherItem<
+        types::IAbstractItem
+      >(json, additional_properties);
+    case types::ModelType::kSomeItem:
+      return DeserializeSomeItem<
+        types::IAbstractItem
+      >(json, additional_properties);
+    default: {
+      std::wstring message = common::Concat(
+        L"The dispatch to the JSON de-serialization of "
+        L"types::IAbstractItem "
+        L"is not defined for model type: ",
+        common::Utf8ToWstring(*model_type_str)
+      );
+
+      return std::make_pair<
+        common::optional<std::shared_ptr<types::IAbstractItem> >,
+        common::optional<DeserializationError>
+      >(
+        common::nullopt,
+        common::make_optional<DeserializationError>(
+          message
+        )
+      );
+    }
+  }
 }
 
 std::set<std::string> kPropertiesInSomeItem = {
@@ -1659,6 +1699,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -1698,6 +1747,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -1802,14 +1860,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/list_of_classes/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_classes/expected_output/src/xmlization.cpp
@@ -2722,12 +2722,13 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomeItem::kName:
+      case properties::OfSomeItem::kName: {
         std::tie(
           the_name,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -2950,12 +2951,13 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfAnotherItem::kSerialNumber:
+      case properties::OfAnotherItem::kSerialNumber: {
         std::tie(
           the_serial_number,
           error
         ) = DeserializeInt64(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3178,12 +3180,13 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSimple::kName:
+      case properties::OfSimple::kName: {
         std::tie(
           the_name,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3416,7 +3419,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeItems:
+      case properties::OfSomething::kSomeItems: {
         std::tie(
           the_some_items,
           error
@@ -3427,7 +3430,8 @@ std::pair<
           AbstractItemFromElement
         );
         break;
-      case properties::OfSomething::kSomeSimples:
+      }
+      case properties::OfSomething::kSomeSimples: {
         std::tie(
           the_some_simples,
           error
@@ -3438,6 +3442,7 @@ std::pair<
           SimpleFromElement
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -4682,6 +4687,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * Serialize a list of instances.
  */
 template <typename T, typename SerializeT>
@@ -4910,37 +4951,14 @@ common::optional<SerializationError> SerializeSomeItemAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "name",
     that.name(),
-    writer
+    writer,
+    iteration::Property::kName,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
     return error;
   }
 
@@ -5010,37 +5028,14 @@ common::optional<SerializationError> SerializeAnotherItemAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "serialNumber"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeInt64(
+  error = SerializePropertyAsElement(
+    "serialNumber",
     that.serial_number(),
-    writer
+    writer,
+    iteration::Property::kSerialNumber,
+    SerializeInt64
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSerialNumber
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "serialNumber"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSerialNumber
-      )
-    );
-
     return error;
   }
 
@@ -5110,37 +5105,14 @@ common::optional<SerializationError> SerializeSimpleAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "name",
     that.name(),
-    writer
+    writer,
+    iteration::Property::kName,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "name"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kName
-      )
-    );
-
     return error;
   }
 
@@ -5210,73 +5182,35 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someItems"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfInstances(
+  error = SerializePropertyAsElement(
+    "someItems",
     that.some_items(),
     writer,
-    SerializeAbstractItemPtrAsElement
+    iteration::Property::kSomeItems,
+    [](
+      const std::vector<std::shared_ptr<types::IAbstractItem>>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfInstances(a_list, a_writer, SerializeAbstractItemPtrAsElement);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeItems
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someItems"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeItems
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someSimples"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfInstances(
+  error = SerializePropertyAsElement(
+    "someSimples",
     that.some_simples(),
     writer,
-    SerializeSimplePtrAsElement
+    iteration::Property::kSomeSimples,
+    [](
+      const std::vector<std::shared_ptr<types::ISimple>>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfInstances(a_list, a_writer, SerializeSimplePtrAsElement);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeSimples
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someSimples"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeSimples
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/list_of_constrained_primitives/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_constrained_primitives/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -804,6 +803,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -843,6 +851,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -947,14 +964,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/list_of_constrained_primitives/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_constrained_primitives/expected_output/src/xmlization.cpp
@@ -2189,7 +2189,8 @@ std::pair<
   common::optional<DeserializationError>
 > DeserializeValueFromVElement(
   ReaderMergingText& reader,
-  const DeserializeT& deserialize_content
+  const DeserializeT& deserialize_content,
+  const std::string& expected_name
 ) {
   #ifdef DEBUG
   if (reader.node().kind() == NodeKind::Error) {
@@ -2203,7 +2204,9 @@ std::pair<
   if (reader.node().kind() != NodeKind::Start) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a start element <v> enclosing a value, but got ",
+        L"Expected a start element <",
+        common::Utf8ToWstring(expected_name),
+        L"> enclosing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
@@ -2215,17 +2218,19 @@ std::pair<
     >(reader.node()).name
   );
 
-  if (start_name != "v") {
+  if (start_name != expected_name) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a start element <v> enclosing a value, but got ",
+        L"Expected a start element <",
+        common::Utf8ToWstring(expected_name),
+        L"> enclosing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
   }
 
   // NOTE (mristin):
-  // We consume the <v>.
+  // We consume the start element.
   reader.Read();
 
   if (reader.node().kind() == NodeKind::Error) {
@@ -2241,7 +2246,9 @@ std::pair<
 
   if (error.has_value()) {
     error->path.segments.emplace_front(
-      common::make_unique<ElementSegment>(L"v")
+      common::make_unique<ElementSegment>(
+        common::Utf8ToWstring(expected_name)
+      )
     );
 
     return NoInstanceAndDeserializationError<T>(
@@ -2252,7 +2259,9 @@ std::pair<
   if (reader.node().kind() != NodeKind::Stop) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a closing element </v> closing a value, but got ",
+        L"Expected a closing element </",
+        common::Utf8ToWstring(expected_name),
+        L"> closing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
@@ -2265,17 +2274,19 @@ std::pair<
   );
 
 
-  if (stop_name != "v") {
+  if (stop_name != expected_name) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a stop element </v> closing a value, but got ",
+        L"Expected a closing element </",
+        common::Utf8ToWstring(expected_name),
+        L"> closing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
   }
 
   // NOTE (mristin):
-  // We consume the </v>.
+  // We consume the closing element.
   reader.Read();
 
   if (reader.node().kind() == NodeKind::Error) {
@@ -2514,7 +2525,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeNames:
+      case properties::OfSomething::kSomeNames: {
         std::tie(
           the_some_names,
           error
@@ -2527,11 +2538,13 @@ std::pair<
               std::wstring
             >(
               a_reader,
-              DeserializeWstring
+              DeserializeWstring,
+              "v"
             );
           }
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3567,6 +3580,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * Serialize a list of items enclosed in <v> elements.
  */
 template <typename T, typename SerializeT>
@@ -3660,38 +3709,19 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someNames"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfVElements(
+  error = SerializePropertyAsElement(
+    "someNames",
     that.some_names(),
     writer,
-    SerializeWstring
+    iteration::Property::kSomeNames,
+    [](
+      const std::vector<std::wstring>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfVElements(a_list, a_writer, SerializeWstring);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeNames
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someNames"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeNames
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/list_of_enums/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_enums/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -864,6 +863,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -903,6 +911,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -1007,14 +1024,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/list_of_enums/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_enums/expected_output/src/xmlization.cpp
@@ -2189,7 +2189,8 @@ std::pair<
   common::optional<DeserializationError>
 > DeserializeValueFromVElement(
   ReaderMergingText& reader,
-  const DeserializeT& deserialize_content
+  const DeserializeT& deserialize_content,
+  const std::string& expected_name
 ) {
   #ifdef DEBUG
   if (reader.node().kind() == NodeKind::Error) {
@@ -2203,7 +2204,9 @@ std::pair<
   if (reader.node().kind() != NodeKind::Start) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a start element <v> enclosing a value, but got ",
+        L"Expected a start element <",
+        common::Utf8ToWstring(expected_name),
+        L"> enclosing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
@@ -2215,17 +2218,19 @@ std::pair<
     >(reader.node()).name
   );
 
-  if (start_name != "v") {
+  if (start_name != expected_name) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a start element <v> enclosing a value, but got ",
+        L"Expected a start element <",
+        common::Utf8ToWstring(expected_name),
+        L"> enclosing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
   }
 
   // NOTE (mristin):
-  // We consume the <v>.
+  // We consume the start element.
   reader.Read();
 
   if (reader.node().kind() == NodeKind::Error) {
@@ -2241,7 +2246,9 @@ std::pair<
 
   if (error.has_value()) {
     error->path.segments.emplace_front(
-      common::make_unique<ElementSegment>(L"v")
+      common::make_unique<ElementSegment>(
+        common::Utf8ToWstring(expected_name)
+      )
     );
 
     return NoInstanceAndDeserializationError<T>(
@@ -2252,7 +2259,9 @@ std::pair<
   if (reader.node().kind() != NodeKind::Stop) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a closing element </v> closing a value, but got ",
+        L"Expected a closing element </",
+        common::Utf8ToWstring(expected_name),
+        L"> closing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
@@ -2265,17 +2274,19 @@ std::pair<
   );
 
 
-  if (stop_name != "v") {
+  if (stop_name != expected_name) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a stop element </v> closing a value, but got ",
+        L"Expected a closing element </",
+        common::Utf8ToWstring(expected_name),
+        L"> closing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
   }
 
   // NOTE (mristin):
-  // We consume the </v>.
+  // We consume the closing element.
   reader.Read();
 
   if (reader.node().kind() == NodeKind::Error) {
@@ -2568,7 +2579,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeResults:
+      case properties::OfSomething::kSomeResults: {
         std::tie(
           the_some_results,
           error
@@ -2581,11 +2592,13 @@ std::pair<
               types::Result
             >(
               a_reader,
-              DeserializeResult
+              DeserializeResult,
+              "v"
             );
           }
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3621,6 +3634,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * Serialize a list of items enclosed in <v> elements.
  */
 template <typename T, typename SerializeT>
@@ -3734,38 +3783,19 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someResults"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfVElements(
+  error = SerializePropertyAsElement(
+    "someResults",
     that.some_results(),
     writer,
-    SerializeResult
+    iteration::Property::kSomeResults,
+    [](
+      const std::vector<types::Result>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfVElements(a_list, a_writer, SerializeResult);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeResults
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someResults"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeResults
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/list_of_primitives/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_primitives/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -984,6 +983,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -1023,6 +1031,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -1129,14 +1146,6 @@ nlohmann::json SerializeListWithInfallible(
   return serialized;
 }
 
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
-}
-
 std::pair<
   common::optional<nlohmann::json>,
   common::optional<SerializationError>
@@ -1163,7 +1172,7 @@ std::pair<
 
   result["someBools"] = SerializeListWithInfallible(
     that.some_bools(),
-    Identity<bool>
+    SerializeBool
   );
 
   common::optional<nlohmann::json> json_some_ints;
@@ -1196,7 +1205,7 @@ std::pair<
 
   result["someFloats"] = SerializeListWithInfallible(
     that.some_floats(),
-    Identity<double>
+    SerializeDouble
   );
 
   result["someStrings"] = SerializeListWithInfallible(

--- a/dev/test_data/main/cpp/expected/list_of_primitives/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/list_of_primitives/expected_output/src/xmlization.cpp
@@ -2189,7 +2189,8 @@ std::pair<
   common::optional<DeserializationError>
 > DeserializeValueFromVElement(
   ReaderMergingText& reader,
-  const DeserializeT& deserialize_content
+  const DeserializeT& deserialize_content,
+  const std::string& expected_name
 ) {
   #ifdef DEBUG
   if (reader.node().kind() == NodeKind::Error) {
@@ -2203,7 +2204,9 @@ std::pair<
   if (reader.node().kind() != NodeKind::Start) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a start element <v> enclosing a value, but got ",
+        L"Expected a start element <",
+        common::Utf8ToWstring(expected_name),
+        L"> enclosing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
@@ -2215,17 +2218,19 @@ std::pair<
     >(reader.node()).name
   );
 
-  if (start_name != "v") {
+  if (start_name != expected_name) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a start element <v> enclosing a value, but got ",
+        L"Expected a start element <",
+        common::Utf8ToWstring(expected_name),
+        L"> enclosing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
   }
 
   // NOTE (mristin):
-  // We consume the <v>.
+  // We consume the start element.
   reader.Read();
 
   if (reader.node().kind() == NodeKind::Error) {
@@ -2241,7 +2246,9 @@ std::pair<
 
   if (error.has_value()) {
     error->path.segments.emplace_front(
-      common::make_unique<ElementSegment>(L"v")
+      common::make_unique<ElementSegment>(
+        common::Utf8ToWstring(expected_name)
+      )
     );
 
     return NoInstanceAndDeserializationError<T>(
@@ -2252,7 +2259,9 @@ std::pair<
   if (reader.node().kind() != NodeKind::Stop) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a closing element </v> closing a value, but got ",
+        L"Expected a closing element </",
+        common::Utf8ToWstring(expected_name),
+        L"> closing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
@@ -2265,17 +2274,19 @@ std::pair<
   );
 
 
-  if (stop_name != "v") {
+  if (stop_name != expected_name) {
     return NoInstanceAndDeserializationErrorWithCause<T>(
       common::Concat(
-        L"Expected a stop element </v> closing a value, but got ",
+        L"Expected a closing element </",
+        common::Utf8ToWstring(expected_name),
+        L"> closing a value, but got ",
         NodeToHumanReadableWstring(reader.node())
       )
     );
   }
 
   // NOTE (mristin):
-  // We consume the </v>.
+  // We consume the closing element.
   reader.Read();
 
   if (reader.node().kind() == NodeKind::Error) {
@@ -2546,7 +2557,7 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeBools:
+      case properties::OfSomething::kSomeBools: {
         std::tie(
           the_some_bools,
           error
@@ -2559,12 +2570,14 @@ std::pair<
               bool
             >(
               a_reader,
-              DeserializeBool
+              DeserializeBool,
+              "v"
             );
           }
         );
         break;
-      case properties::OfSomething::kSomeInts:
+      }
+      case properties::OfSomething::kSomeInts: {
         std::tie(
           the_some_ints,
           error
@@ -2577,12 +2590,14 @@ std::pair<
               int64_t
             >(
               a_reader,
-              DeserializeInt64
+              DeserializeInt64,
+              "v"
             );
           }
         );
         break;
-      case properties::OfSomething::kSomeFloats:
+      }
+      case properties::OfSomething::kSomeFloats: {
         std::tie(
           the_some_floats,
           error
@@ -2595,12 +2610,14 @@ std::pair<
               double
             >(
               a_reader,
-              DeserializeDouble
+              DeserializeDouble,
+              "v"
             );
           }
         );
         break;
-      case properties::OfSomething::kSomeStrings:
+      }
+      case properties::OfSomething::kSomeStrings: {
         std::tie(
           the_some_strings,
           error
@@ -2613,12 +2630,14 @@ std::pair<
               std::wstring
             >(
               a_reader,
-              DeserializeWstring
+              DeserializeWstring,
+              "v"
             );
           }
         );
         break;
-      case properties::OfSomething::kSomeBytes:
+      }
+      case properties::OfSomething::kSomeBytes: {
         std::tie(
           the_some_bytes,
           error
@@ -2631,11 +2650,13 @@ std::pair<
               std::vector<std::uint8_t>
             >(
               a_reader,
-              DeserializeByteArray
+              DeserializeByteArray,
+              "v"
             );
           }
         );
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3707,6 +3728,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * Serialize a list of items enclosed in <v> elements.
  */
 template <typename T, typename SerializeT>
@@ -3800,178 +3857,83 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someBools"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfVElements(
+  error = SerializePropertyAsElement(
+    "someBools",
     that.some_bools(),
     writer,
-    SerializeBool
+    iteration::Property::kSomeBools,
+    [](
+      const std::vector<bool>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfVElements(a_list, a_writer, SerializeBool);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBools
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someBools"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBools
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someInts"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfVElements(
+  error = SerializePropertyAsElement(
+    "someInts",
     that.some_ints(),
     writer,
-    SerializeInt64
+    iteration::Property::kSomeInts,
+    [](
+      const std::vector<int64_t>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfVElements(a_list, a_writer, SerializeInt64);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeInts
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someInts"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeInts
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someFloats"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfVElements(
+  error = SerializePropertyAsElement(
+    "someFloats",
     that.some_floats(),
     writer,
-    SerializeDouble
+    iteration::Property::kSomeFloats,
+    [](
+      const std::vector<double>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfVElements(a_list, a_writer, SerializeDouble);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeFloats
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someFloats"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeFloats
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someStrings"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfVElements(
+  error = SerializePropertyAsElement(
+    "someStrings",
     that.some_strings(),
     writer,
-    SerializeWstring
+    iteration::Property::kSomeStrings,
+    [](
+      const std::vector<std::wstring>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfVElements(a_list, a_writer, SerializeWstring);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeStrings
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someStrings"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeStrings
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someBytes"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeListOfVElements(
+  error = SerializePropertyAsElement(
+    "someBytes",
     that.some_bytes(),
     writer,
-    SerializeByteArray
+    iteration::Property::kSomeBytes,
+    [](
+      const std::vector<std::vector<std::uint8_t>>& a_list,
+      SelfClosingWriter& a_writer
+    ) {
+      return SerializeListOfVElements(a_list, a_writer, SerializeByteArray);
+    }
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBytes
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someBytes"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBytes
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/primitive_types/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/primitive_types/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -907,6 +906,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -946,6 +954,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -1052,14 +1069,6 @@ nlohmann::json SerializeListWithInfallible(
   return serialized;
 }
 
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
-}
-
 std::pair<
   common::optional<nlohmann::json>,
   common::optional<SerializationError>
@@ -1084,7 +1093,9 @@ std::pair<
 
   common::optional<SerializationError> error;
 
-  result["someBool"] = that.some_bool();
+  result["someBool"] = SerializeBool(
+    that.some_bool()
+  );
 
   common::optional<nlohmann::json> json_some_int;
   std::tie(
@@ -1113,7 +1124,9 @@ std::pair<
     json_some_int.value()
   );
 
-  result["someFloat"] = that.some_float();
+  result["someFloat"] = SerializeDouble(
+    that.some_float()
+  );
 
   result["someString"] = SerializeWstring(
     that.some_string()

--- a/dev/test_data/main/cpp/expected/primitive_types/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/primitive_types/expected_output/src/xmlization.cpp
@@ -2342,36 +2342,41 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kSomeBool:
+      case properties::OfSomething::kSomeBool: {
         std::tie(
           the_some_bool,
           error
         ) = DeserializeBool(reader);
         break;
-      case properties::OfSomething::kSomeInt:
+      }
+      case properties::OfSomething::kSomeInt: {
         std::tie(
           the_some_int,
           error
         ) = DeserializeInt64(reader);
         break;
-      case properties::OfSomething::kSomeFloat:
+      }
+      case properties::OfSomething::kSomeFloat: {
         std::tie(
           the_some_float,
           error
         ) = DeserializeDouble(reader);
         break;
-      case properties::OfSomething::kSomeString:
+      }
+      case properties::OfSomething::kSomeString: {
         std::tie(
           the_some_string,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSomething::kSomeBytes:
+      }
+      case properties::OfSomething::kSomeBytes: {
         std::tie(
           the_some_bytes,
           error
         ) = DeserializeByteArray(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3443,6 +3448,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * \brief Serialize \p that instance as a sequence of XML elements.
  *
  * Each XML element corresponds to a property.
@@ -3489,173 +3530,58 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "someBool"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeBool(
+  error = SerializePropertyAsElement(
+    "someBool",
     that.some_bool(),
-    writer
+    writer,
+    iteration::Property::kSomeBool,
+    SerializeBool
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBool
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someBool"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBool
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someInt"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeInt64(
+  error = SerializePropertyAsElement(
+    "someInt",
     that.some_int(),
-    writer
+    writer,
+    iteration::Property::kSomeInt,
+    SerializeInt64
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeInt
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someInt"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeInt
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someFloat"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeDouble(
+  error = SerializePropertyAsElement(
+    "someFloat",
     that.some_float(),
-    writer
+    writer,
+    iteration::Property::kSomeFloat,
+    SerializeDouble
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeFloat
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someFloat"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeFloat
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someString"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "someString",
     that.some_string(),
-    writer
+    writer,
+    iteration::Property::kSomeString,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeString
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someString"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeString
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "someBytes"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeByteArray(
+  error = SerializePropertyAsElement(
+    "someBytes",
     that.some_bytes(),
-    writer
+    writer,
+    iteration::Property::kSomeBytes,
+    SerializeByteArray
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBytes
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "someBytes"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kSomeBytes
-      )
-    );
-
     return error;
   }
 

--- a/dev/test_data/main/cpp/expected/problematic_keywords/expected_output/src/jsonization.cpp
+++ b/dev/test_data/main/cpp/expected/problematic_keywords/expected_output/src/jsonization.cpp
@@ -6,10 +6,9 @@
 #include "dummy/wstringification.hpp"
 
 #pragma warning(push, 0)
-#include <functional>
-#include <map>
 #include <set>
 #include <sstream>
+#include <unordered_map>
 #pragma warning(pop)
 
 namespace dummy {
@@ -864,6 +863,15 @@ const iteration::Path& SerializationException::path() const noexcept {
 // endregion SerializationException
 
 /**
+ * Serialize the given boolean to a JSON value.
+ */
+nlohmann::json SerializeBool(
+  bool value
+) {
+  return value;
+}
+
+/**
  * \brief Serialize the given number to a JSON value.
  *
  * We verify that the integer is within the range representable by 64-bit floats
@@ -903,6 +911,15 @@ std::pair<
     common::make_optional<nlohmann::json>(value),
     common::nullopt
   );
+}
+
+/**
+ * Serialize the given floating-point number to a JSON value.
+ */
+nlohmann::json SerializeDouble(
+  double value
+) {
+  return value;
 }
 
 /**
@@ -1007,14 +1024,6 @@ nlohmann::json SerializeListWithInfallible(
   }
 
   return serialized;
-}
-
-/**
- * Just forward the value as it is.
- */
-template<typename T>
-const T& Identity(const T& value) {
-  return value;
 }
 
 std::pair<

--- a/dev/test_data/main/cpp/expected/problematic_keywords/expected_output/src/xmlization.cpp
+++ b/dev/test_data/main/cpp/expected/problematic_keywords/expected_output/src/xmlization.cpp
@@ -2335,30 +2335,34 @@ std::pair<
     );
 
     switch (property) {
-      case properties::OfSomething::kInterface:
+      case properties::OfSomething::kInterface: {
         std::tie(
           the_interface,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSomething::kType:
+      }
+      case properties::OfSomething::kType: {
         std::tie(
           the_type,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSomething::kRange:
+      }
+      case properties::OfSomething::kRange: {
         std::tie(
           the_range,
           error
         ) = DeserializeWstring(reader);
         break;
-      case properties::OfSomething::kVoid:
+      }
+      case properties::OfSomething::kVoid: {
         std::tie(
           the_void,
           error
         ) = DeserializeWstring(reader);
         break;
+      }
       default:
         throw std::logic_error(
           common::Concat(
@@ -3421,6 +3425,42 @@ common::optional<SerializationError> SerializeByteArray(
 }
 
 /**
+ * Serialize a property wrapped in its own named XML element.
+ */
+template <typename T, typename SerializeT>
+common::optional<SerializationError> SerializePropertyAsElement(
+  const std::string& name,
+  const T& value,
+  SelfClosingWriter& writer,
+  iteration::Property property,
+  const SerializeT& serialize_value
+) {
+  writer.StartElement(name);
+  if (writer.error().has_value()) {
+    return writer.move_error();
+  }
+
+  common::optional<SerializationError> error = serialize_value(value, writer);
+  if (error.has_value()) {
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  writer.StopElement(name);
+  if (writer.error().has_value()) {
+    error = writer.move_error();
+    error->path.segments.emplace_front(
+      common::make_unique<iteration::PropertySegment>(property)
+    );
+    return error;
+  }
+
+  return common::nullopt;
+}
+
+/**
  * \brief Serialize \p that instance as a sequence of XML elements.
  *
  * Each XML element corresponds to a property.
@@ -3467,139 +3507,47 @@ common::optional<SerializationError> SerializeSomethingAsSequence(
 ) {
   common::optional<SerializationError> error;
 
-  writer.StartElement(
-    "interface"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "interface",
     that.interface(),
-    writer
+    writer,
+    iteration::Property::kInterface,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kInterface
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "interface"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kInterface
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "type",
     that.type(),
-    writer
+    writer,
+    iteration::Property::kType,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "type"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kType
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "range"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "range",
     that.range(),
-    writer
+    writer,
+    iteration::Property::kRange,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kRange
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "range"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kRange
-      )
-    );
-
     return error;
   }
 
-  writer.StartElement(
-    "void"
-  );
-  if (writer.error().has_value()) {
-    return writer.move_error();
-  }
-  error = SerializeWstring(
+  error = SerializePropertyAsElement(
+    "void",
     that.voiD(),
-    writer
+    writer,
+    iteration::Property::kVoid,
+    SerializeWstring
   );
   if (error.has_value()) {
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kVoid
-      )
-    );
-
-    return error;
-  }
-  writer.StopElement(
-    "void"
-  );
-  if (writer.error().has_value()) {
-    error = writer.move_error();
-
-    error->path.segments.emplace_front(
-      common::make_unique<iteration::PropertySegment>(
-        iteration::Property::kVoid
-      )
-    );
-
     return error;
   }
 


### PR DESCRIPTION
We factor out a generic ``SerializePropertyAsElement`` helper for XML serialization, and switch JSON's model-type dispatch from a ``std::map<string, std::function>`` to a string->enum lookup plus a per-interface switch, mirroring XML's existing dispatch.