### PR TITLE
Simplify JSON and XML de/serialization in C#

### DIFF
--- a/aas_core_codegen/csharp/lib/_generate_jsonization.py
+++ b/aas_core_codegen/csharp/lib/_generate_jsonization.py
@@ -226,6 +226,144 @@ def _parse_method_for_atomic_value(
     return Stripped(parse_method)
 
 
+def _generate_parse_array_of_class_helper() -> Stripped:
+    """Generate the generic helper to de-serialize an array of reference-type items."""
+    return Stripped(
+        f"""\
+/// <summary>
+/// Read a single array item.
+/// </summary>
+/// <typeparam name="T">Type of the parsed item</typeparam>
+private delegate T? JsonClassItemDeserializer<T>(
+{I}Nodes.JsonNode node,
+{I}out Reporting.Error? error
+{I}) where T : class;
+
+/// <summary>
+/// Parse every item of <paramref name="array" /> with
+/// <paramref name="deserializeItem" />.
+/// </summary>
+/// <remarks>
+/// This is shared by all the list-typed constructor arguments whose items are
+/// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+/// or a class instance).
+/// </remarks>
+/// <typeparam name="T">Type of a single array item</typeparam>
+private static List<T> ParseArrayOfClass<T>(
+{I}Nodes.JsonArray array,
+{I}JsonClassItemDeserializer<T> deserializeItem,
+{I}out Reporting.Error? error
+{I}) where T : class
+{{
+{I}error = null;
+{I}List<T> result = new List<T>(array.Count);
+
+{I}int index = 0;
+{I}foreach (Nodes.JsonNode? item in array)
+{I}{{
+{II}if (item == null)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}"Expected a non-null item, but got a null");
+{III}error.PrependSegment(
+{IIII}new Reporting.IndexSegment(
+{IIIII}index));
+{III}return result;
+{II}}}
+
+{II}T? parsedItem = deserializeItem(
+{III}item ?? throw new System.InvalidOperationException(),
+{III}out error);
+{II}if (error != null)
+{II}{{
+{III}error.PrependSegment(
+{IIII}new Reporting.IndexSegment(
+{IIIII}index));
+{III}return result;
+{II}}}
+
+{II}result.Add(
+{III}parsedItem
+{IIII}?? throw new System.InvalidOperationException(
+{IIIII}"Unexpected result null when error is null"));
+
+{II}index++;
+{I}}}
+
+{I}return result;
+}}"""
+    )
+
+
+def _generate_parse_array_of_struct_helper() -> Stripped:
+    """Generate the generic helper to de-serialize an array of value-type items."""
+    return Stripped(
+        f"""\
+/// <summary>
+/// Read a single array item.
+/// </summary>
+/// <typeparam name="T">Type of the parsed item</typeparam>
+private delegate T? JsonStructItemDeserializer<T>(
+{I}Nodes.JsonNode node,
+{I}out Reporting.Error? error
+{I}) where T : struct;
+
+/// <summary>
+/// Parse every item of <paramref name="array" /> with
+/// <paramref name="deserializeItem" />.
+/// </summary>
+/// <remarks>
+/// This is shared by all the list-typed constructor arguments whose items are
+/// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+/// an enumeration literal).
+/// </remarks>
+/// <typeparam name="T">Type of a single array item</typeparam>
+private static List<T> ParseArrayOfStruct<T>(
+{I}Nodes.JsonArray array,
+{I}JsonStructItemDeserializer<T> deserializeItem,
+{I}out Reporting.Error? error
+{I}) where T : struct
+{{
+{I}error = null;
+{I}List<T> result = new List<T>(array.Count);
+
+{I}int index = 0;
+{I}foreach (Nodes.JsonNode? item in array)
+{I}{{
+{II}if (item == null)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}"Expected a non-null item, but got a null");
+{III}error.PrependSegment(
+{IIII}new Reporting.IndexSegment(
+{IIIII}index));
+{III}return result;
+{II}}}
+
+{II}T? parsedItem = deserializeItem(
+{III}item ?? throw new System.InvalidOperationException(),
+{III}out error);
+{II}if (error != null)
+{II}{{
+{III}error.PrependSegment(
+{IIII}new Reporting.IndexSegment(
+{IIIII}index));
+{III}return result;
+{II}}}
+
+{II}result.Add(
+{III}parsedItem
+{IIII}?? throw new System.InvalidOperationException(
+{IIIII}"Unexpected result null when error is null"));
+
+{II}index++;
+{I}}}
+
+{I}return result;
+}}"""
+    )
+
+
 @ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate_deserialize_constructor_argument(
     arg: intermediate.Argument,
@@ -281,9 +419,24 @@ if ({target_var} == null)
         item_type = csharp_common.generate_type(type_anno.items)
 
         array_var = csharp_naming.variable_name(Identifier(f"array_{arg.name}"))
-        index_var = csharp_naming.variable_name(Identifier(f"index_{arg.name}"))
 
         parse_method = _parse_method_for_atomic_value(type_anno.items)
+
+        primitive_type = intermediate.try_primitive_type(type_anno.items)
+        if primitive_type is not None:
+            is_value_type = primitive_type in (
+                intermediate.PrimitiveType.BOOL,
+                intermediate.PrimitiveType.INT,
+                intermediate.PrimitiveType.FLOAT,
+            )
+        else:
+            is_value_type = isinstance(
+                type_anno.items, intermediate.OurTypeAnnotation
+            ) and isinstance(type_anno.items.our_type, intermediate.Enumeration)
+
+        parse_array_function = (
+            "ParseArrayOfStruct" if is_value_type else "ParseArrayOfClass"
+        )
 
         parse_block = Stripped(
             f"""\
@@ -297,41 +450,16 @@ if ({array_var} == null)
 {III}{json_literal}));
 {I}return null;
 }}
-{target_var} = new List<{item_type}>(
-{I}{array_var}.Count);
-int {index_var} = 0;
-foreach (Nodes.JsonNode? item in {array_var})
+{target_var} = {parse_array_function}<{item_type}>(
+{I}{array_var},
+{I}{parse_method},
+{I}out error);
+if (error != null)
 {{
-{I}if (item == null)
-{I}{{
-{II}error = new Reporting.Error(
-{III}"Expected a non-null item, but got a null");
-{II}error.PrependSegment(
-{III}new Reporting.IndexSegment(
-{IIII}{index_var}));
-{II}error.PrependSegment(
-{III}new Reporting.NameSegment(
-{IIII}{json_literal}));
-{II}return null;
-{I}}}
-{I}{item_type}? parsedItem = {parse_method}(
-{II}item ?? throw new System.InvalidOperationException(),
-{II}out error);
-{I}if (error != null)
-{I}{{
-{II}error.PrependSegment(
-{III}new Reporting.IndexSegment(
-{IIII}{index_var}));
-{II}error.PrependSegment(
-{III}new Reporting.NameSegment(
-{IIII}{json_literal}));
-{II}return null;
-{I}}}
-{I}{target_var}.Add(
-{II}parsedItem
-{III}?? throw new System.InvalidOperationException(
-{IIII}"Unexpected result null when error is null"));
-{I}{index_var}++;
+{I}error.PrependSegment(
+{II}new Reporting.NameSegment(
+{III}{json_literal}));
+{I}return null;
 }}"""
         )
     else:
@@ -849,6 +977,8 @@ internal static byte[]? BytesFrom(
 {I}}}
 }}"""
         ),
+        _generate_parse_array_of_class_helper(),
+        _generate_parse_array_of_struct_helper(),
     ]  # type: List[Stripped]
 
     for our_type in symbol_table.our_types:
@@ -1200,12 +1330,10 @@ def _generate_transform_property(
         stmts.append(
             Stripped(
                 f"""\
-var {array_var} = new Nodes.JsonArray();
-foreach ({item_type} item in {source_expr})
-{{
-{I}{array_var}.Add(
+Nodes.JsonArray {array_var} = SerializeArray(
+{I}{source_expr},
+{I}({item_type} item) =>
 {II}{indent_but_first_line(item_conversion_expr, II)});
-}}
 result[{prop_literal}] = {array_var};"""
             )
         )
@@ -1336,6 +1464,29 @@ private static Nodes.JsonValue ToJsonValue(long that)
 {III}$"The number can not be losslessly represented in JSON: {{that}}");
 {I}}}
 {I}return Nodes.JsonValue.Create(that);
+}}"""
+        ),
+        Stripped(
+            f"""\
+/// <summary>
+/// Serialize every item of <paramref name="items" /> with
+/// <paramref name="serializeItem" /> into a JSON array.
+/// </summary>
+/// <remarks>
+/// This is shared by all the list-typed properties.
+/// </remarks>
+/// <typeparam name="T">Type of a single list item</typeparam>
+private static Nodes.JsonArray SerializeArray<T>(
+{I}IEnumerable<T> items,
+{I}System.Func<T, Nodes.JsonNode?> serializeItem)
+{{
+{I}var result = new Nodes.JsonArray();
+{I}foreach (T item in items)
+{I}{{
+{II}result.Add(
+{III}serializeItem(item));
+{I}}}
+{I}return result;
 }}"""
         ),
     ]  # type: List[Stripped]

--- a/aas_core_codegen/csharp/lib/_generate_xmlization.py
+++ b/aas_core_codegen/csharp/lib/_generate_xmlization.py
@@ -1888,6 +1888,40 @@ public static class Deserialize
     return Stripped(writer.getvalue())
 
 
+def _generate_serialize_element_helper() -> Stripped:
+    """Generate the generic helper to write a property as a named XML element."""
+    return Stripped(
+        f"""\
+/// <summary>
+/// Write the content of a property, positioned between its start and end tag.
+/// </summary>
+/// <typeparam name="T">Type of the property value</typeparam>
+private delegate void ElementContentSerializer<T>(
+{I}T that, Xml.XmlWriter writer);
+
+/// <summary>
+/// Serialize <paramref name="that" /> as an XML element with
+/// the given <paramref name="name" />, delegating the content in-between the
+/// start and the end tag to <paramref name="serializeContent" />.
+/// </summary>
+/// <remarks>
+/// This is shared by all the property kinds (primitive, enumeration, class,
+/// interface, list) as they all wrap their content in exactly the same way.
+/// </remarks>
+/// <typeparam name="T">Type of the property value</typeparam>
+private static void SerializeElement<T>(
+{I}string name,
+{I}T that,
+{I}Xml.XmlWriter writer,
+{I}ElementContentSerializer<T> serializeContent)
+{{
+{I}writer.WriteStartElement(name, NS);
+{I}serializeContent(that, writer);
+{I}writer.WriteEndElement();
+}}"""
+    )
+
+
 def _generate_serialize_primitive_property_as_content(
     prop: intermediate.Property,
 ) -> Stripped:
@@ -1902,7 +1936,7 @@ def _generate_serialize_primitive_property_as_content(
     prop_name = csharp_naming.property_name(prop.name)
     xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
 
-    write_value_block: Stripped
+    content_serializer: Stripped
 
     if (
         a_type is intermediate.PrimitiveType.BOOL
@@ -1910,34 +1944,13 @@ def _generate_serialize_primitive_property_as_content(
         or a_type is intermediate.PrimitiveType.FLOAT
         or a_type is intermediate.PrimitiveType.STR
     ):
-        write_value_block = Stripped(
-            f"""\
-writer.WriteValue(
-{I}that.{prop_name});"""
-        )
+        content_serializer = Stripped("(value, w) => w.WriteValue(value)")
     elif a_type is intermediate.PrimitiveType.BYTEARRAY:
-        write_value_block = Stripped(
-            f"""\
-writer.WriteBase64(
-{I}that.{prop_name},
-{I}0,
-{I}that.{prop_name}.Length);"""
+        content_serializer = Stripped(
+            "(value, w) => w.WriteBase64(value, 0, value.Length)"
         )
     else:
         assert_never(a_type)
-
-    # NOTE (mristin, 2022-06-21):
-    # Wrap the write_value_block with property even if we discard it below
-    write_value_block = Stripped(
-        f"""\
-writer.WriteStartElement(
-{I}{xml_prop_name_literal},
-{I}NS);
-
-{write_value_block}
-
-writer.WriteEndElement();"""
-    )
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
         if a_type in (
@@ -1945,30 +1958,38 @@ writer.WriteEndElement();"""
             intermediate.PrimitiveType.INT,
             intermediate.PrimitiveType.FLOAT,
         ):
-            write_value_block = Stripped(
+            return Stripped(
                 f"""\
 if (that.{prop_name}.HasValue)
 {{
-{I}writer.WriteStartElement(
+{I}SerializeElement(
 {II}{xml_prop_name_literal},
-{II}NS);
-
-{I}writer.WriteValue(
-{II}that.{prop_name}.Value);
-
-{I}writer.WriteEndElement();
+{II}that.{prop_name}.Value,
+{II}writer,
+{II}{indent_but_first_line(content_serializer, II)});
 }}"""
             )
         else:
-            write_value_block = Stripped(
+            return Stripped(
                 f"""\
 if (that.{prop_name} != null)
 {{
-{I}{indent_but_first_line(write_value_block, I)}
+{I}SerializeElement(
+{II}{xml_prop_name_literal},
+{II}that.{prop_name},
+{II}writer,
+{II}{indent_but_first_line(content_serializer, II)});
 }}"""
             )
 
-    return write_value_block
+    return Stripped(
+        f"""\
+SerializeElement(
+{I}{xml_prop_name_literal},
+{I}that.{prop_name},
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
+    )
 
 
 def _generate_serialize_enumeration_property_as_content(
@@ -1987,34 +2008,38 @@ def _generate_serialize_enumeration_property_as_content(
 
     enum_name = csharp_naming.enum_name(enumeration.name)
 
-    text_var = csharp_naming.variable_name(Identifier(f"text_{prop.name}"))
-    write_value_block = Stripped(
+    content_serializer = Stripped(
         f"""\
-writer.WriteStartElement(
+(value, w) =>
+{{
+{I}string? text = Stringification.ToString(value);
+{I}w.WriteValue(
+{II}text
+{III}?? throw new System.ArgumentException(
+{IIII}"Invalid literal for the enumeration {enum_name}: " +
+{IIII}value.ToString()));
+}}"""
+    )
+
+    result = Stripped(
+        f"""\
+SerializeElement(
 {I}{xml_prop_name_literal},
-{I}NS);
-
-string? {text_var} = Stringification.ToString(
-{I}that.{prop_name});
-writer.WriteValue(
-{I}{text_var}
-{II}?? throw new System.ArgumentException(
-{III}"Invalid literal for the enumeration {enum_name}: " +
-{III}that.{prop_name}.ToString()));
-
-writer.WriteEndElement();"""
+{I}that.{prop_name},
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-        write_value_block = Stripped(
+        result = Stripped(
             f"""\
 if (that.{prop_name} != null)
 {{
-{I}{indent_but_first_line(write_value_block, I)}
+{I}{indent_but_first_line(result, I)}
 }}"""
         )
 
-    return write_value_block
+    return result
 
 
 def _generate_serialize_interface_property_as_content(
@@ -2039,17 +2064,15 @@ def _generate_serialize_interface_property_as_content(
     prop_name = csharp_naming.property_name(prop.name)
     xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
 
+    content_serializer = Stripped("(value, w) => this.Visit(value, w)")
+
     result = Stripped(
         f"""\
-writer.WriteStartElement(
+SerializeElement(
 {I}{xml_prop_name_literal},
-{I}NS);
-
-this.Visit(
 {I}that.{prop_name},
-{I}writer);
-
-writer.WriteEndElement();"""
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
@@ -2079,17 +2102,15 @@ def _generate_serialize_concrete_class_property_as_sequence(
     prop_name = csharp_naming.property_name(prop.name)
     xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
 
+    content_serializer = Stripped(f"(value, w) => this.{cls_to_sequence}(value, w)")
+
     result = Stripped(
         f"""\
-writer.WriteStartElement(
+SerializeElement(
 {I}{xml_prop_name_literal},
-{I}NS);
-
-this.{cls_to_sequence}(
 {I}that.{prop_name},
-{I}writer);
-
-writer.WriteEndElement();"""
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
@@ -2113,7 +2134,7 @@ def _generate_serialize_list_property_as_content(
 
     primitive_type = intermediate.try_primitive_type(type_anno.items)
 
-    body: Stripped
+    item_write_block: Stripped
 
     if primitive_type is not None:
         write_item_statement: Stripped
@@ -2126,21 +2147,21 @@ def _generate_serialize_list_property_as_content(
         ):
             write_item_statement = Stripped(
                 """\
-writer.WriteValue(item);"""
+w.WriteValue(item);"""
             )
         elif primitive_type is intermediate.PrimitiveType.BYTEARRAY:
             write_item_statement = Stripped(
                 """\
-writer.WriteBase64(item, 0, item.Length);"""
+w.WriteBase64(item, 0, item.Length);"""
             )
         else:
             assert_never(primitive_type)
 
-        body = Stripped(
+        item_write_block = Stripped(
             f"""\
-writer.WriteStartElement("v", NS);
+w.WriteStartElement("v", NS);
 {write_item_statement}
-writer.WriteEndElement();"""
+w.WriteEndElement();"""
         )
 
     elif isinstance(type_anno.items, intermediate.OurTypeAnnotation):
@@ -2149,15 +2170,15 @@ writer.WriteEndElement();"""
         if isinstance(our_type, intermediate.Enumeration):
             enum_name = csharp_naming.enum_name(our_type.name)
 
-            body = Stripped(
+            item_write_block = Stripped(
                 f"""\
-writer.WriteStartElement("v", NS);
-writer.WriteValue(
+w.WriteStartElement("v", NS);
+w.WriteValue(
 {I}Stringification.ToString(item)
 {II}?? throw new System.ArgumentException(
 {III}"Invalid literal for the enumeration {enum_name}: " +
 {III}item.ToString()));
-writer.WriteEndElement();"""
+w.WriteEndElement();"""
             )
         elif isinstance(our_type, intermediate.ConstrainedPrimitive):
             raise AssertionError("This case should have been handled before.")
@@ -2165,10 +2186,12 @@ writer.WriteEndElement();"""
         elif isinstance(
             our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
         ):
-            body = Stripped(
+            item_write_block = Stripped(
                 """\
-this.Visit(item, writer);"""
+this.Visit(item, w);"""
             )
+        else:
+            assert_never(our_type)
     else:
         raise NotImplementedError(
             "(mristin) We generate currently only the code for serializing lists of "
@@ -2177,21 +2200,27 @@ this.Visit(item, writer);"""
             f"Please contact the developers if you need this feature."
         )
 
+    content_serializer = Stripped(
+        f"""\
+(value, w) =>
+{{
+{I}foreach (var item in value)
+{I}{{
+{II}{indent_but_first_line(item_write_block, II)}
+{I}}}
+}}"""
+    )
+
     prop_name = csharp_naming.property_name(prop.name)
     xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
 
     result = Stripped(
         f"""\
-writer.WriteStartElement(
+SerializeElement(
 {I}{xml_prop_name_literal},
-{I}NS);
-
-foreach (var item in that.{prop_name})
-{{
-{I}{indent_but_first_line(body, I)}
-}}
-
-writer.WriteEndElement();"""
+{I}that.{prop_name},
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
@@ -2323,7 +2352,7 @@ def _generate_visitor(
     """Generate a visitor which serializes instances of the meta-model to XML."""
     errors = []  # type: List[Error]
 
-    blocks = []  # type: List[Stripped]
+    blocks = [_generate_serialize_element_helper()]  # type: List[Stripped]
 
     # The abstract classes are directly dispatched by the transformer,
     # so we do not need to handle them separately.

--- a/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/jsonization.cs
@@ -200,6 +200,132 @@ namespace AasCore.Aas3_0
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of IHasSemantics by dispatching
             /// based on <c>modelType</c> property of the <paramref name="node" />.
             /// </summary>
@@ -419,41 +545,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -540,41 +641,16 @@ namespace AasCore.Aas3_0
                                         "refersTo"));
                                 return null;
                             }
-                            theRefersTo = new List<IReference>(
-                                arrayRefersTo.Count);
-                            int indexRefersTo = 0;
-                            foreach (Nodes.JsonNode? item in arrayRefersTo)
+                            theRefersTo = ParseArrayOfClass<IReference>(
+                                arrayRefersTo,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexRefersTo));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "refersTo"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexRefersTo));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "refersTo"));
-                                    return null;
-                                }
-                                theRefersTo.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexRefersTo++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "refersTo"));
+                                return null;
                             }
                             break;
                         }
@@ -1123,41 +1199,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -1569,41 +1620,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -1850,41 +1876,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -1971,41 +1972,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -2032,41 +2008,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -2123,41 +2074,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -2214,41 +2140,16 @@ namespace AasCore.Aas3_0
                                         "submodels"));
                                 return null;
                             }
-                            theSubmodels = new List<IReference>(
-                                arraySubmodels.Count);
-                            int indexSubmodels = 0;
-                            foreach (Nodes.JsonNode? item in arraySubmodels)
+                            theSubmodels = ParseArrayOfClass<IReference>(
+                                arraySubmodels,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSubmodels));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "submodels"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSubmodels));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "submodels"));
-                                    return null;
-                                }
-                                theSubmodels.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSubmodels++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "submodels"));
+                                return null;
                             }
                             break;
                         }
@@ -2440,41 +2341,16 @@ namespace AasCore.Aas3_0
                                         "specificAssetIds"));
                                 return null;
                             }
-                            theSpecificAssetIds = new List<ISpecificAssetId>(
-                                arraySpecificAssetIds.Count);
-                            int indexSpecificAssetIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySpecificAssetIds)
+                            theSpecificAssetIds = ParseArrayOfClass<ISpecificAssetId>(
+                                arraySpecificAssetIds,
+                                DeserializeImplementation.SpecificAssetIdFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSpecificAssetIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "specificAssetIds"));
-                                    return null;
-                                }
-                                ISpecificAssetId? parsedItem = DeserializeImplementation.SpecificAssetIdFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSpecificAssetIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "specificAssetIds"));
-                                    return null;
-                                }
-                                theSpecificAssetIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSpecificAssetIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "specificAssetIds"));
+                                return null;
                             }
                             break;
                         }
@@ -2838,41 +2714,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -3030,41 +2881,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -3151,41 +2977,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -3212,41 +3013,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -3363,41 +3139,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -3424,41 +3175,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -3485,41 +3211,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -3546,41 +3247,16 @@ namespace AasCore.Aas3_0
                                         "submodelElements"));
                                 return null;
                             }
-                            theSubmodelElements = new List<ISubmodelElement>(
-                                arraySubmodelElements.Count);
-                            int indexSubmodelElements = 0;
-                            foreach (Nodes.JsonNode? item in arraySubmodelElements)
+                            theSubmodelElements = ParseArrayOfClass<ISubmodelElement>(
+                                arraySubmodelElements,
+                                DeserializeImplementation.ISubmodelElementFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSubmodelElements));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "submodelElements"));
-                                    return null;
-                                }
-                                ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSubmodelElements));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "submodelElements"));
-                                    return null;
-                                }
-                                theSubmodelElements.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSubmodelElements++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "submodelElements"));
+                                return null;
                             }
                             break;
                         }
@@ -3928,41 +3604,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -4049,41 +3700,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -4110,41 +3736,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -4201,41 +3802,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -4262,41 +3838,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -4323,41 +3874,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -4560,41 +4086,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -4681,41 +4182,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -4742,41 +4218,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -4833,41 +4284,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -4894,41 +4320,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -4955,41 +4356,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -5106,41 +4482,16 @@ namespace AasCore.Aas3_0
                                         "value"));
                                 return null;
                             }
-                            theValue = new List<ISubmodelElement>(
-                                arrayValue.Count);
-                            int indexValue = 0;
-                            foreach (Nodes.JsonNode? item in arrayValue)
+                            theValue = ParseArrayOfClass<ISubmodelElement>(
+                                arrayValue,
+                                DeserializeImplementation.ISubmodelElementFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValue));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValue));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                theValue.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexValue++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "value"));
+                                return null;
                             }
                             break;
                         }
@@ -5274,41 +4625,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -5395,41 +4721,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -5456,41 +4757,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -5547,41 +4823,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -5608,41 +4859,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -5669,41 +4895,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -5730,41 +4931,16 @@ namespace AasCore.Aas3_0
                                         "value"));
                                 return null;
                             }
-                            theValue = new List<ISubmodelElement>(
-                                arrayValue.Count);
-                            int indexValue = 0;
-                            foreach (Nodes.JsonNode? item in arrayValue)
+                            theValue = ParseArrayOfClass<ISubmodelElement>(
+                                arrayValue,
+                                DeserializeImplementation.ISubmodelElementFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValue));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValue));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                theValue.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexValue++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "value"));
+                                return null;
                             }
                             break;
                         }
@@ -5990,41 +5166,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -6111,41 +5262,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -6172,41 +5298,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -6263,41 +5364,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -6324,41 +5400,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -6385,41 +5436,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -6612,41 +5638,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -6733,41 +5734,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -6794,41 +5770,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -6885,41 +5836,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -6946,41 +5872,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -7007,41 +5908,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -7068,41 +5944,16 @@ namespace AasCore.Aas3_0
                                         "value"));
                                 return null;
                             }
-                            theValue = new List<ILangStringTextType>(
-                                arrayValue.Count);
-                            int indexValue = 0;
-                            foreach (Nodes.JsonNode? item in arrayValue)
+                            theValue = ParseArrayOfClass<ILangStringTextType>(
+                                arrayValue,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValue));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValue));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                theValue.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexValue++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "value"));
+                                return null;
                             }
                             break;
                         }
@@ -7287,41 +6138,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -7408,41 +6234,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -7469,41 +6270,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -7560,41 +6336,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -7621,41 +6372,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -7682,41 +6408,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -7908,41 +6609,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -8029,41 +6705,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -8090,41 +6741,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -8181,41 +6807,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -8242,41 +6843,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -8303,41 +6879,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -8520,41 +7071,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -8641,41 +7167,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -8702,41 +7203,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -8793,41 +7269,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -8854,41 +7305,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -8915,41 +7341,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -9140,41 +7541,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -9261,41 +7637,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -9322,41 +7673,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -9413,41 +7739,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -9474,41 +7775,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -9535,41 +7811,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -9790,41 +8041,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -9911,41 +8137,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -9972,41 +8173,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -10063,41 +8239,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -10124,41 +8275,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -10185,41 +8311,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -10246,41 +8347,16 @@ namespace AasCore.Aas3_0
                                         "annotations"));
                                 return null;
                             }
-                            theAnnotations = new List<IDataElement>(
-                                arrayAnnotations.Count);
-                            int indexAnnotations = 0;
-                            foreach (Nodes.JsonNode? item in arrayAnnotations)
+                            theAnnotations = ParseArrayOfClass<IDataElement>(
+                                arrayAnnotations,
+                                DeserializeImplementation.IDataElementFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexAnnotations));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "annotations"));
-                                    return null;
-                                }
-                                IDataElement? parsedItem = DeserializeImplementation.IDataElementFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexAnnotations));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "annotations"));
-                                    return null;
-                                }
-                                theAnnotations.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexAnnotations++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "annotations"));
+                                return null;
                             }
                             break;
                         }
@@ -10453,41 +8529,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -10574,41 +8625,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -10635,41 +8661,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -10726,41 +8727,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -10787,41 +8763,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -10848,41 +8799,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -10909,41 +8835,16 @@ namespace AasCore.Aas3_0
                                         "statements"));
                                 return null;
                             }
-                            theStatements = new List<ISubmodelElement>(
-                                arrayStatements.Count);
-                            int indexStatements = 0;
-                            foreach (Nodes.JsonNode? item in arrayStatements)
+                            theStatements = ParseArrayOfClass<ISubmodelElement>(
+                                arrayStatements,
+                                DeserializeImplementation.ISubmodelElementFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexStatements));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "statements"));
-                                    return null;
-                                }
-                                ISubmodelElement? parsedItem = DeserializeImplementation.ISubmodelElementFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexStatements));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "statements"));
-                                    return null;
-                                }
-                                theStatements.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexStatements++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "statements"));
+                                return null;
                             }
                             break;
                         }
@@ -11000,41 +8901,16 @@ namespace AasCore.Aas3_0
                                         "specificAssetIds"));
                                 return null;
                             }
-                            theSpecificAssetIds = new List<ISpecificAssetId>(
-                                arraySpecificAssetIds.Count);
-                            int indexSpecificAssetIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySpecificAssetIds)
+                            theSpecificAssetIds = ParseArrayOfClass<ISpecificAssetId>(
+                                arraySpecificAssetIds,
+                                DeserializeImplementation.SpecificAssetIdFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSpecificAssetIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "specificAssetIds"));
-                                    return null;
-                                }
-                                ISpecificAssetId? parsedItem = DeserializeImplementation.SpecificAssetIdFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSpecificAssetIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "specificAssetIds"));
-                                    return null;
-                                }
-                                theSpecificAssetIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSpecificAssetIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "specificAssetIds"));
+                                return null;
                             }
                             break;
                         }
@@ -11722,41 +9598,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -11843,41 +9694,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -11904,41 +9730,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -11995,41 +9796,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -12056,41 +9832,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -12117,41 +9868,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -12458,41 +10184,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -12579,41 +10280,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -12640,41 +10316,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -12731,41 +10382,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -12792,41 +10418,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -12853,41 +10454,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -12914,41 +10490,16 @@ namespace AasCore.Aas3_0
                                         "inputVariables"));
                                 return null;
                             }
-                            theInputVariables = new List<IOperationVariable>(
-                                arrayInputVariables.Count);
-                            int indexInputVariables = 0;
-                            foreach (Nodes.JsonNode? item in arrayInputVariables)
+                            theInputVariables = ParseArrayOfClass<IOperationVariable>(
+                                arrayInputVariables,
+                                DeserializeImplementation.OperationVariableFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexInputVariables));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "inputVariables"));
-                                    return null;
-                                }
-                                IOperationVariable? parsedItem = DeserializeImplementation.OperationVariableFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexInputVariables));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "inputVariables"));
-                                    return null;
-                                }
-                                theInputVariables.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexInputVariables++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "inputVariables"));
+                                return null;
                             }
                             break;
                         }
@@ -12975,41 +10526,16 @@ namespace AasCore.Aas3_0
                                         "outputVariables"));
                                 return null;
                             }
-                            theOutputVariables = new List<IOperationVariable>(
-                                arrayOutputVariables.Count);
-                            int indexOutputVariables = 0;
-                            foreach (Nodes.JsonNode? item in arrayOutputVariables)
+                            theOutputVariables = ParseArrayOfClass<IOperationVariable>(
+                                arrayOutputVariables,
+                                DeserializeImplementation.OperationVariableFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexOutputVariables));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "outputVariables"));
-                                    return null;
-                                }
-                                IOperationVariable? parsedItem = DeserializeImplementation.OperationVariableFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexOutputVariables));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "outputVariables"));
-                                    return null;
-                                }
-                                theOutputVariables.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexOutputVariables++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "outputVariables"));
+                                return null;
                             }
                             break;
                         }
@@ -13036,41 +10562,16 @@ namespace AasCore.Aas3_0
                                         "inoutputVariables"));
                                 return null;
                             }
-                            theInoutputVariables = new List<IOperationVariable>(
-                                arrayInoutputVariables.Count);
-                            int indexInoutputVariables = 0;
-                            foreach (Nodes.JsonNode? item in arrayInoutputVariables)
+                            theInoutputVariables = ParseArrayOfClass<IOperationVariable>(
+                                arrayInoutputVariables,
+                                DeserializeImplementation.OperationVariableFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexInoutputVariables));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "inoutputVariables"));
-                                    return null;
-                                }
-                                IOperationVariable? parsedItem = DeserializeImplementation.OperationVariableFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexInoutputVariables));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "inoutputVariables"));
-                                    return null;
-                                }
-                                theInoutputVariables.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexInoutputVariables++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "inoutputVariables"));
+                                return null;
                             }
                             break;
                         }
@@ -13268,41 +10769,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -13389,41 +10865,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -13450,41 +10901,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -13541,41 +10967,16 @@ namespace AasCore.Aas3_0
                                         "supplementalSemanticIds"));
                                 return null;
                             }
-                            theSupplementalSemanticIds = new List<IReference>(
-                                arraySupplementalSemanticIds.Count);
-                            int indexSupplementalSemanticIds = 0;
-                            foreach (Nodes.JsonNode? item in arraySupplementalSemanticIds)
+                            theSupplementalSemanticIds = ParseArrayOfClass<IReference>(
+                                arraySupplementalSemanticIds,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSupplementalSemanticIds));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "supplementalSemanticIds"));
-                                    return null;
-                                }
-                                theSupplementalSemanticIds.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSupplementalSemanticIds++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "supplementalSemanticIds"));
+                                return null;
                             }
                             break;
                         }
@@ -13602,41 +11003,16 @@ namespace AasCore.Aas3_0
                                         "qualifiers"));
                                 return null;
                             }
-                            theQualifiers = new List<IQualifier>(
-                                arrayQualifiers.Count);
-                            int indexQualifiers = 0;
-                            foreach (Nodes.JsonNode? item in arrayQualifiers)
+                            theQualifiers = ParseArrayOfClass<IQualifier>(
+                                arrayQualifiers,
+                                DeserializeImplementation.QualifierFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                IQualifier? parsedItem = DeserializeImplementation.QualifierFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexQualifiers));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "qualifiers"));
-                                    return null;
-                                }
-                                theQualifiers.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexQualifiers++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "qualifiers"));
+                                return null;
                             }
                             break;
                         }
@@ -13663,41 +11039,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -13847,41 +11198,16 @@ namespace AasCore.Aas3_0
                                         "extensions"));
                                 return null;
                             }
-                            theExtensions = new List<IExtension>(
-                                arrayExtensions.Count);
-                            int indexExtensions = 0;
-                            foreach (Nodes.JsonNode? item in arrayExtensions)
+                            theExtensions = ParseArrayOfClass<IExtension>(
+                                arrayExtensions,
+                                DeserializeImplementation.ExtensionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                IExtension? parsedItem = DeserializeImplementation.ExtensionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexExtensions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "extensions"));
-                                    return null;
-                                }
-                                theExtensions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexExtensions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "extensions"));
+                                return null;
                             }
                             break;
                         }
@@ -13968,41 +11294,16 @@ namespace AasCore.Aas3_0
                                         "displayName"));
                                 return null;
                             }
-                            theDisplayName = new List<ILangStringNameType>(
-                                arrayDisplayName.Count);
-                            int indexDisplayName = 0;
-                            foreach (Nodes.JsonNode? item in arrayDisplayName)
+                            theDisplayName = ParseArrayOfClass<ILangStringNameType>(
+                                arrayDisplayName,
+                                DeserializeImplementation.LangStringNameTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                ILangStringNameType? parsedItem = DeserializeImplementation.LangStringNameTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDisplayName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "displayName"));
-                                    return null;
-                                }
-                                theDisplayName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDisplayName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "displayName"));
+                                return null;
                             }
                             break;
                         }
@@ -14029,41 +11330,16 @@ namespace AasCore.Aas3_0
                                         "description"));
                                 return null;
                             }
-                            theDescription = new List<ILangStringTextType>(
-                                arrayDescription.Count);
-                            int indexDescription = 0;
-                            foreach (Nodes.JsonNode? item in arrayDescription)
+                            theDescription = ParseArrayOfClass<ILangStringTextType>(
+                                arrayDescription,
+                                DeserializeImplementation.LangStringTextTypeFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                ILangStringTextType? parsedItem = DeserializeImplementation.LangStringTextTypeFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDescription));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "description"));
-                                    return null;
-                                }
-                                theDescription.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDescription++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "description"));
+                                return null;
                             }
                             break;
                         }
@@ -14120,41 +11396,16 @@ namespace AasCore.Aas3_0
                                         "embeddedDataSpecifications"));
                                 return null;
                             }
-                            theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>(
-                                arrayEmbeddedDataSpecifications.Count);
-                            int indexEmbeddedDataSpecifications = 0;
-                            foreach (Nodes.JsonNode? item in arrayEmbeddedDataSpecifications)
+                            theEmbeddedDataSpecifications = ParseArrayOfClass<IEmbeddedDataSpecification>(
+                                arrayEmbeddedDataSpecifications,
+                                DeserializeImplementation.EmbeddedDataSpecificationFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                IEmbeddedDataSpecification? parsedItem = DeserializeImplementation.EmbeddedDataSpecificationFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexEmbeddedDataSpecifications));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "embeddedDataSpecifications"));
-                                    return null;
-                                }
-                                theEmbeddedDataSpecifications.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexEmbeddedDataSpecifications++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "embeddedDataSpecifications"));
+                                return null;
                             }
                             break;
                         }
@@ -14181,41 +11432,16 @@ namespace AasCore.Aas3_0
                                         "isCaseOf"));
                                 return null;
                             }
-                            theIsCaseOf = new List<IReference>(
-                                arrayIsCaseOf.Count);
-                            int indexIsCaseOf = 0;
-                            foreach (Nodes.JsonNode? item in arrayIsCaseOf)
+                            theIsCaseOf = ParseArrayOfClass<IReference>(
+                                arrayIsCaseOf,
+                                DeserializeImplementation.ReferenceFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexIsCaseOf));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "isCaseOf"));
-                                    return null;
-                                }
-                                IReference? parsedItem = DeserializeImplementation.ReferenceFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexIsCaseOf));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "isCaseOf"));
-                                    return null;
-                                }
-                                theIsCaseOf.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexIsCaseOf++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "isCaseOf"));
+                                return null;
                             }
                             break;
                         }
@@ -14393,41 +11619,16 @@ namespace AasCore.Aas3_0
                                         "keys"));
                                 return null;
                             }
-                            theKeys = new List<IKey>(
-                                arrayKeys.Count);
-                            int indexKeys = 0;
-                            foreach (Nodes.JsonNode? item in arrayKeys)
+                            theKeys = ParseArrayOfClass<IKey>(
+                                arrayKeys,
+                                DeserializeImplementation.KeyFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexKeys));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "keys"));
-                                    return null;
-                                }
-                                IKey? parsedItem = DeserializeImplementation.KeyFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexKeys));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "keys"));
-                                    return null;
-                                }
-                                theKeys.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexKeys++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "keys"));
+                                return null;
                             }
                             break;
                         }
@@ -15013,41 +12214,16 @@ namespace AasCore.Aas3_0
                                         "assetAdministrationShells"));
                                 return null;
                             }
-                            theAssetAdministrationShells = new List<IAssetAdministrationShell>(
-                                arrayAssetAdministrationShells.Count);
-                            int indexAssetAdministrationShells = 0;
-                            foreach (Nodes.JsonNode? item in arrayAssetAdministrationShells)
+                            theAssetAdministrationShells = ParseArrayOfClass<IAssetAdministrationShell>(
+                                arrayAssetAdministrationShells,
+                                DeserializeImplementation.AssetAdministrationShellFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexAssetAdministrationShells));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "assetAdministrationShells"));
-                                    return null;
-                                }
-                                IAssetAdministrationShell? parsedItem = DeserializeImplementation.AssetAdministrationShellFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexAssetAdministrationShells));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "assetAdministrationShells"));
-                                    return null;
-                                }
-                                theAssetAdministrationShells.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexAssetAdministrationShells++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "assetAdministrationShells"));
+                                return null;
                             }
                             break;
                         }
@@ -15074,41 +12250,16 @@ namespace AasCore.Aas3_0
                                         "submodels"));
                                 return null;
                             }
-                            theSubmodels = new List<ISubmodel>(
-                                arraySubmodels.Count);
-                            int indexSubmodels = 0;
-                            foreach (Nodes.JsonNode? item in arraySubmodels)
+                            theSubmodels = ParseArrayOfClass<ISubmodel>(
+                                arraySubmodels,
+                                DeserializeImplementation.SubmodelFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSubmodels));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "submodels"));
-                                    return null;
-                                }
-                                ISubmodel? parsedItem = DeserializeImplementation.SubmodelFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSubmodels));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "submodels"));
-                                    return null;
-                                }
-                                theSubmodels.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSubmodels++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "submodels"));
+                                return null;
                             }
                             break;
                         }
@@ -15135,41 +12286,16 @@ namespace AasCore.Aas3_0
                                         "conceptDescriptions"));
                                 return null;
                             }
-                            theConceptDescriptions = new List<IConceptDescription>(
-                                arrayConceptDescriptions.Count);
-                            int indexConceptDescriptions = 0;
-                            foreach (Nodes.JsonNode? item in arrayConceptDescriptions)
+                            theConceptDescriptions = ParseArrayOfClass<IConceptDescription>(
+                                arrayConceptDescriptions,
+                                DeserializeImplementation.ConceptDescriptionFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexConceptDescriptions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "conceptDescriptions"));
-                                    return null;
-                                }
-                                IConceptDescription? parsedItem = DeserializeImplementation.ConceptDescriptionFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexConceptDescriptions));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "conceptDescriptions"));
-                                    return null;
-                                }
-                                theConceptDescriptions.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexConceptDescriptions++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "conceptDescriptions"));
+                                return null;
                             }
                             break;
                         }
@@ -15744,41 +12870,16 @@ namespace AasCore.Aas3_0
                                         "valueReferencePairs"));
                                 return null;
                             }
-                            theValueReferencePairs = new List<IValueReferencePair>(
-                                arrayValueReferencePairs.Count);
-                            int indexValueReferencePairs = 0;
-                            foreach (Nodes.JsonNode? item in arrayValueReferencePairs)
+                            theValueReferencePairs = ParseArrayOfClass<IValueReferencePair>(
+                                arrayValueReferencePairs,
+                                DeserializeImplementation.ValueReferencePairFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValueReferencePairs));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueReferencePairs"));
-                                    return null;
-                                }
-                                IValueReferencePair? parsedItem = DeserializeImplementation.ValueReferencePairFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexValueReferencePairs));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueReferencePairs"));
-                                    return null;
-                                }
-                                theValueReferencePairs.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexValueReferencePairs++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "valueReferencePairs"));
+                                return null;
                             }
                             break;
                         }
@@ -16204,41 +13305,16 @@ namespace AasCore.Aas3_0
                                         "preferredName"));
                                 return null;
                             }
-                            thePreferredName = new List<ILangStringPreferredNameTypeIec61360>(
-                                arrayPreferredName.Count);
-                            int indexPreferredName = 0;
-                            foreach (Nodes.JsonNode? item in arrayPreferredName)
+                            thePreferredName = ParseArrayOfClass<ILangStringPreferredNameTypeIec61360>(
+                                arrayPreferredName,
+                                DeserializeImplementation.LangStringPreferredNameTypeIec61360From,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexPreferredName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "preferredName"));
-                                    return null;
-                                }
-                                ILangStringPreferredNameTypeIec61360? parsedItem = DeserializeImplementation.LangStringPreferredNameTypeIec61360From(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexPreferredName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "preferredName"));
-                                    return null;
-                                }
-                                thePreferredName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexPreferredName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "preferredName"));
+                                return null;
                             }
                             break;
                         }
@@ -16265,41 +13341,16 @@ namespace AasCore.Aas3_0
                                         "shortName"));
                                 return null;
                             }
-                            theShortName = new List<ILangStringShortNameTypeIec61360>(
-                                arrayShortName.Count);
-                            int indexShortName = 0;
-                            foreach (Nodes.JsonNode? item in arrayShortName)
+                            theShortName = ParseArrayOfClass<ILangStringShortNameTypeIec61360>(
+                                arrayShortName,
+                                DeserializeImplementation.LangStringShortNameTypeIec61360From,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexShortName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "shortName"));
-                                    return null;
-                                }
-                                ILangStringShortNameTypeIec61360? parsedItem = DeserializeImplementation.LangStringShortNameTypeIec61360From(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexShortName));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "shortName"));
-                                    return null;
-                                }
-                                theShortName.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexShortName++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "shortName"));
+                                return null;
                             }
                             break;
                         }
@@ -16476,41 +13527,16 @@ namespace AasCore.Aas3_0
                                         "definition"));
                                 return null;
                             }
-                            theDefinition = new List<ILangStringDefinitionTypeIec61360>(
-                                arrayDefinition.Count);
-                            int indexDefinition = 0;
-                            foreach (Nodes.JsonNode? item in arrayDefinition)
+                            theDefinition = ParseArrayOfClass<ILangStringDefinitionTypeIec61360>(
+                                arrayDefinition,
+                                DeserializeImplementation.LangStringDefinitionTypeIec61360From,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDefinition));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "definition"));
-                                    return null;
-                                }
-                                ILangStringDefinitionTypeIec61360? parsedItem = DeserializeImplementation.LangStringDefinitionTypeIec61360From(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexDefinition));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "definition"));
-                                    return null;
-                                }
-                                theDefinition.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexDefinition++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "definition"));
+                                return null;
                             }
                             break;
                         }
@@ -18320,6 +15346,27 @@ namespace AasCore.Aas3_0
                 return Nodes.JsonValue.Create(that);
             }
 
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
+            }
+
             public override Nodes.JsonObject TransformExtension(
                 Aas.IExtension that
             )
@@ -18334,13 +15381,11 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
@@ -18364,13 +15409,11 @@ namespace AasCore.Aas3_0
 
                 if (that.RefersTo != null)
                 {
-                    var arrayRefersTo = new Nodes.JsonArray();
-                    foreach (IReference item in that.RefersTo)
-                    {
-                        arrayRefersTo.Add(
+                    Nodes.JsonArray arrayRefersTo = SerializeArray(
+                        that.RefersTo,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["refersTo"] = arrayRefersTo;
                 }
 
@@ -18385,13 +15428,11 @@ namespace AasCore.Aas3_0
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -18436,13 +15477,11 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
@@ -18484,13 +15523,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -18508,25 +15545,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -18541,13 +15574,11 @@ namespace AasCore.Aas3_0
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -18562,13 +15593,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Submodels != null)
                 {
-                    var arraySubmodels = new Nodes.JsonArray();
-                    foreach (IReference item in that.Submodels)
-                    {
-                        arraySubmodels.Add(
+                    Nodes.JsonArray arraySubmodels = SerializeArray(
+                        that.Submodels,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["submodels"] = arraySubmodels;
                 }
 
@@ -18594,13 +15623,11 @@ namespace AasCore.Aas3_0
 
                 if (that.SpecificAssetIds != null)
                 {
-                    var arraySpecificAssetIds = new Nodes.JsonArray();
-                    foreach (ISpecificAssetId item in that.SpecificAssetIds)
-                    {
-                        arraySpecificAssetIds.Add(
+                    Nodes.JsonArray arraySpecificAssetIds = SerializeArray(
+                        that.SpecificAssetIds,
+                        (ISpecificAssetId item) =>
                             Transform(
                                 item));
-                    }
                     result["specificAssetIds"] = arraySpecificAssetIds;
                 }
 
@@ -18651,13 +15678,11 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
@@ -18684,13 +15709,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -18708,25 +15731,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -18756,49 +15775,41 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.SubmodelElements != null)
                 {
-                    var arraySubmodelElements = new Nodes.JsonArray();
-                    foreach (ISubmodelElement item in that.SubmodelElements)
-                    {
-                        arraySubmodelElements.Add(
+                    Nodes.JsonArray arraySubmodelElements = SerializeArray(
+                        that.SubmodelElements,
+                        (ISubmodelElement item) =>
                             Transform(
                                 item));
-                    }
                     result["submodelElements"] = arraySubmodelElements;
                 }
 
@@ -18815,13 +15826,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -18839,25 +15848,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -18869,37 +15874,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -18922,13 +15921,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -18946,25 +15943,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -18976,37 +15969,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -19036,13 +16023,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Value != null)
                 {
-                    var arrayValue = new Nodes.JsonArray();
-                    foreach (ISubmodelElement item in that.Value)
-                    {
-                        arrayValue.Add(
+                    Nodes.JsonArray arrayValue = SerializeArray(
+                        that.Value,
+                        (ISubmodelElement item) =>
                             Transform(
                                 item));
-                    }
                     result["value"] = arrayValue;
                 }
 
@@ -19059,13 +16044,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19083,25 +16066,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19113,49 +16092,41 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Value != null)
                 {
-                    var arrayValue = new Nodes.JsonArray();
-                    foreach (ISubmodelElement item in that.Value)
-                    {
-                        arrayValue.Add(
+                    Nodes.JsonArray arrayValue = SerializeArray(
+                        that.Value,
+                        (ISubmodelElement item) =>
                             Transform(
                                 item));
-                    }
                     result["value"] = arrayValue;
                 }
 
@@ -19172,13 +16143,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19196,25 +16165,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19226,37 +16191,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -19288,13 +16247,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19312,25 +16269,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19342,49 +16295,41 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Value != null)
                 {
-                    var arrayValue = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Value)
-                    {
-                        arrayValue.Add(
+                    Nodes.JsonArray arrayValue = SerializeArray(
+                        that.Value,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["value"] = arrayValue;
                 }
 
@@ -19407,13 +16352,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19431,25 +16374,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19461,37 +16400,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -19523,13 +16456,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19547,25 +16478,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19577,37 +16504,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -19630,13 +16551,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19654,25 +16573,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19684,37 +16599,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -19741,13 +16650,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19765,25 +16672,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19795,37 +16698,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -19851,13 +16748,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19875,25 +16770,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -19905,37 +16796,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -19947,13 +16832,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Annotations != null)
                 {
-                    var arrayAnnotations = new Nodes.JsonArray();
-                    foreach (IDataElement item in that.Annotations)
-                    {
-                        arrayAnnotations.Add(
+                    Nodes.JsonArray arrayAnnotations = SerializeArray(
+                        that.Annotations,
+                        (IDataElement item) =>
                             Transform(
                                 item));
-                    }
                     result["annotations"] = arrayAnnotations;
                 }
 
@@ -19970,13 +16853,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -19994,25 +16875,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -20024,49 +16901,41 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.Statements != null)
                 {
-                    var arrayStatements = new Nodes.JsonArray();
-                    foreach (ISubmodelElement item in that.Statements)
-                    {
-                        arrayStatements.Add(
+                    Nodes.JsonArray arrayStatements = SerializeArray(
+                        that.Statements,
+                        (ISubmodelElement item) =>
                             Transform(
                                 item));
-                    }
                     result["statements"] = arrayStatements;
                 }
 
@@ -20081,13 +16950,11 @@ namespace AasCore.Aas3_0
 
                 if (that.SpecificAssetIds != null)
                 {
-                    var arraySpecificAssetIds = new Nodes.JsonArray();
-                    foreach (ISpecificAssetId item in that.SpecificAssetIds)
-                    {
-                        arraySpecificAssetIds.Add(
+                    Nodes.JsonArray arraySpecificAssetIds = SerializeArray(
+                        that.SpecificAssetIds,
+                        (ISpecificAssetId item) =>
                             Transform(
                                 item));
-                    }
                     result["specificAssetIds"] = arraySpecificAssetIds;
                 }
 
@@ -20153,13 +17020,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -20177,25 +17042,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -20207,37 +17068,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -20293,13 +17148,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -20317,25 +17170,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -20347,73 +17196,61 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.InputVariables != null)
                 {
-                    var arrayInputVariables = new Nodes.JsonArray();
-                    foreach (IOperationVariable item in that.InputVariables)
-                    {
-                        arrayInputVariables.Add(
+                    Nodes.JsonArray arrayInputVariables = SerializeArray(
+                        that.InputVariables,
+                        (IOperationVariable item) =>
                             Transform(
                                 item));
-                    }
                     result["inputVariables"] = arrayInputVariables;
                 }
 
                 if (that.OutputVariables != null)
                 {
-                    var arrayOutputVariables = new Nodes.JsonArray();
-                    foreach (IOperationVariable item in that.OutputVariables)
-                    {
-                        arrayOutputVariables.Add(
+                    Nodes.JsonArray arrayOutputVariables = SerializeArray(
+                        that.OutputVariables,
+                        (IOperationVariable item) =>
                             Transform(
                                 item));
-                    }
                     result["outputVariables"] = arrayOutputVariables;
                 }
 
                 if (that.InoutputVariables != null)
                 {
-                    var arrayInoutputVariables = new Nodes.JsonArray();
-                    foreach (IOperationVariable item in that.InoutputVariables)
-                    {
-                        arrayInoutputVariables.Add(
+                    Nodes.JsonArray arrayInoutputVariables = SerializeArray(
+                        that.InoutputVariables,
+                        (IOperationVariable item) =>
                             Transform(
                                 item));
-                    }
                     result["inoutputVariables"] = arrayInoutputVariables;
                 }
 
@@ -20442,13 +17279,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -20466,25 +17301,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -20496,37 +17327,31 @@ namespace AasCore.Aas3_0
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    var arraySupplementalSemanticIds = new Nodes.JsonArray();
-                    foreach (IReference item in that.SupplementalSemanticIds)
-                    {
-                        arraySupplementalSemanticIds.Add(
+                    Nodes.JsonArray arraySupplementalSemanticIds = SerializeArray(
+                        that.SupplementalSemanticIds,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["supplementalSemanticIds"] = arraySupplementalSemanticIds;
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    var arrayQualifiers = new Nodes.JsonArray();
-                    foreach (IQualifier item in that.Qualifiers)
-                    {
-                        arrayQualifiers.Add(
+                    Nodes.JsonArray arrayQualifiers = SerializeArray(
+                        that.Qualifiers,
+                        (IQualifier item) =>
                             Transform(
                                 item));
-                    }
                     result["qualifiers"] = arrayQualifiers;
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
@@ -20543,13 +17368,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Extensions != null)
                 {
-                    var arrayExtensions = new Nodes.JsonArray();
-                    foreach (IExtension item in that.Extensions)
-                    {
-                        arrayExtensions.Add(
+                    Nodes.JsonArray arrayExtensions = SerializeArray(
+                        that.Extensions,
+                        (IExtension item) =>
                             Transform(
                                 item));
-                    }
                     result["extensions"] = arrayExtensions;
                 }
 
@@ -20567,25 +17390,21 @@ namespace AasCore.Aas3_0
 
                 if (that.DisplayName != null)
                 {
-                    var arrayDisplayName = new Nodes.JsonArray();
-                    foreach (ILangStringNameType item in that.DisplayName)
-                    {
-                        arrayDisplayName.Add(
+                    Nodes.JsonArray arrayDisplayName = SerializeArray(
+                        that.DisplayName,
+                        (ILangStringNameType item) =>
                             Transform(
                                 item));
-                    }
                     result["displayName"] = arrayDisplayName;
                 }
 
                 if (that.Description != null)
                 {
-                    var arrayDescription = new Nodes.JsonArray();
-                    foreach (ILangStringTextType item in that.Description)
-                    {
-                        arrayDescription.Add(
+                    Nodes.JsonArray arrayDescription = SerializeArray(
+                        that.Description,
+                        (ILangStringTextType item) =>
                             Transform(
                                 item));
-                    }
                     result["description"] = arrayDescription;
                 }
 
@@ -20600,25 +17419,21 @@ namespace AasCore.Aas3_0
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    var arrayEmbeddedDataSpecifications = new Nodes.JsonArray();
-                    foreach (IEmbeddedDataSpecification item in that.EmbeddedDataSpecifications)
-                    {
-                        arrayEmbeddedDataSpecifications.Add(
+                    Nodes.JsonArray arrayEmbeddedDataSpecifications = SerializeArray(
+                        that.EmbeddedDataSpecifications,
+                        (IEmbeddedDataSpecification item) =>
                             Transform(
                                 item));
-                    }
                     result["embeddedDataSpecifications"] = arrayEmbeddedDataSpecifications;
                 }
 
                 if (that.IsCaseOf != null)
                 {
-                    var arrayIsCaseOf = new Nodes.JsonArray();
-                    foreach (IReference item in that.IsCaseOf)
-                    {
-                        arrayIsCaseOf.Add(
+                    Nodes.JsonArray arrayIsCaseOf = SerializeArray(
+                        that.IsCaseOf,
+                        (IReference item) =>
                             Transform(
                                 item));
-                    }
                     result["isCaseOf"] = arrayIsCaseOf;
                 }
 
@@ -20642,13 +17457,11 @@ namespace AasCore.Aas3_0
                         that.ReferredSemanticId);
                 }
 
-                var arrayKeys = new Nodes.JsonArray();
-                foreach (IKey item in that.Keys)
-                {
-                    arrayKeys.Add(
+                Nodes.JsonArray arrayKeys = SerializeArray(
+                    that.Keys,
+                    (IKey item) =>
                         Transform(
                             item));
-                }
                 result["keys"] = arrayKeys;
 
                 return result;
@@ -20707,37 +17520,31 @@ namespace AasCore.Aas3_0
 
                 if (that.AssetAdministrationShells != null)
                 {
-                    var arrayAssetAdministrationShells = new Nodes.JsonArray();
-                    foreach (IAssetAdministrationShell item in that.AssetAdministrationShells)
-                    {
-                        arrayAssetAdministrationShells.Add(
+                    Nodes.JsonArray arrayAssetAdministrationShells = SerializeArray(
+                        that.AssetAdministrationShells,
+                        (IAssetAdministrationShell item) =>
                             Transform(
                                 item));
-                    }
                     result["assetAdministrationShells"] = arrayAssetAdministrationShells;
                 }
 
                 if (that.Submodels != null)
                 {
-                    var arraySubmodels = new Nodes.JsonArray();
-                    foreach (ISubmodel item in that.Submodels)
-                    {
-                        arraySubmodels.Add(
+                    Nodes.JsonArray arraySubmodels = SerializeArray(
+                        that.Submodels,
+                        (ISubmodel item) =>
                             Transform(
                                 item));
-                    }
                     result["submodels"] = arraySubmodels;
                 }
 
                 if (that.ConceptDescriptions != null)
                 {
-                    var arrayConceptDescriptions = new Nodes.JsonArray();
-                    foreach (IConceptDescription item in that.ConceptDescriptions)
-                    {
-                        arrayConceptDescriptions.Add(
+                    Nodes.JsonArray arrayConceptDescriptions = SerializeArray(
+                        that.ConceptDescriptions,
+                        (IConceptDescription item) =>
                             Transform(
                                 item));
-                    }
                     result["conceptDescriptions"] = arrayConceptDescriptions;
                 }
 
@@ -20801,13 +17608,11 @@ namespace AasCore.Aas3_0
             {
                 var result = new Nodes.JsonObject();
 
-                var arrayValueReferencePairs = new Nodes.JsonArray();
-                foreach (IValueReferencePair item in that.ValueReferencePairs)
-                {
-                    arrayValueReferencePairs.Add(
+                Nodes.JsonArray arrayValueReferencePairs = SerializeArray(
+                    that.ValueReferencePairs,
+                    (IValueReferencePair item) =>
                         Transform(
                             item));
-                }
                 result["valueReferencePairs"] = arrayValueReferencePairs;
 
                 return result;
@@ -20864,24 +17669,20 @@ namespace AasCore.Aas3_0
             {
                 var result = new Nodes.JsonObject();
 
-                var arrayPreferredName = new Nodes.JsonArray();
-                foreach (ILangStringPreferredNameTypeIec61360 item in that.PreferredName)
-                {
-                    arrayPreferredName.Add(
+                Nodes.JsonArray arrayPreferredName = SerializeArray(
+                    that.PreferredName,
+                    (ILangStringPreferredNameTypeIec61360 item) =>
                         Transform(
                             item));
-                }
                 result["preferredName"] = arrayPreferredName;
 
                 if (that.ShortName != null)
                 {
-                    var arrayShortName = new Nodes.JsonArray();
-                    foreach (ILangStringShortNameTypeIec61360 item in that.ShortName)
-                    {
-                        arrayShortName.Add(
+                    Nodes.JsonArray arrayShortName = SerializeArray(
+                        that.ShortName,
+                        (ILangStringShortNameTypeIec61360 item) =>
                             Transform(
                                 item));
-                    }
                     result["shortName"] = arrayShortName;
                 }
 
@@ -20920,13 +17721,11 @@ namespace AasCore.Aas3_0
 
                 if (that.Definition != null)
                 {
-                    var arrayDefinition = new Nodes.JsonArray();
-                    foreach (ILangStringDefinitionTypeIec61360 item in that.Definition)
-                    {
-                        arrayDefinition.Add(
+                    Nodes.JsonArray arrayDefinition = SerializeArray(
+                        that.Definition,
+                        (ILangStringDefinitionTypeIec61360 item) =>
                             Transform(
                                 item));
-                    }
                     result["definition"] = arrayDefinition;
                 }
 

--- a/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/xmlization.cs
@@ -18625,87 +18625,107 @@ namespace AasCore.Aas3_0
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void ExtensionToSequence(
                 Aas.IExtension that,
                 Xml.XmlWriter writer)
             {
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "name",
-                    NS);
-
-                writer.WriteValue(
-                    that.Name);
-
-                writer.WriteEndElement();
+                    that.Name,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
                 if (that.ValueType != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "valueType",
-                        NS);
-
-                    string? textValueType = Stringification.ToString(
-                        that.ValueType);
-                    writer.WriteValue(
-                        textValueType
-                            ?? throw new System.ArgumentException(
-                                "Invalid literal for the enumeration DataTypeDefXsd: " +
-                                that.ValueType.ToString()));
-
-                    writer.WriteEndElement();
+                        that.ValueType,
+                        writer,
+                        (value, w) =>
+                        {
+                            string? text = Stringification.ToString(value);
+                            w.WriteValue(
+                                text
+                                    ?? throw new System.ArgumentException(
+                                        "Invalid literal for the enumeration DataTypeDefXsd: " +
+                                        value.ToString()));
+                        });
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Value);
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.RefersTo != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "refersTo",
-                        NS);
-
-                    foreach (var item in that.RefersTo)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.RefersTo,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void ExtensionToSequence
 
@@ -18728,65 +18748,53 @@ namespace AasCore.Aas3_0
             {
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Version != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "version",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Version);
-
-                    writer.WriteEndElement();
+                        that.Version,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.Revision != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "revision",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Revision);
-
-                    writer.WriteEndElement();
+                        that.Revision,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.Creator != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "creator",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.Creator,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.TemplateId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "templateId",
-                        NS);
-
-                    writer.WriteValue(
-                        that.TemplateId);
-
-                    writer.WriteEndElement();
+                        that.TemplateId,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
             }  // private void AdministrativeInformationToSequence
 
@@ -18809,94 +18817,81 @@ namespace AasCore.Aas3_0
             {
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Kind != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "kind",
-                        NS);
-
-                    string? textKind = Stringification.ToString(
-                        that.Kind);
-                    writer.WriteValue(
-                        textKind
-                            ?? throw new System.ArgumentException(
-                                "Invalid literal for the enumeration QualifierKind: " +
-                                that.Kind.ToString()));
-
-                    writer.WriteEndElement();
+                        that.Kind,
+                        writer,
+                        (value, w) =>
+                        {
+                            string? text = Stringification.ToString(value);
+                            w.WriteValue(
+                                text
+                                    ?? throw new System.ArgumentException(
+                                        "Invalid literal for the enumeration QualifierKind: " +
+                                        value.ToString()));
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "type",
-                    NS);
+                    that.Type,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Type);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "valueType",
-                    NS);
-
-                string? textValueType = Stringification.ToString(
-                    that.ValueType);
-                writer.WriteValue(
-                    textValueType
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration DataTypeDefXsd: " +
-                            that.ValueType.ToString()));
-
-                writer.WriteEndElement();
+                    that.ValueType,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration DataTypeDefXsd: " +
+                                    value.ToString()));
+                    });
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Value);
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.ValueId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "valueId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.ValueId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
             }  // private void QualifierToSequence
 
@@ -18919,141 +18914,125 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Administration != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "administration",
-                        NS);
-
-                    this.AdministrativeInformationToSequence(
                         that.Administration,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.AdministrativeInformationToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "id",
-                    NS);
-
-                writer.WriteValue(
-                    that.Id);
-
-                writer.WriteEndElement();
+                    that.Id,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.DerivedFrom != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "derivedFrom",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.DerivedFrom,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "assetInformation",
-                    NS);
-
-                this.AssetInformationToSequence(
                     that.AssetInformation,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.AssetInformationToSequence(value, w));
 
                 if (that.Submodels != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "submodels",
-                        NS);
-
-                    foreach (var item in that.Submodels)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Submodels,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void AssetAdministrationShellToSequence
 
@@ -19074,69 +19053,60 @@ namespace AasCore.Aas3_0
                 Aas.IAssetInformation that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "assetKind",
-                    NS);
-
-                string? textAssetKind = Stringification.ToString(
-                    that.AssetKind);
-                writer.WriteValue(
-                    textAssetKind
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration AssetKind: " +
-                            that.AssetKind.ToString()));
-
-                writer.WriteEndElement();
+                    that.AssetKind,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration AssetKind: " +
+                                    value.ToString()));
+                    });
 
                 if (that.GlobalAssetId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "globalAssetId",
-                        NS);
-
-                    writer.WriteValue(
-                        that.GlobalAssetId);
-
-                    writer.WriteEndElement();
+                        that.GlobalAssetId,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.SpecificAssetIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "specificAssetIds",
-                        NS);
-
-                    foreach (var item in that.SpecificAssetIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SpecificAssetIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.AssetType != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "assetType",
-                        NS);
-
-                    writer.WriteValue(
-                        that.AssetType);
-
-                    writer.WriteEndElement();
+                        that.AssetType,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DefaultThumbnail != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "defaultThumbnail",
-                        NS);
-
-                    this.ResourceToSequence(
                         that.DefaultThumbnail,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ResourceToSequence(value, w));
                 }
             }  // private void AssetInformationToSequence
 
@@ -19157,25 +19127,19 @@ namespace AasCore.Aas3_0
                 Aas.IResource that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "path",
-                    NS);
-
-                writer.WriteValue(
-                    that.Path);
-
-                writer.WriteEndElement();
+                    that.Path,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
                 if (that.ContentType != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "contentType",
-                        NS);
-
-                    writer.WriteValue(
-                        that.ContentType);
-
-                    writer.WriteEndElement();
+                        that.ContentType,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
             }  // private void ResourceToSequence
 
@@ -19198,60 +19162,47 @@ namespace AasCore.Aas3_0
             {
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "name",
-                    NS);
+                    that.Name,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Name);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "value",
-                    NS);
-
-                writer.WriteValue(
-                    that.Value);
-
-                writer.WriteEndElement();
+                    that.Value,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
                 if (that.ExternalSubjectId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "externalSubjectId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.ExternalSubjectId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
             }  // private void SpecificAssetIdToSequence
 
@@ -19274,176 +19225,166 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Administration != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "administration",
-                        NS);
-
-                    this.AdministrativeInformationToSequence(
                         that.Administration,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.AdministrativeInformationToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "id",
-                    NS);
-
-                writer.WriteValue(
-                    that.Id);
-
-                writer.WriteEndElement();
+                    that.Id,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
                 if (that.Kind != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "kind",
-                        NS);
-
-                    string? textKind = Stringification.ToString(
-                        that.Kind);
-                    writer.WriteValue(
-                        textKind
-                            ?? throw new System.ArgumentException(
-                                "Invalid literal for the enumeration ModellingKind: " +
-                                that.Kind.ToString()));
-
-                    writer.WriteEndElement();
+                        that.Kind,
+                        writer,
+                        (value, w) =>
+                        {
+                            string? text = Stringification.ToString(value);
+                            w.WriteValue(
+                                text
+                                    ?? throw new System.ArgumentException(
+                                        "Invalid literal for the enumeration ModellingKind: " +
+                                        value.ToString()));
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SubmodelElements != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "submodelElements",
-                        NS);
-
-                    foreach (var item in that.SubmodelElements)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SubmodelElements,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void SubmodelToSequence
 
@@ -19466,144 +19407,132 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "first",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.First,
-                    writer);
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
 
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "second",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.Second,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
             }  // private void RelationshipElementToSequence
 
             public override void VisitRelationshipElement(
@@ -19625,193 +19554,183 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.OrderRelevant.HasValue)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "orderRelevant",
-                        NS);
-
-                    writer.WriteValue(
-                        that.OrderRelevant.Value);
-
-                    writer.WriteEndElement();
+                        that.OrderRelevant.Value,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.SemanticIdListElement != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticIdListElement",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticIdListElement,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "typeValueListElement",
-                    NS);
-
-                string? textTypeValueListElement = Stringification.ToString(
-                    that.TypeValueListElement);
-                writer.WriteValue(
-                    textTypeValueListElement
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration AasSubmodelElements: " +
-                            that.TypeValueListElement.ToString()));
-
-                writer.WriteEndElement();
+                    that.TypeValueListElement,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration AasSubmodelElements: " +
+                                    value.ToString()));
+                    });
 
                 if (that.ValueTypeListElement != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "valueTypeListElement",
-                        NS);
-
-                    string? textValueTypeListElement = Stringification.ToString(
-                        that.ValueTypeListElement);
-                    writer.WriteValue(
-                        textValueTypeListElement
-                            ?? throw new System.ArgumentException(
-                                "Invalid literal for the enumeration DataTypeDefXsd: " +
-                                that.ValueTypeListElement.ToString()));
-
-                    writer.WriteEndElement();
+                        that.ValueTypeListElement,
+                        writer,
+                        (value, w) =>
+                        {
+                            string? text = Stringification.ToString(value);
+                            w.WriteValue(
+                                text
+                                    ?? throw new System.ArgumentException(
+                                        "Invalid literal for the enumeration DataTypeDefXsd: " +
+                                        value.ToString()));
+                        });
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    foreach (var item in that.Value)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void SubmodelElementListToSequence
 
@@ -19834,137 +19753,134 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    foreach (var item in that.Value)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void SubmodelElementCollectionToSequence
 
@@ -19987,162 +19903,151 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "valueType",
-                    NS);
-
-                string? textValueType = Stringification.ToString(
-                    that.ValueType);
-                writer.WriteValue(
-                    textValueType
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration DataTypeDefXsd: " +
-                            that.ValueType.ToString()));
-
-                writer.WriteEndElement();
+                    that.ValueType,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration DataTypeDefXsd: " +
+                                    value.ToString()));
+                    });
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Value);
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.ValueId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "valueId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.ValueId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
             }  // private void PropertyToSequence
 
@@ -20165,150 +20070,143 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    foreach (var item in that.Value)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.ValueId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "valueId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.ValueId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
             }  // private void MultiLanguagePropertyToSequence
 
@@ -20331,161 +20229,151 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "valueType",
-                    NS);
-
-                string? textValueType = Stringification.ToString(
-                    that.ValueType);
-                writer.WriteValue(
-                    textValueType
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration DataTypeDefXsd: " +
-                            that.ValueType.ToString()));
-
-                writer.WriteEndElement();
+                    that.ValueType,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration DataTypeDefXsd: " +
+                                    value.ToString()));
+                    });
 
                 if (that.Min != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "min",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Min);
-
-                    writer.WriteEndElement();
+                        that.Min,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.Max != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "max",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Max);
-
-                    writer.WriteEndElement();
+                        that.Max,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
             }  // private void RangeToSequence
 
@@ -20508,136 +20396,128 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.Value,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
             }  // private void ReferenceElementToSequence
 
@@ -20660,147 +20540,135 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    writer.WriteBase64(
                         that.Value,
-                        0,
-                        that.Value.Length);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => w.WriteBase64(value, 0, value.Length));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "contentType",
-                    NS);
-
-                writer.WriteValue(
-                    that.ContentType);
-
-                writer.WriteEndElement();
+                    that.ContentType,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void BlobToSequence
 
             public override void VisitBlob(
@@ -20822,145 +20690,135 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Value);
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "contentType",
-                    NS);
-
-                writer.WriteValue(
-                    that.ContentType);
-
-                writer.WriteEndElement();
+                    that.ContentType,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void FileToSequence
 
             public override void VisitFile(
@@ -20982,157 +20840,146 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "first",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.First,
-                    writer);
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
 
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "second",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.Second,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
 
                 if (that.Annotations != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "annotations",
-                        NS);
-
-                    foreach (var item in that.Annotations)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Annotations,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void AnnotatedRelationshipElementToSequence
 
@@ -21155,177 +21002,172 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Statements != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "statements",
-                        NS);
-
-                    foreach (var item in that.Statements)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Statements,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "entityType",
-                    NS);
-
-                string? textEntityType = Stringification.ToString(
-                    that.EntityType);
-                writer.WriteValue(
-                    textEntityType
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration EntityType: " +
-                            that.EntityType.ToString()));
-
-                writer.WriteEndElement();
+                    that.EntityType,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration EntityType: " +
+                                    value.ToString()));
+                    });
 
                 if (that.GlobalAssetId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "globalAssetId",
-                        NS);
-
-                    writer.WriteValue(
-                        that.GlobalAssetId);
-
-                    writer.WriteEndElement();
+                        that.GlobalAssetId,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.SpecificAssetIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "specificAssetIds",
-                        NS);
-
-                    foreach (var item in that.SpecificAssetIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SpecificAssetIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void EntityToSequence
 
@@ -21346,98 +21188,67 @@ namespace AasCore.Aas3_0
                 Aas.IEventPayload that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "source",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.Source,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
 
                 if (that.SourceSemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "sourceSemanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SourceSemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "observableReference",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.ObservableReference,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
 
                 if (that.ObservableSemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "observableSemanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.ObservableSemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.Topic != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "topic",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Topic);
-
-                    writer.WriteEndElement();
+                        that.Topic,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.SubjectId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "subjectId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SubjectId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "timeStamp",
-                    NS);
-
-                writer.WriteValue(
-                    that.TimeStamp);
-
-                writer.WriteEndElement();
+                    that.TimeStamp,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
                 if (that.Payload != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "payload",
-                        NS);
-
-                    writer.WriteBase64(
                         that.Payload,
-                        0,
-                        that.Payload.Length);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => w.WriteBase64(value, 0, value.Length));
                 }
             }  // private void EventPayloadToSequence
 
@@ -21460,222 +21271,198 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "observed",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.Observed,
-                    writer);
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
 
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "direction",
-                    NS);
+                    that.Direction,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration Direction: " +
+                                    value.ToString()));
+                    });
 
-                string? textDirection = Stringification.ToString(
-                    that.Direction);
-                writer.WriteValue(
-                    textDirection
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration Direction: " +
-                            that.Direction.ToString()));
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "state",
-                    NS);
-
-                string? textState = Stringification.ToString(
-                    that.State);
-                writer.WriteValue(
-                    textState
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration StateOfEvent: " +
-                            that.State.ToString()));
-
-                writer.WriteEndElement();
+                    that.State,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration StateOfEvent: " +
+                                    value.ToString()));
+                    });
 
                 if (that.MessageTopic != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "messageTopic",
-                        NS);
-
-                    writer.WriteValue(
-                        that.MessageTopic);
-
-                    writer.WriteEndElement();
+                        that.MessageTopic,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.MessageBroker != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "messageBroker",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.MessageBroker,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.LastUpdate != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "lastUpdate",
-                        NS);
-
-                    writer.WriteValue(
-                        that.LastUpdate);
-
-                    writer.WriteEndElement();
+                        that.LastUpdate,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.MinInterval != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "minInterval",
-                        NS);
-
-                    writer.WriteValue(
-                        that.MinInterval);
-
-                    writer.WriteEndElement();
+                        that.MinInterval,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.MaxInterval != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "maxInterval",
-                        NS);
-
-                    writer.WriteValue(
-                        that.MaxInterval);
-
-                    writer.WriteEndElement();
+                        that.MaxInterval,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
             }  // private void BasicEventElementToSequence
 
@@ -21698,165 +21485,164 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.InputVariables != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "inputVariables",
-                        NS);
-
-                    foreach (var item in that.InputVariables)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.InputVariables,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.OutputVariables != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "outputVariables",
-                        NS);
-
-                    foreach (var item in that.OutputVariables)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.OutputVariables,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.InoutputVariables != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "inoutputVariables",
-                        NS);
-
-                    foreach (var item in that.InoutputVariables)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.InoutputVariables,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void OperationToSequence
 
@@ -21877,15 +21663,11 @@ namespace AasCore.Aas3_0
                 Aas.IOperationVariable that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "value",
-                    NS);
-
-                this.Visit(
                     that.Value,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.Visit(value, w));
             }  // private void OperationVariableToSequence
 
             public override void VisitOperationVariable(
@@ -21907,123 +21689,119 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.SemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "semanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.SemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SupplementalSemanticIds != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "supplementalSemanticIds",
-                        NS);
-
-                    foreach (var item in that.SupplementalSemanticIds)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.SupplementalSemanticIds,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Qualifiers != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "qualifiers",
-                        NS);
-
-                    foreach (var item in that.Qualifiers)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Qualifiers,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void CapabilityToSequence
 
@@ -22046,118 +21824,110 @@ namespace AasCore.Aas3_0
             {
                 if (that.Extensions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "extensions",
-                        NS);
-
-                    foreach (var item in that.Extensions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Extensions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Category != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "category",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Category);
-
-                    writer.WriteEndElement();
+                        that.Category,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.IdShort != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "idShort",
-                        NS);
-
-                    writer.WriteValue(
-                        that.IdShort);
-
-                    writer.WriteEndElement();
+                        that.IdShort,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DisplayName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "displayName",
-                        NS);
-
-                    foreach (var item in that.DisplayName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.DisplayName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Description != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "description",
-                        NS);
-
-                    foreach (var item in that.Description)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Description,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Administration != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "administration",
-                        NS);
-
-                    this.AdministrativeInformationToSequence(
                         that.Administration,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.AdministrativeInformationToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "id",
-                    NS);
-
-                writer.WriteValue(
-                    that.Id);
-
-                writer.WriteEndElement();
+                    that.Id,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
                 if (that.EmbeddedDataSpecifications != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "embeddedDataSpecifications",
-                        NS);
-
-                    foreach (var item in that.EmbeddedDataSpecifications)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.EmbeddedDataSpecifications,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.IsCaseOf != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "isCaseOf",
-                        NS);
-
-                    foreach (var item in that.IsCaseOf)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.IsCaseOf,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void ConceptDescriptionToSequence
 
@@ -22178,43 +21948,40 @@ namespace AasCore.Aas3_0
                 Aas.IReference that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "type",
-                    NS);
-
-                string? textType = Stringification.ToString(
-                    that.Type);
-                writer.WriteValue(
-                    textType
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration ReferenceTypes: " +
-                            that.Type.ToString()));
-
-                writer.WriteEndElement();
+                    that.Type,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration ReferenceTypes: " +
+                                    value.ToString()));
+                    });
 
                 if (that.ReferredSemanticId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "referredSemanticId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.ReferredSemanticId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
-                writer.WriteStartElement(
+                SerializeElement(
                     "keys",
-                    NS);
-
-                foreach (var item in that.Keys)
-                {
-                    this.Visit(item, writer);
-                }
-
-                writer.WriteEndElement();
+                    that.Keys,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            this.Visit(item, w);
+                        }
+                    });
             }  // private void ReferenceToSequence
 
             public override void VisitReference(
@@ -22234,28 +22001,25 @@ namespace AasCore.Aas3_0
                 Aas.IKey that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "type",
-                    NS);
+                    that.Type,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration KeyTypes: " +
+                                    value.ToString()));
+                    });
 
-                string? textType = Stringification.ToString(
-                    that.Type);
-                writer.WriteValue(
-                    textType
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration KeyTypes: " +
-                            that.Type.ToString()));
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "value",
-                    NS);
-
-                writer.WriteValue(
-                    that.Value);
-
-                writer.WriteEndElement();
+                    that.Value,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void KeyToSequence
 
             public override void VisitKey(
@@ -22275,23 +22039,17 @@ namespace AasCore.Aas3_0
                 Aas.ILangStringNameType that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "language",
-                    NS);
+                    that.Language,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Language);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "text",
-                    NS);
-
-                writer.WriteValue(
-                    that.Text);
-
-                writer.WriteEndElement();
+                    that.Text,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void LangStringNameTypeToSequence
 
             public override void VisitLangStringNameType(
@@ -22311,23 +22069,17 @@ namespace AasCore.Aas3_0
                 Aas.ILangStringTextType that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "language",
-                    NS);
+                    that.Language,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Language);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "text",
-                    NS);
-
-                writer.WriteValue(
-                    that.Text);
-
-                writer.WriteEndElement();
+                    that.Text,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void LangStringTextTypeToSequence
 
             public override void VisitLangStringTextType(
@@ -22349,44 +22101,47 @@ namespace AasCore.Aas3_0
             {
                 if (that.AssetAdministrationShells != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "assetAdministrationShells",
-                        NS);
-
-                    foreach (var item in that.AssetAdministrationShells)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.AssetAdministrationShells,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Submodels != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "submodels",
-                        NS);
-
-                    foreach (var item in that.Submodels)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Submodels,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.ConceptDescriptions != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "conceptDescriptions",
-                        NS);
-
-                    foreach (var item in that.ConceptDescriptions)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.ConceptDescriptions,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
             }  // private void EnvironmentToSequence
 
@@ -22407,25 +22162,17 @@ namespace AasCore.Aas3_0
                 Aas.IEmbeddedDataSpecification that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "dataSpecification",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.DataSpecification,
-                    writer);
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
 
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "dataSpecificationContent",
-                    NS);
-
-                this.Visit(
                     that.DataSpecificationContent,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.Visit(value, w));
             }  // private void EmbeddedDataSpecificationToSequence
 
             public override void VisitEmbeddedDataSpecification(
@@ -22445,41 +22192,29 @@ namespace AasCore.Aas3_0
                 Aas.ILevelType that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "min",
-                    NS);
+                    that.Min,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Min);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "nom",
-                    NS);
+                    that.Nom,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Nom);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "typ",
-                    NS);
+                    that.Typ,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Typ);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "max",
-                    NS);
-
-                writer.WriteValue(
-                    that.Max);
-
-                writer.WriteEndElement();
+                    that.Max,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void LevelTypeToSequence
 
             public override void VisitLevelType(
@@ -22499,24 +22234,17 @@ namespace AasCore.Aas3_0
                 Aas.IValueReferencePair that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "value",
-                    NS);
+                    that.Value,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Value);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "valueId",
-                    NS);
-
-                this.ReferenceToSequence(
                     that.ValueId,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.ReferenceToSequence(value, w));
             }  // private void ValueReferencePairToSequence
 
             public override void VisitValueReferencePair(
@@ -22536,16 +22264,17 @@ namespace AasCore.Aas3_0
                 Aas.IValueList that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "valueReferencePairs",
-                    NS);
-
-                foreach (var item in that.ValueReferencePairs)
-                {
-                    this.Visit(item, writer);
-                }
-
-                writer.WriteEndElement();
+                    that.ValueReferencePairs,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            this.Visit(item, w);
+                        }
+                    });
             }  // private void ValueListToSequence
 
             public override void VisitValueList(
@@ -22565,23 +22294,17 @@ namespace AasCore.Aas3_0
                 Aas.ILangStringPreferredNameTypeIec61360 that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "language",
-                    NS);
+                    that.Language,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Language);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "text",
-                    NS);
-
-                writer.WriteValue(
-                    that.Text);
-
-                writer.WriteEndElement();
+                    that.Text,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void LangStringPreferredNameTypeIec61360ToSequence
 
             public override void VisitLangStringPreferredNameTypeIec61360(
@@ -22601,23 +22324,17 @@ namespace AasCore.Aas3_0
                 Aas.ILangStringShortNameTypeIec61360 that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "language",
-                    NS);
+                    that.Language,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Language);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "text",
-                    NS);
-
-                writer.WriteValue(
-                    that.Text);
-
-                writer.WriteEndElement();
+                    that.Text,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void LangStringShortNameTypeIec61360ToSequence
 
             public override void VisitLangStringShortNameTypeIec61360(
@@ -22637,23 +22354,17 @@ namespace AasCore.Aas3_0
                 Aas.ILangStringDefinitionTypeIec61360 that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "language",
-                    NS);
+                    that.Language,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Language);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "text",
-                    NS);
-
-                writer.WriteValue(
-                    that.Text);
-
-                writer.WriteEndElement();
+                    that.Text,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void LangStringDefinitionTypeIec61360ToSequence
 
             public override void VisitLangStringDefinitionTypeIec61360(
@@ -22673,159 +22384,135 @@ namespace AasCore.Aas3_0
                 Aas.IDataSpecificationIec61360 that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "preferredName",
-                    NS);
-
-                foreach (var item in that.PreferredName)
-                {
-                    this.Visit(item, writer);
-                }
-
-                writer.WriteEndElement();
+                    that.PreferredName,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            this.Visit(item, w);
+                        }
+                    });
 
                 if (that.ShortName != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "shortName",
-                        NS);
-
-                    foreach (var item in that.ShortName)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.ShortName,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.Unit != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "unit",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Unit);
-
-                    writer.WriteEndElement();
+                        that.Unit,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.UnitId != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "unitId",
-                        NS);
-
-                    this.ReferenceToSequence(
                         that.UnitId,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ReferenceToSequence(value, w));
                 }
 
                 if (that.SourceOfDefinition != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "sourceOfDefinition",
-                        NS);
-
-                    writer.WriteValue(
-                        that.SourceOfDefinition);
-
-                    writer.WriteEndElement();
+                        that.SourceOfDefinition,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.Symbol != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "symbol",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Symbol);
-
-                    writer.WriteEndElement();
+                        that.Symbol,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.DataType != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "dataType",
-                        NS);
-
-                    string? textDataType = Stringification.ToString(
-                        that.DataType);
-                    writer.WriteValue(
-                        textDataType
-                            ?? throw new System.ArgumentException(
-                                "Invalid literal for the enumeration DataTypeIec61360: " +
-                                that.DataType.ToString()));
-
-                    writer.WriteEndElement();
+                        that.DataType,
+                        writer,
+                        (value, w) =>
+                        {
+                            string? text = Stringification.ToString(value);
+                            w.WriteValue(
+                                text
+                                    ?? throw new System.ArgumentException(
+                                        "Invalid literal for the enumeration DataTypeIec61360: " +
+                                        value.ToString()));
+                        });
                 }
 
                 if (that.Definition != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "definition",
-                        NS);
-
-                    foreach (var item in that.Definition)
-                    {
-                        this.Visit(item, writer);
-                    }
-
-                    writer.WriteEndElement();
+                        that.Definition,
+                        writer,
+                        (value, w) =>
+                        {
+                            foreach (var item in value)
+                            {
+                                this.Visit(item, w);
+                            }
+                        });
                 }
 
                 if (that.ValueFormat != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "valueFormat",
-                        NS);
-
-                    writer.WriteValue(
-                        that.ValueFormat);
-
-                    writer.WriteEndElement();
+                        that.ValueFormat,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.ValueList != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "valueList",
-                        NS);
-
-                    this.ValueListToSequence(
                         that.ValueList,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.ValueListToSequence(value, w));
                 }
 
                 if (that.Value != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "value",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Value);
-
-                    writer.WriteEndElement();
+                        that.Value,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.LevelType != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "levelType",
-                        NS);
-
-                    this.LevelTypeToSequence(
                         that.LevelType,
-                        writer);
-
-                    writer.WriteEndElement();
+                        writer,
+                        (value, w) => this.LevelTypeToSequence(value, w));
                 }
             }  // private void DataSpecificationIec61360ToSequence
 

--- a/dev/test_data/main/csharp/expected/constrained_primitives/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/constrained_primitives/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of Something from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -510,6 +636,27 @@ namespace dummy
                         $"The number can not be losslessly represented in JSON: {that}");
                 }
                 return Nodes.JsonValue.Create(that);
+            }
+
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
             }
 
             public override Nodes.JsonObject TransformSomething(

--- a/dev/test_data/main/csharp/expected/constrained_primitives/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/constrained_primitives/expected_output/dummy/xmlization.cs
@@ -1192,56 +1192,67 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomethingToSequence(
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someBool",
-                    NS);
+                    that.SomeBool,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeBool);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someInt",
-                    NS);
+                    that.SomeInt,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeInt);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someFloat",
-                    NS);
+                    that.SomeFloat,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeFloat);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someString",
-                    NS);
+                    that.SomeString,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeString);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someBytes",
-                    NS);
-
-                writer.WriteBase64(
                     that.SomeBytes,
-                    0,
-                    that.SomeBytes.Length);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => w.WriteBase64(value, 0, value.Length));
             }  // private void SomethingToSequence
 
             public override void VisitSomething(

--- a/dev/test_data/main/csharp/expected/custom_serialization_names/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/custom_serialization_names/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of QueryCondition from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -376,6 +502,27 @@ namespace dummy
                         $"The number can not be losslessly represented in JSON: {that}");
                 }
                 return Nodes.JsonValue.Create(that);
+            }
+
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
             }
 
             public override Nodes.JsonObject TransformQueryCondition(

--- a/dev/test_data/main/csharp/expected/custom_serialization_names/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/custom_serialization_names/expected_output/dummy/xmlization.cs
@@ -999,32 +999,54 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void QueryConditionToSequence(
                 Aas.IQueryCondition that,
                 Xml.XmlWriter writer)
             {
                 if (that.Eq != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "eq",
-                        NS);
-
-                    writer.WriteValue(
-                        that.Eq);
-
-                    writer.WriteEndElement();
+                        that.Eq,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
 
                 if (that.NotEq != null)
                 {
-                    writer.WriteStartElement(
+                    SerializeElement(
                         "not-eq",
-                        NS);
-
-                    writer.WriteValue(
-                        that.NotEq);
-
-                    writer.WriteEndElement();
+                        that.NotEq,
+                        writer,
+                        (value, w) => w.WriteValue(value));
                 }
             }  // private void QueryConditionToSequence
 

--- a/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of INode by dispatching
             /// based on <c>modelType</c> property of the <paramref name="node" />.
             /// </summary>
@@ -1450,6 +1576,27 @@ namespace dummy
                         $"The number can not be losslessly represented in JSON: {that}");
                 }
                 return Nodes.JsonValue.Create(that);
+            }
+
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
             }
 
             public override Nodes.JsonObject TransformBranch(

--- a/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/xmlization.cs
@@ -2661,27 +2661,49 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void BranchToSequence(
                 Aas.IBranch that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "identifier",
-                    NS);
+                    that.Identifier,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Identifier);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "description",
-                    NS);
-
-                writer.WriteValue(
-                    that.Description);
-
-                writer.WriteEndElement();
+                    that.Description,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void BranchToSequence
 
             public override void VisitBranch(
@@ -2701,32 +2723,23 @@ namespace dummy
                 Aas.ILeaf that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "identifier",
-                    NS);
+                    that.Identifier,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Identifier);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "description",
-                    NS);
+                    that.Description,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Description);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "value",
-                    NS);
-
-                writer.WriteValue(
-                    that.Value);
-
-                writer.WriteEndElement();
+                    that.Value,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void LeafToSequence
 
             public override void VisitLeaf(
@@ -2746,41 +2759,29 @@ namespace dummy
                 Aas.IBlossom that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "identifier",
-                    NS);
+                    that.Identifier,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Identifier);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "description",
-                    NS);
+                    that.Description,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Description);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "value",
-                    NS);
+                    that.Value,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Value);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "details",
-                    NS);
-
-                writer.WriteValue(
-                    that.Details);
-
-                writer.WriteEndElement();
+                    that.Details,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void BlossomToSequence
 
             public override void VisitBlossom(
@@ -2800,25 +2801,17 @@ namespace dummy
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someChoice",
-                    NS);
-
-                this.Visit(
                     that.SomeChoice,
-                    writer);
+                    writer,
+                    (value, w) => this.Visit(value, w));
 
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "somethingWithoutChoice",
-                    NS);
-
-                this.Visit(
                     that.SomethingWithoutChoice,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.Visit(value, w));
             }  // private void SomethingToSequence
 
             public override void VisitSomething(
@@ -2838,25 +2831,17 @@ namespace dummy
                 Aas.IContainer that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "node",
-                    NS);
-
-                this.Visit(
                     that.Node,
-                    writer);
+                    writer,
+                    (value, w) => this.Visit(value, w));
 
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "something",
-                    NS);
-
-                this.SomethingToSequence(
                     that.Something,
-                    writer);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => this.SomethingToSequence(value, w));
             }  // private void ContainerToSequence
 
             public override void VisitContainer(

--- a/dev/test_data/main/csharp/expected/empty_class/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/empty_class/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of Something from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -313,6 +439,27 @@ namespace dummy
                         $"The number can not be losslessly represented in JSON: {that}");
                 }
                 return Nodes.JsonValue.Create(that);
+            }
+
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
             }
 
             public override Nodes.JsonObject TransformSomething(

--- a/dev/test_data/main/csharp/expected/empty_class/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/empty_class/expected_output/dummy/xmlization.cs
@@ -824,6 +824,34 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             [CodeAnalysis.SuppressMessage("ReSharper", "UnusedParameter.Local")]
             private void SomethingToSequence(
                 Aas.ISomething that,

--- a/dev/test_data/main/csharp/expected/enum/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/enum/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize the enumeration Result from the <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -405,6 +531,27 @@ namespace dummy
                         $"The number can not be losslessly represented in JSON: {that}");
                 }
                 return Nodes.JsonValue.Create(that);
+            }
+
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
             }
 
             public override Nodes.JsonObject TransformSomething(

--- a/dev/test_data/main/csharp/expected/enum/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/enum/expected_output/dummy/xmlization.cs
@@ -1026,23 +1026,51 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomethingToSequence(
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someResult",
-                    NS);
-
-                string? textSomeResult = Stringification.ToString(
-                    that.SomeResult);
-                writer.WriteValue(
-                    textSomeResult
-                        ?? throw new System.ArgumentException(
-                            "Invalid literal for the enumeration Result: " +
-                            that.SomeResult.ToString()));
-
-                writer.WriteEndElement();
+                    that.SomeResult,
+                    writer,
+                    (value, w) =>
+                    {
+                        string? text = Stringification.ToString(value);
+                        w.WriteValue(
+                            text
+                                ?? throw new System.ArgumentException(
+                                    "Invalid literal for the enumeration Result: " +
+                                    value.ToString()));
+                    });
             }  // private void SomethingToSequence
 
             public override void VisitSomething(

--- a/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of IAbstractItem by dispatching
             /// based on <c>modelType</c> property of the <paramref name="node" />.
             /// </summary>
@@ -609,41 +735,16 @@ namespace dummy
                                         "someItems"));
                                 return null;
                             }
-                            theSomeItems = new List<IAbstractItem>(
-                                arraySomeItems.Count);
-                            int indexSomeItems = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeItems)
+                            theSomeItems = ParseArrayOfClass<IAbstractItem>(
+                                arraySomeItems,
+                                DeserializeImplementation.IAbstractItemFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeItems));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someItems"));
-                                    return null;
-                                }
-                                IAbstractItem? parsedItem = DeserializeImplementation.IAbstractItemFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeItems));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someItems"));
-                                    return null;
-                                }
-                                theSomeItems.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeItems++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someItems"));
+                                return null;
                             }
                             break;
                         }
@@ -669,41 +770,16 @@ namespace dummy
                                         "someSimples"));
                                 return null;
                             }
-                            theSomeSimples = new List<ISimple>(
-                                arraySomeSimples.Count);
-                            int indexSomeSimples = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeSimples)
+                            theSomeSimples = ParseArrayOfClass<ISimple>(
+                                arraySomeSimples,
+                                DeserializeImplementation.SimpleFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeSimples));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someSimples"));
-                                    return null;
-                                }
-                                ISimple? parsedItem = DeserializeImplementation.SimpleFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeSimples));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someSimples"));
-                                    return null;
-                                }
-                                theSomeSimples.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeSimples++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someSimples"));
+                                return null;
                             }
                             break;
                         }
@@ -917,6 +993,27 @@ namespace dummy
                 return Nodes.JsonValue.Create(that);
             }
 
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
+            }
+
             public override Nodes.JsonObject TransformSomeItem(
                 Aas.ISomeItem that
             )
@@ -963,22 +1060,18 @@ namespace dummy
             {
                 var result = new Nodes.JsonObject();
 
-                var arraySomeItems = new Nodes.JsonArray();
-                foreach (IAbstractItem item in that.SomeItems)
-                {
-                    arraySomeItems.Add(
+                Nodes.JsonArray arraySomeItems = SerializeArray(
+                    that.SomeItems,
+                    (IAbstractItem item) =>
                         Transform(
                             item));
-                }
                 result["someItems"] = arraySomeItems;
 
-                var arraySomeSimples = new Nodes.JsonArray();
-                foreach (ISimple item in that.SomeSimples)
-                {
-                    arraySomeSimples.Add(
+                Nodes.JsonArray arraySomeSimples = SerializeArray(
+                    that.SomeSimples,
+                    (ISimple item) =>
                         Transform(
                             item));
-                }
                 result["someSimples"] = arraySomeSimples;
 
                 return result;

--- a/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/xmlization.cs
@@ -1830,18 +1830,43 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomeItemToSequence(
                 Aas.ISomeItem that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "name",
-                    NS);
-
-                writer.WriteValue(
-                    that.Name);
-
-                writer.WriteEndElement();
+                    that.Name,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void SomeItemToSequence
 
             public override void VisitSomeItem(
@@ -1861,14 +1886,11 @@ namespace dummy
                 Aas.IAnotherItem that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "serialNumber",
-                    NS);
-
-                writer.WriteValue(
-                    that.SerialNumber);
-
-                writer.WriteEndElement();
+                    that.SerialNumber,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void AnotherItemToSequence
 
             public override void VisitAnotherItem(
@@ -1888,14 +1910,11 @@ namespace dummy
                 Aas.ISimple that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "name",
-                    NS);
-
-                writer.WriteValue(
-                    that.Name);
-
-                writer.WriteEndElement();
+                    that.Name,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void SimpleToSequence
 
             public override void VisitSimple(
@@ -1915,27 +1934,29 @@ namespace dummy
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someItems",
-                    NS);
+                    that.SomeItems,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            this.Visit(item, w);
+                        }
+                    });
 
-                foreach (var item in that.SomeItems)
-                {
-                    this.Visit(item, writer);
-                }
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someSimples",
-                    NS);
-
-                foreach (var item in that.SomeSimples)
-                {
-                    this.Visit(item, writer);
-                }
-
-                writer.WriteEndElement();
+                    that.SomeSimples,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            this.Visit(item, w);
+                        }
+                    });
             }  // private void SomethingToSequence
 
             public override void VisitSomething(

--- a/dev/test_data/main/csharp/expected/list_of_constrained_primitives/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_constrained_primitives/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of Something from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -246,41 +372,16 @@ namespace dummy
                                         "someNames"));
                                 return null;
                             }
-                            theSomeNames = new List<string>(
-                                arraySomeNames.Count);
-                            int indexSomeNames = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeNames)
+                            theSomeNames = ParseArrayOfClass<string>(
+                                arraySomeNames,
+                                DeserializeImplementation.StringFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeNames));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someNames"));
-                                    return null;
-                                }
-                                string? parsedItem = DeserializeImplementation.StringFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeNames));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someNames"));
-                                    return null;
-                                }
-                                theSomeNames.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeNames++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someNames"));
+                                return null;
                             }
                             break;
                         }
@@ -383,19 +484,38 @@ namespace dummy
                 return Nodes.JsonValue.Create(that);
             }
 
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
+            }
+
             public override Nodes.JsonObject TransformSomething(
                 Aas.ISomething that
             )
             {
                 var result = new Nodes.JsonObject();
 
-                var arraySomeNames = new Nodes.JsonArray();
-                foreach (string item in that.SomeNames)
-                {
-                    arraySomeNames.Add(
+                Nodes.JsonArray arraySomeNames = SerializeArray(
+                    that.SomeNames,
+                    (string item) =>
                         Nodes.JsonValue.Create(
                             item));
-                }
                 result["someNames"] = arraySomeNames;
 
                 return result;

--- a/dev/test_data/main/csharp/expected/list_of_constrained_primitives/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_constrained_primitives/expected_output/dummy/xmlization.cs
@@ -957,22 +957,51 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomethingToSequence(
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someNames",
-                    NS);
-
-                foreach (var item in that.SomeNames)
-                {
-                    writer.WriteStartElement("v", NS);
-                    writer.WriteValue(item);
-                    writer.WriteEndElement();
-                }
-
-                writer.WriteEndElement();
+                    that.SomeNames,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            w.WriteStartElement("v", NS);
+                            w.WriteValue(item);
+                            w.WriteEndElement();
+                        }
+                    });
             }  // private void SomethingToSequence
 
             public override void VisitSomething(

--- a/dev/test_data/main/csharp/expected/list_of_enums/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_enums/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize the enumeration Result from the <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -276,41 +402,16 @@ namespace dummy
                                         "someResults"));
                                 return null;
                             }
-                            theSomeResults = new List<Result>(
-                                arraySomeResults.Count);
-                            int indexSomeResults = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeResults)
+                            theSomeResults = ParseArrayOfStruct<Result>(
+                                arraySomeResults,
+                                DeserializeImplementation.ResultFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeResults));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someResults"));
-                                    return null;
-                                }
-                                Result? parsedItem = DeserializeImplementation.ResultFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeResults));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someResults"));
-                                    return null;
-                                }
-                                theSomeResults.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeResults++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someResults"));
+                                return null;
                             }
                             break;
                         }
@@ -438,19 +539,38 @@ namespace dummy
                 return Nodes.JsonValue.Create(that);
             }
 
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
+            }
+
             public override Nodes.JsonObject TransformSomething(
                 Aas.ISomething that
             )
             {
                 var result = new Nodes.JsonObject();
 
-                var arraySomeResults = new Nodes.JsonArray();
-                foreach (Result item in that.SomeResults)
-                {
-                    arraySomeResults.Add(
+                Nodes.JsonArray arraySomeResults = SerializeArray(
+                    that.SomeResults,
+                    (Result item) =>
                         Serialize.ResultToJsonValue(
                             item));
-                }
                 result["someResults"] = arraySomeResults;
 
                 return result;

--- a/dev/test_data/main/csharp/expected/list_of_enums/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_enums/expected_output/dummy/xmlization.cs
@@ -993,26 +993,55 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomethingToSequence(
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someResults",
-                    NS);
-
-                foreach (var item in that.SomeResults)
-                {
-                    writer.WriteStartElement("v", NS);
-                    writer.WriteValue(
-                        Stringification.ToString(item)
-                            ?? throw new System.ArgumentException(
-                                "Invalid literal for the enumeration Result: " +
-                                item.ToString()));
-                    writer.WriteEndElement();
-                }
-
-                writer.WriteEndElement();
+                    that.SomeResults,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            w.WriteStartElement("v", NS);
+                            w.WriteValue(
+                                Stringification.ToString(item)
+                                    ?? throw new System.ArgumentException(
+                                        "Invalid literal for the enumeration Result: " +
+                                        item.ToString()));
+                            w.WriteEndElement();
+                        }
+                    });
             }  // private void SomethingToSequence
 
             public override void VisitSomething(

--- a/dev/test_data/main/csharp/expected/list_of_primitives/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_primitives/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of Something from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -250,41 +376,16 @@ namespace dummy
                                         "someBools"));
                                 return null;
                             }
-                            theSomeBools = new List<bool>(
-                                arraySomeBools.Count);
-                            int indexSomeBools = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeBools)
+                            theSomeBools = ParseArrayOfStruct<bool>(
+                                arraySomeBools,
+                                DeserializeImplementation.BoolFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeBools));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBools"));
-                                    return null;
-                                }
-                                bool? parsedItem = DeserializeImplementation.BoolFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeBools));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBools"));
-                                    return null;
-                                }
-                                theSomeBools.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeBools++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someBools"));
+                                return null;
                             }
                             break;
                         }
@@ -310,41 +411,16 @@ namespace dummy
                                         "someInts"));
                                 return null;
                             }
-                            theSomeInts = new List<long>(
-                                arraySomeInts.Count);
-                            int indexSomeInts = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeInts)
+                            theSomeInts = ParseArrayOfStruct<long>(
+                                arraySomeInts,
+                                DeserializeImplementation.LongFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeInts));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someInts"));
-                                    return null;
-                                }
-                                long? parsedItem = DeserializeImplementation.LongFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeInts));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someInts"));
-                                    return null;
-                                }
-                                theSomeInts.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeInts++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someInts"));
+                                return null;
                             }
                             break;
                         }
@@ -370,41 +446,16 @@ namespace dummy
                                         "someFloats"));
                                 return null;
                             }
-                            theSomeFloats = new List<double>(
-                                arraySomeFloats.Count);
-                            int indexSomeFloats = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeFloats)
+                            theSomeFloats = ParseArrayOfStruct<double>(
+                                arraySomeFloats,
+                                DeserializeImplementation.DoubleFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeFloats));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someFloats"));
-                                    return null;
-                                }
-                                double? parsedItem = DeserializeImplementation.DoubleFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeFloats));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someFloats"));
-                                    return null;
-                                }
-                                theSomeFloats.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeFloats++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someFloats"));
+                                return null;
                             }
                             break;
                         }
@@ -430,41 +481,16 @@ namespace dummy
                                         "someStrings"));
                                 return null;
                             }
-                            theSomeStrings = new List<string>(
-                                arraySomeStrings.Count);
-                            int indexSomeStrings = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeStrings)
+                            theSomeStrings = ParseArrayOfClass<string>(
+                                arraySomeStrings,
+                                DeserializeImplementation.StringFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeStrings));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someStrings"));
-                                    return null;
-                                }
-                                string? parsedItem = DeserializeImplementation.StringFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeStrings));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someStrings"));
-                                    return null;
-                                }
-                                theSomeStrings.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeStrings++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someStrings"));
+                                return null;
                             }
                             break;
                         }
@@ -490,41 +516,16 @@ namespace dummy
                                         "someBytes"));
                                 return null;
                             }
-                            theSomeBytes = new List<byte[]>(
-                                arraySomeBytes.Count);
-                            int indexSomeBytes = 0;
-                            foreach (Nodes.JsonNode? item in arraySomeBytes)
+                            theSomeBytes = ParseArrayOfClass<byte[]>(
+                                arraySomeBytes,
+                                DeserializeImplementation.BytesFrom,
+                                out error);
+                            if (error != null)
                             {
-                                if (item == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "Expected a non-null item, but got a null");
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeBytes));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBytes"));
-                                    return null;
-                                }
-                                byte[]? parsedItem = DeserializeImplementation.BytesFrom(
-                                    item ?? throw new System.InvalidOperationException(),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.IndexSegment(
-                                            indexSomeBytes));
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBytes"));
-                                    return null;
-                                }
-                                theSomeBytes.Add(
-                                    parsedItem
-                                        ?? throw new System.InvalidOperationException(
-                                            "Unexpected result null when error is null"));
-                                indexSomeBytes++;
+                                error.PrependSegment(
+                                    new Reporting.NameSegment(
+                                        "someBytes"));
+                                return null;
                             }
                             break;
                         }
@@ -667,56 +668,67 @@ namespace dummy
                 return Nodes.JsonValue.Create(that);
             }
 
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
+            }
+
             public override Nodes.JsonObject TransformSomething(
                 Aas.ISomething that
             )
             {
                 var result = new Nodes.JsonObject();
 
-                var arraySomeBools = new Nodes.JsonArray();
-                foreach (bool item in that.SomeBools)
-                {
-                    arraySomeBools.Add(
+                Nodes.JsonArray arraySomeBools = SerializeArray(
+                    that.SomeBools,
+                    (bool item) =>
                         Nodes.JsonValue.Create(
                             item));
-                }
                 result["someBools"] = arraySomeBools;
 
-                var arraySomeInts = new Nodes.JsonArray();
-                foreach (long item in that.SomeInts)
-                {
-                    arraySomeInts.Add(
+                Nodes.JsonArray arraySomeInts = SerializeArray(
+                    that.SomeInts,
+                    (long item) =>
                         Transformer.ToJsonValue(
                             item));
-                }
                 result["someInts"] = arraySomeInts;
 
-                var arraySomeFloats = new Nodes.JsonArray();
-                foreach (double item in that.SomeFloats)
-                {
-                    arraySomeFloats.Add(
+                Nodes.JsonArray arraySomeFloats = SerializeArray(
+                    that.SomeFloats,
+                    (double item) =>
                         Nodes.JsonValue.Create(
                             item));
-                }
                 result["someFloats"] = arraySomeFloats;
 
-                var arraySomeStrings = new Nodes.JsonArray();
-                foreach (string item in that.SomeStrings)
-                {
-                    arraySomeStrings.Add(
+                Nodes.JsonArray arraySomeStrings = SerializeArray(
+                    that.SomeStrings,
+                    (string item) =>
                         Nodes.JsonValue.Create(
                             item));
-                }
                 result["someStrings"] = arraySomeStrings;
 
-                var arraySomeBytes = new Nodes.JsonArray();
-                foreach (byte[] item in that.SomeBytes)
-                {
-                    arraySomeBytes.Add(
+                Nodes.JsonArray arraySomeBytes = SerializeArray(
+                    that.SomeBytes,
+                    (byte[] item) =>
                         Nodes.JsonValue.Create(
                             System.Convert.ToBase64String(
                                 item)));
-                }
                 result["someBytes"] = arraySomeBytes;
 
                 return result;

--- a/dev/test_data/main/csharp/expected/list_of_primitives/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_primitives/expected_output/dummy/xmlization.cs
@@ -1093,74 +1093,107 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomethingToSequence(
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someBools",
-                    NS);
+                    that.SomeBools,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            w.WriteStartElement("v", NS);
+                            w.WriteValue(item);
+                            w.WriteEndElement();
+                        }
+                    });
 
-                foreach (var item in that.SomeBools)
-                {
-                    writer.WriteStartElement("v", NS);
-                    writer.WriteValue(item);
-                    writer.WriteEndElement();
-                }
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someInts",
-                    NS);
+                    that.SomeInts,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            w.WriteStartElement("v", NS);
+                            w.WriteValue(item);
+                            w.WriteEndElement();
+                        }
+                    });
 
-                foreach (var item in that.SomeInts)
-                {
-                    writer.WriteStartElement("v", NS);
-                    writer.WriteValue(item);
-                    writer.WriteEndElement();
-                }
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someFloats",
-                    NS);
+                    that.SomeFloats,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            w.WriteStartElement("v", NS);
+                            w.WriteValue(item);
+                            w.WriteEndElement();
+                        }
+                    });
 
-                foreach (var item in that.SomeFloats)
-                {
-                    writer.WriteStartElement("v", NS);
-                    writer.WriteValue(item);
-                    writer.WriteEndElement();
-                }
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someStrings",
-                    NS);
+                    that.SomeStrings,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            w.WriteStartElement("v", NS);
+                            w.WriteValue(item);
+                            w.WriteEndElement();
+                        }
+                    });
 
-                foreach (var item in that.SomeStrings)
-                {
-                    writer.WriteStartElement("v", NS);
-                    writer.WriteValue(item);
-                    writer.WriteEndElement();
-                }
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someBytes",
-                    NS);
-
-                foreach (var item in that.SomeBytes)
-                {
-                    writer.WriteStartElement("v", NS);
-                    writer.WriteBase64(item, 0, item.Length);
-                    writer.WriteEndElement();
-                }
-
-                writer.WriteEndElement();
+                    that.SomeBytes,
+                    writer,
+                    (value, w) =>
+                    {
+                        foreach (var item in value)
+                        {
+                            w.WriteStartElement("v", NS);
+                            w.WriteBase64(item, 0, item.Length);
+                            w.WriteEndElement();
+                        }
+                    });
             }  // private void SomethingToSequence
 
             public override void VisitSomething(

--- a/dev/test_data/main/csharp/expected/primitive_types/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/primitive_types/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of Something from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -510,6 +636,27 @@ namespace dummy
                         $"The number can not be losslessly represented in JSON: {that}");
                 }
                 return Nodes.JsonValue.Create(that);
+            }
+
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
             }
 
             public override Nodes.JsonObject TransformSomething(

--- a/dev/test_data/main/csharp/expected/primitive_types/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/primitive_types/expected_output/dummy/xmlization.cs
@@ -1192,56 +1192,67 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomethingToSequence(
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "someBool",
-                    NS);
+                    that.SomeBool,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeBool);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someInt",
-                    NS);
+                    that.SomeInt,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeInt);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someFloat",
-                    NS);
+                    that.SomeFloat,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeFloat);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someString",
-                    NS);
+                    that.SomeString,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.SomeString);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "someBytes",
-                    NS);
-
-                writer.WriteBase64(
                     that.SomeBytes,
-                    0,
-                    that.SomeBytes.Length);
-
-                writer.WriteEndElement();
+                    writer,
+                    (value, w) => w.WriteBase64(value, 0, value.Length));
             }  // private void SomethingToSequence
 
             public override void VisitSomething(

--- a/dev/test_data/main/csharp/expected/problematic_keywords/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/problematic_keywords/expected_output/dummy/jsonization.cs
@@ -200,6 +200,132 @@ namespace dummy
             }
 
             /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonClassItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : class;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte array
+            /// or a class instance).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfClass<T>(
+                Nodes.JsonArray array,
+                JsonClassItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : class
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a single array item.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed item</typeparam>
+            private delegate T? JsonStructItemDeserializer<T>(
+                Nodes.JsonNode node,
+                out Reporting.Error? error
+                ) where T : struct;
+
+            /// <summary>
+            /// Parse every item of <paramref name="array" /> with
+            /// <paramref name="deserializeItem" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed constructor arguments whose items are
+            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
+            /// an enumeration literal).
+            /// </remarks>
+            /// <typeparam name="T">Type of a single array item</typeparam>
+            private static List<T> ParseArrayOfStruct<T>(
+                Nodes.JsonArray array,
+                JsonStructItemDeserializer<T> deserializeItem,
+                out Reporting.Error? error
+                ) where T : struct
+            {
+                error = null;
+                List<T> result = new List<T>(array.Count);
+
+                int index = 0;
+                foreach (Nodes.JsonNode? item in array)
+                {
+                    if (item == null)
+                    {
+                        error = new Reporting.Error(
+                            "Expected a non-null item, but got a null");
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    T? parsedItem = deserializeItem(
+                        item ?? throw new System.InvalidOperationException(),
+                        out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(
+                        parsedItem
+                            ?? throw new System.InvalidOperationException(
+                                "Unexpected result null when error is null"));
+
+                    index++;
+                }
+
+                return result;
+            }
+
+            /// <summary>
             /// Deserialize an instance of Something from <paramref name="node" />.
             /// </summary>
             /// <param name="node">JSON node to be parsed</param>
@@ -470,6 +596,27 @@ namespace dummy
                         $"The number can not be losslessly represented in JSON: {that}");
                 }
                 return Nodes.JsonValue.Create(that);
+            }
+
+            /// <summary>
+            /// Serialize every item of <paramref name="items" /> with
+            /// <paramref name="serializeItem" /> into a JSON array.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the list-typed properties.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static Nodes.JsonArray SerializeArray<T>(
+                IEnumerable<T> items,
+                System.Func<T, Nodes.JsonNode?> serializeItem)
+            {
+                var result = new Nodes.JsonArray();
+                foreach (T item in items)
+                {
+                    result.Add(
+                        serializeItem(item));
+                }
+                return result;
             }
 
             public override Nodes.JsonObject TransformSomething(

--- a/dev/test_data/main/csharp/expected/problematic_keywords/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/problematic_keywords/expected_output/dummy/xmlization.cs
@@ -1115,45 +1115,61 @@ namespace dummy
         internal class VisitorWithWriter
             : Visitation.AbstractVisitorWithContext<Xml.XmlWriter>
         {
+            /// <summary>
+            /// Write the content of a property, positioned between its start and end tag.
+            /// </summary>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private delegate void ElementContentSerializer<T>(
+                T that, Xml.XmlWriter writer);
+
+            /// <summary>
+            /// Serialize <paramref name="that" /> as an XML element with
+            /// the given <paramref name="name" />, delegating the content in-between the
+            /// start and the end tag to <paramref name="serializeContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by all the property kinds (primitive, enumeration, class,
+            /// interface, list) as they all wrap their content in exactly the same way.
+            /// </remarks>
+            /// <typeparam name="T">Type of the property value</typeparam>
+            private static void SerializeElement<T>(
+                string name,
+                T that,
+                Xml.XmlWriter writer,
+                ElementContentSerializer<T> serializeContent)
+            {
+                writer.WriteStartElement(name, NS);
+                serializeContent(that, writer);
+                writer.WriteEndElement();
+            }
+
             private void SomethingToSequence(
                 Aas.ISomething that,
                 Xml.XmlWriter writer)
             {
-                writer.WriteStartElement(
+                SerializeElement(
                     "interface",
-                    NS);
+                    that.Interface,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Interface);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "type",
-                    NS);
+                    that.Type,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Type);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "range",
-                    NS);
+                    that.Range,
+                    writer,
+                    (value, w) => w.WriteValue(value));
 
-                writer.WriteValue(
-                    that.Range);
-
-                writer.WriteEndElement();
-
-                writer.WriteStartElement(
+                SerializeElement(
                     "void",
-                    NS);
-
-                writer.WriteValue(
-                    that.Void);
-
-                writer.WriteEndElement();
+                    that.Void,
+                    writer,
+                    (value, w) => w.WriteValue(value));
             }  // private void SomethingToSequence
 
             public override void VisitSomething(


### PR DESCRIPTION
We factor out a generic ``SerializeElement`` helper for XML serialization, and add ``ParseArrayOfClass``/``ParseArrayOfStruct`` plus ``SerializeArray`` generic helpers for JSON lists, replacing per-property inlined boilerplate with shared calls.