### PR TITLE
Simplify JSON and XML de/serialization in Java

### DIFF
--- a/aas_core_codegen/java/lib/_generate_jsonization.py
+++ b/aas_core_codegen/java/lib/_generate_jsonization.py
@@ -45,17 +45,17 @@ def _generate_from_method_for_enumeration(
  *
  * @param node JSON node to be parsed
  */
-private static _Result<{name}> try{name}From(JsonNode node) {{
-{I}final _Result<String> textResult = tryStringFrom(node);
+private static Reporting.Result<{name}> try{name}From(JsonNode node) {{
+{I}final Reporting.Result<String> textResult = tryStringFrom(node);
 {I}if (textResult.isError()) {{
 {II}return textResult.castTo({name}.class);
 {I}}}
 {I}final Optional<{name}> {var_name} = Stringification.{method_name}(textResult.getResult());
 {I}if (!{var_name}.isPresent()) {{
 {II}final Reporting.Error error = new Reporting.Error({message_literal});
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}return _Result.success({var_name}.get());
+{I}return Reporting.Result.success({var_name}.get());
 }}"""
     )
 
@@ -73,16 +73,16 @@ def _generate_from_method_for_interface(
 if (node == null || !node.isObject()) {{
 {I}final Reporting.Error error = new Reporting.Error(
 {II}"Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
 
 final JsonNode modelTypeNode = node.get("modelType");
 if (modelTypeNode == null) {{
 {I}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a model type, but none is present");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
-final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
 if (modelTypeResult.isError()) {{
 {I}return modelTypeResult.castTo({interface_name}.class);
 }}"""
@@ -114,7 +114,7 @@ switch (modelTypeResult.getResult())
 {I}default: {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Unexpected model type for {name}: " + modelTypeResult.getResult());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 }}"""
     )
@@ -132,7 +132,7 @@ switch (modelTypeResult.getResult())
  *
  * @param node JSON node to be parsed
  */
-public static _Result<? extends {name}> try{name}From(JsonNode node) {{
+public static Reporting.Result<? extends {name}> try{name}From(JsonNode node) {{
 """
     )
 
@@ -223,7 +223,7 @@ def _generate_deserialize_constructor_argument(
 
         parse_block = Stripped(
             f"""\
-final _Result<? extends {value_type}> {target_var}Result = {parse_method}(currentNode.getValue());
+final Reporting.Result<? extends {value_type}> {target_var}Result = {parse_method}(currentNode.getValue());
 if ({target_var}Result.isError()) {{
 {I}{target_var}Result.getError()
 {II}.prependSegment(new Reporting.NameSegment("{json_name}"));
@@ -247,7 +247,6 @@ if ({target_var}Result.isError()) {{
         item_type = java_common.generate_type(type_anno.items)
 
         array_var = java_naming.variable_name(Identifier(f"array_{arg.name}"))
-        index_var = java_naming.variable_name(Identifier(f"index_{arg.name}"))
 
         cls_name = java_naming.class_name(cls.name)
 
@@ -262,42 +261,19 @@ if (!{array_var}.isArray()) {{
 {I}error.prependSegment(
 {II}new Reporting.NameSegment(
 {III}{json_literal}));
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
-{target_var} = new ArrayList<>(
-{I}{array_var}.size());
-int {index_var} = 0;
-for (JsonNode item : {array_var}) {{
-{I}if (item == null) {{
-{II}final Reporting.Error error = new Reporting.Error(
-{III}"Expected a non-null item, but got a null");
-{II}error.prependSegment(
-{III}new Reporting.IndexSegment(
-{IIII}{index_var}));
-{II}error.prependSegment(
+final Reporting.Result<List<{item_type}>> {target_var}Result = parseArray(
+{I}{array_var},
+{I}_DeserializeImplementation::{parse_method});
+if ({target_var}Result.isError()) {{
+{I}{target_var}Result.getError()
+{II}.prependSegment(
 {III}new Reporting.NameSegment(
 {IIII}{json_literal}));
-{II}return _Result.failure(error);
-{I}}}
-{I}final _Result<? extends {item_type}> parsedItemResult =
-{II}{parse_method}(item);
-{I}if (parsedItemResult.isError()) {{
-{II}parsedItemResult
-{III}.getError()
-{III}.prependSegment(
-{III}new Reporting.IndexSegment(
-{IIII}{index_var}));
-{II}parsedItemResult
-{III}.getError()
-{III}.prependSegment(
-{III}new Reporting.NameSegment(
-{IIII}{json_literal}));
-{II}return parsedItemResult.castTo({cls_name}.class);
-{I}}}
-{I}{target_var}.add(
-{II}parsedItemResult.getResult());
-{I}{index_var}++;
-}}"""
+{I}return {target_var}Result.castTo({cls_name}.class);
+}}
+{target_var} = {target_var}Result.getResult();"""
         )
     else:
         assert_never(arg.type_annotation)
@@ -320,7 +296,7 @@ def _generate_from_method_for_class(
 if (node == null || !node.isObject()) {{
 {I}final Reporting.Error error = new Reporting.Error(
 {II}"Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}"""
         ),
     ]  # type: List[Stripped]
@@ -388,9 +364,9 @@ case "modelType": {{
 {I}if (currentNode.getValue() == null) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a model type, but got null");
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}final _Result<? extends String> modelTypeResult =
+{I}final Reporting.Result<? extends String> modelTypeResult =
 {II}_DeserializeImplementation.tryStringFrom(currentNode.getValue());
 {I}if (modelTypeResult.isError()) {{
 {II}modelTypeResult.getError()
@@ -404,7 +380,7 @@ case "modelType": {{
 {III}"Expected the model type '{model_type}', " +
 {III}"but got '" + modelType + "'");
 {III}error.prependSegment(new Reporting.NameSegment("modelType"));
-{III}return _Result.failure(error);
+{III}return Reporting.Result.failure(error);
 {I}}}
 {I}break;
 }}"""
@@ -417,7 +393,7 @@ case "modelType": {{
 default: {{
 {I}final Reporting.Error error = new Reporting.Error(
 {II}"Unexpected property: " + currentNode.getKey());
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}"""
         )
     )
@@ -450,7 +426,7 @@ for (Iterator<Map.Entry<String, JsonNode>> iterator = node.fields(); iterator.ha
 if (modelType == null) {{
 {I}final Reporting.Error error = new Reporting.Error(
 {II}"Required property \\"modelType\\" is missing");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}"""
             )
         )
@@ -472,7 +448,7 @@ if (modelType == null) {{
 if ({arg_var} == null) {{
 {I}final Reporting.Error error = new Reporting.Error(
 {II}"Required property \\\"{json_name}\\\" is missing");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}"""
         )
 
@@ -497,10 +473,10 @@ if ({arg_var} == null) {{
     # fmt: on
 
     if len(cls.constructor.arguments) == 0:
-        blocks.append(Stripped(f"return _Result.success(new {name}());"))
+        blocks.append(Stripped(f"return Reporting.Result.success(new {name}());"))
     else:
         init_writer = io.StringIO()
-        init_writer.write(f"return _Result.success(new {name}(\n")
+        init_writer.write(f"return Reporting.Result.success(new {name}(\n")
 
         for i, arg in enumerate(cls.constructor.arguments):
             prop = cls.properties_by_name[arg.name]
@@ -561,7 +537,7 @@ if ({arg_var} == null) {{
  * @param node JSON node to be parsed
  * @param elem Error, if any, during the deserialization
  */
-private static _Result<{name}> try{name}From(JsonNode node) {{
+private static Reporting.Result<{name}> try{name}From(JsonNode node) {{
 """
     )
 
@@ -588,13 +564,13 @@ def _generate_deserialize_impl(
 /** Convert {{@code value}} to a string.
  * @param node JSON node to be parsed
  */
-private static _Result<String> tryStringFrom(JsonNode value) {{
+private static Reporting.Result<String> tryStringFrom(JsonNode value) {{
 {I}if (!value.isTextual()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a JsonValue of String, but got " + value.getNodeType());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}return _Result.success(value.asText());
+{I}return Reporting.Result.success(value.asText());
 }}"""
         ),
         Stripped(
@@ -602,13 +578,13 @@ private static _Result<String> tryStringFrom(JsonNode value) {{
 /** Convert {{@code value}} to a boolean.
  * @param node JSON node to be parsed
  */
-private static _Result<Boolean> tryBooleanFrom(JsonNode value) {{
+private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {{
 {I}if (!value.isBoolean()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a JsonValue of Boolean, but got " + value.getNodeType());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}return _Result.success(value.asBoolean());
+{I}return Reporting.Result.success(value.asBoolean());
 }}"""
         ),
         Stripped(
@@ -616,13 +592,13 @@ private static _Result<Boolean> tryBooleanFrom(JsonNode value) {{
 /** Convert {{@code value}} to a long 64-bit integer.
  * @param node JSON node to be parsed
  */
-private static _Result<Long> tryLongFrom(JsonNode value) {{
+private static Reporting.Result<Long> tryLongFrom(JsonNode value) {{
 {I}if (!value.isIntegralNumber()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a JsonValue of Long, but got " + value.getNodeType());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}return _Result.success(value.asLong());
+{I}return Reporting.Result.success(value.asLong());
 }}"""
         ),
         Stripped(
@@ -630,22 +606,22 @@ private static _Result<Long> tryLongFrom(JsonNode value) {{
 /** Convert {{@code value}} to a double-precision 64-bit float.
  * @param node JSON node to be parsed
  */
-private static _Result<Double> tryDoubleFrom(JsonNode value) {{
+private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {{
 {I}if (!value.isFloatingPointNumber()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a JsonValue of Double, but got " + value.getNodeType());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}return _Result.success(value.asDouble());
+{I}return Reporting.Result.success(value.asDouble());
 }}"""
         ),
         Stripped(
             f"""\
-private static _Result<byte[]> tryBytesFrom(JsonNode value) {{
+private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {{
 {I}if (!value.isTextual()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a JsonValue of String, but got " + value.getNodeType());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 {I}final byte[] decodedData;
 {I}Base64.Decoder decoder = Base64.getDecoder();
@@ -656,10 +632,47 @@ private static _Result<byte[]> tryBytesFrom(JsonNode value) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected Base-64 encoded bytes, but the conversion failed " +
 {IIII}"because: " + exception.getMessage());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
-{I}return _Result.success(decodedData);
+{I}return Reporting.Result.success(decodedData);
+}}"""
+        ),
+        Stripped(
+            f"""\
+/**
+ * Parse every item of {{@code array}} with {{@code parseItem}}.
+ *
+ * @param array JSON array to be parsed
+ * @param parseItem to parse a single item of the array
+ */
+private static <T> Reporting.Result<List<T>> parseArray(
+{I}JsonNode array,
+{I}Function<JsonNode, Reporting.Result<? extends T>> parseItem) {{
+{I}final List<T> result = new ArrayList<>(array.size());
+{I}int index = 0;
+{I}for (JsonNode item : array) {{
+{II}if (item == null) {{
+{III}final Reporting.Error error = new Reporting.Error(
+{IIII}"Expected a non-null item, but got a null");
+{III}error.prependSegment(
+{IIII}new Reporting.IndexSegment(index));
+{III}return Reporting.Result.failure(error);
+{II}}}
+
+{II}final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+{II}if (parsedItemResult.isError()) {{
+{III}parsedItemResult.getError()
+{IIII}.prependSegment(
+{IIII}new Reporting.IndexSegment(index));
+{III}return Reporting.Result.failure(parsedItemResult.getError());
+{II}}}
+
+{II}result.add(parsedItemResult.getResult());
+{II}index++;
+{I}}}
+
+{I}return Reporting.Result.success(result);
 }}"""
         ),
     ]  # type: List[Stripped]
@@ -760,7 +773,7 @@ def _generate_deserialize_from(name: str) -> Stripped:
     writer.write(
         f"""\
 public static {name} deserialize{name}(JsonNode node) {{
-{I}final _Result<? extends {name}> result =
+{I}final Reporting.Result<? extends {name}> result =
 {II}_DeserializeImplementation.try{name}From(
 {III}node);
 
@@ -904,9 +917,8 @@ _Transformer.toJsonNode(
         # We can not use textwrap due to indent_but_first_line.
         return Stripped(
             f"""\
-JsonNodeFactory.instance.textNode(
-{II}Base64.getEncoder()
-{III}.encodeToString({indent_but_first_line(source_expr, II)}))"""
+_Transformer.bytesToJsonNode(
+{I}{indent_but_first_line(source_expr, I)})"""
         )
     else:
         assert_never(primitive_type)
@@ -1016,11 +1028,10 @@ def _generate_transform_property(
         stmts.append(
             Stripped(
                 f"""\
-final ArrayNode {array_var} = JsonNodeFactory.instance.arrayNode();
-for ({item_type} item : {source_expr}) {{
-{I}{array_var}.add(
+final ArrayNode {array_var} = serializeArray(
+{I}{source_expr},
+{I}({item_type} item) ->
 {II}{indent_but_first_line(item_conversion_expr, II)});
-}}
 result.set({prop_literal}, {array_var});"""
             )
         )
@@ -1120,6 +1131,38 @@ private static JsonNode toJsonNode(Long that) {{
 {I}return JsonNodeFactory.instance.numberNode(that);
 }}"""
         ),
+        Stripped(
+            f"""\
+/**
+ * Convert {{@code that}} byte array to a JSON value.
+ *
+ * @param that value to be converted
+ */
+private static JsonNode bytesToJsonNode(byte[] that) {{
+{I}return JsonNodeFactory.instance.textNode(
+{II}Base64.getEncoder().encodeToString(that));
+}}"""
+        ),
+        Stripped(
+            f"""\
+/**
+ * Serialize every item of {{@code items}} with {{@code serializeItem}} into
+ * a JSON array.
+ *
+ * @param items to be serialized
+ * @param serializeItem to serialize a single item of {{@code items}}
+ */
+private static <T> ArrayNode serializeArray(
+{I}Iterable<T> items,
+{I}Function<T, JsonNode> serializeItem) {{
+{I}final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+{I}for (T item : items) {{
+{II}result.add(
+{III}serializeItem.apply(item));
+{I}}}
+{I}return result;
+}}"""
+        ),
     ]  # type: List[Stripped]
 
     for our_type in symbol_table.our_types:
@@ -1210,12 +1253,7 @@ public static JsonNode toJsonObject(IClass that) {{
  * Serialize a literal of {name} into a JSON string.
  */
 public static JsonNode {method_name}({name} that) {{
-{I}Optional<String> text = Stringification.toString(that);
-{I}if (!text.isPresent()) {{
-{II}throw new IllegalArgumentException("Invalid {name}: " + that);
-{I}}}
-
-{I}return JsonNodeFactory.instance.textNode(text.get());
+{I}return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
 }}"""
             )
         )
@@ -1355,70 +1393,9 @@ def generate(
 {I}}}"""
     )
 
-    result_block = Stripped(
-        f"""\
-private static class _Result<T> {{
-{I}private final T result;
-{I}private final Reporting.Error error;
-{I}private final boolean success;
-
-{I}private _Result(T result, Reporting.Error error, boolean success) {{
-{II}this.result = result;
-{II}this.error = error;
-{II}this.success = success;
-{I}}}
-
-{I}public static <T> _Result<T> success(T result) {{
-{II}if (result == null) throw new IllegalArgumentException("Result must not be null.");
-{II}return new _Result<>(result, null, true);
-{I}}}
-
-{I}public static <T> _Result<T> failure(Reporting.Error error) {{
-{II}if (error == null) throw new IllegalArgumentException("Error must not be null.");
-{II}return new _Result<>(null, error, false);
-{I}}}
-
-{I}@SuppressWarnings("unchecked")
-{I}public <I> _Result<I> castTo(Class<I> type) {{
-{II}if (isError() || type.isInstance(result)) return (_Result<I>) this;
-{II}throw new IllegalStateException("Result of type "
-{III}+ result.getClass().getName()
-{III}+ " is not an instance of "
-{III}+ type.getName());
-{I}}}
-
-{I}public T getResult() {{
-{II}if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-{II}return result;
-{I}}}
-
-{I}public boolean isSuccess() {{
-{II}return success;
-{I}}}
-
-{I}public boolean isError() {{
-{II}return !success;
-{I}}}
-
-{I}public Reporting.Error getError() {{
-{II}if (isSuccess()) throw new IllegalStateException("Result is present.");
-{II}return error;
-{I}}}
-
-{I}public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {{
-{II}return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-{I}}}
-
-{I}public T onError(Function<Reporting.Error, T> errorFunction) {{
-{II}return map(Function.identity(), errorFunction);
-{I}}}
-}}"""
-    )
-
     jsonization_blocks = [
         deserialize_impl_block,
         exception_block,
-        result_block,
         deserialize_block,
         transformer_block,
         serialize_block,

--- a/aas_core_codegen/java/lib/_generate_reporting.py
+++ b/aas_core_codegen/java/lib/_generate_reporting.py
@@ -184,6 +184,72 @@ public static class Error {{
 {I}}}
 }}"""
         ),
+        Stripped(
+            f"""\
+/**
+ * Represent the outcome of a de/serialization or a verification step.
+ *
+ * <p>This is shared by JSON de/serialization, XML de/serialization and
+ * verification, all of which propagate an {{@link Error}} instead of relying
+ * on exceptions for the common (successful) case.
+ */
+public static class Result<T> {{
+{I}private final T result;
+{I}private final Error error;
+{I}private final boolean success;
+
+{I}private Result(T result, Error error, boolean success) {{
+{II}this.result = result;
+{II}this.error = error;
+{II}this.success = success;
+{I}}}
+
+{I}public static <T> Result<T> success(T result) {{
+{II}if (result == null) throw new IllegalArgumentException("Result must not be null.");
+{II}return new Result<>(result, null, true);
+{I}}}
+
+{I}public static <T> Result<T> failure(Error error) {{
+{II}if (error == null) throw new IllegalArgumentException("Error must not be null.");
+{II}return new Result<>(null, error, false);
+{I}}}
+
+{I}@SuppressWarnings("unchecked")
+{I}public <I> Result<I> castTo(Class<I> type) {{
+{II}if (isError() || type.isInstance(result)) return (Result<I>) this;
+{II}throw new IllegalStateException("Result of type "
+{III}+ result.getClass().getName()
+{III}+ " is not an instance of "
+{III}+ type.getName());
+{I}}}
+
+{I}public T getResult() {{
+{II}if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+{II}return result;
+{I}}}
+
+{I}public boolean isSuccess() {{
+{II}return success;
+{I}}}
+
+{I}public boolean isError() {{
+{II}return !success;
+{I}}}
+
+{I}public Error getError() {{
+{II}if (isSuccess()) throw new IllegalStateException("Result is present.");
+{II}return error;
+{I}}}
+
+{I}public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {{
+{II}return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+{I}}}
+
+{I}public T onError(Function<Error, T> errorFunction) {{
+{II}return map(Function.identity(), errorFunction);
+{I}}}
+}}"""
+        ),
     ]  # type: List[Stripped]
 
     writer = io.StringIO()
@@ -198,6 +264,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/aas_core_codegen/java/lib/_generate_stringification.py
+++ b/aas_core_codegen/java/lib/_generate_stringification.py
@@ -91,6 +91,31 @@ public static Optional<String> {to_str_name}({name} that)
 
     # endregion
 
+    # region Must-to-string-method
+
+    must_to_str_name = java_naming.method_name(Identifier("must_to_string"))
+
+    blocks.append(
+        Stripped(
+            f"""\
+/**
+ * Retrieve the string representation of {{@code that}}.
+ *
+ * @throws IllegalArgumentException if {{@code that}} is not a valid literal
+ */
+public static String {must_to_str_name}({name} that)
+{{
+{I}final Optional<String> text = {to_str_name}(that);
+{I}if (!text.isPresent()) {{
+{II}throw new IllegalArgumentException("Invalid literal of {name}: " + that);
+{I}}}
+{I}return text.get();
+}}"""
+        )
+    )
+
+    # endregion
+
     # region From-string-map
 
     string_to_enum_blocks = []  # type: List[Stripped]

--- a/aas_core_codegen/java/lib/_generate_xmlization.py
+++ b/aas_core_codegen/java/lib/_generate_xmlization.py
@@ -31,67 +31,6 @@ from aas_core_codegen.java.common import (
 # region Generate
 
 
-def _generate_result() -> Stripped:
-    """Generate the class to represent XML de/serialize results."""
-    return Stripped(
-        f"""\
-private static class _Result<T> {{
-{I}private final T result;
-{I}private final Reporting.Error error;
-{I}private final boolean success;
-
-{I}private _Result(T result, Reporting.Error error, boolean success) {{
-{II}this.result = result;
-{II}this.error = error;
-{II}this.success = success;
-{I}}}
-
-{I}public static <T> _Result<T> success(T result) {{
-{II}if(result == null) throw new IllegalArgumentException("Result must not be null.");
-{II}return new _Result<>(result, null, true);
-{I}}}
-
-{I}public static <T> _Result<T> failure(Reporting.Error error) {{
-{II}if(error == null) throw new IllegalArgumentException("Error must not be null.");
-{II}return new _Result<>(null, error, false);
-{I}}}
-
-{I}@SuppressWarnings("unchecked")
-{I}public <I> _Result<I> castTo(Class<I> type){{
-{II}if(isError() || type.isInstance(result)) return (_Result<I>) this;
-{II}throw new IllegalStateException("Result of type "
-{III}+ result.getClass().getName()
-{III}+ " is not an instance of "
-{III}+ type.getName());
-{I}}}
-
-{I}public T getResult() {{
-{II}if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-{II}return result;
-{I}}}
-
-{I}public boolean isSuccess() {{
-{II}return success;
-{I}}}
-
-{I}public boolean isError(){{return !success;}}
-
-{I}public Reporting.Error getError() {{
-{II}if (isSuccess()) throw new IllegalStateException("Result is present.");
-{II}return error;
-{I}}}
-
-{I}public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {{
-{II}return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-{I}}}
-
-{I}public T onError(Function<Reporting.Error, T>  errorFunction){{
-{II}return map(Function.identity(), errorFunction);
-{I}}}
-}}"""
-    )
-
-
 def _generate_current_event() -> Stripped:
     """Generate the function to a single XML event."""
 
@@ -206,21 +145,21 @@ def _generate_try_v_start_element() -> Stripped:
  * Consume a {{@code <v>}} element from the reader and return whether
  * it was a self-closing (empty) element.
  */
-private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {{
+private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {{
 {I}if (currentEvent(reader).isEndDocument()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a <v> element, but got an end-of-file.");
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}if (!currentEvent(reader).isStartElement()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a <v> start element, but got the node of type "
 {IIII}+ getEventTypeAsString(currentEvent(reader)));
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
-{I}final _Result<String> tryElementName = tryElementName(reader);
+{I}final Reporting.Result<String> tryElementName = tryElementName(reader);
 {I}if (tryElementName.isError()) {{
 {II}return tryElementName.castTo(Boolean.class);
 {I}}}
@@ -228,11 +167,11 @@ private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {{
 {I}if (!"v".equals(tryElementName.getResult())) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a <v> element, but got an element " + tryElementName.getResult());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}final boolean isEmpty = isEmptyElement(reader);
-{I}return _Result.success(isEmpty);
+{I}return Reporting.Result.success(isEmpty);
 }}"""
     )
 
@@ -244,23 +183,23 @@ def _generate_try_v_end_element() -> Stripped:
 /**
  * Consume a {{@code </v>}} element from the reader.
  */
-private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {{
+private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {{
 {I}skipWhitespaceAndComments(reader);
 
 {I}if (currentEvent(reader).isEndDocument()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a </v> element, but got an end-of-file.");
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}if (!currentEvent(reader).isEndElement()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a </v> end element, but got the node of type "
 {IIII}+ getEventTypeAsString(currentEvent(reader)));
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
-{I}final _Result<String> tryElementName = tryElementName(reader);
+{I}final Reporting.Result<String> tryElementName = tryElementName(reader);
 {I}if (tryElementName.isError()) {{
 {II}return tryElementName.castTo(XMLEvent.class);
 {I}}}
@@ -268,11 +207,11 @@ private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {{
 {I}if (!"v".equals(tryElementName.getResult())) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected a </v> element, but got an end element " + tryElementName.getResult());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}try {{
-{II}return _Result.success(reader.nextEvent());
+{II}return Reporting.Result.success(reader.nextEvent());
 {I}}} catch (XMLStreamException xmlStreamException) {{
 {II}throw new Xmlization.DeserializeException("",
 {III}"Failed in method tryVEndElement because of: " +
@@ -297,8 +236,8 @@ def _generate_try_v_element_as_primitive_functions() -> List[Stripped]:
 /**
  * Read the content of a {{@code <v>}} element and parse it as {result_type}.
  */
-private static _Result<{result_type}> {function_name}(XMLEventReader reader) {{
-{I}final _Result<Boolean> tryVStart = tryVStartElement(reader);
+private static Reporting.Result<{result_type}> {function_name}(XMLEventReader reader) {{
+{I}final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
 {I}if (tryVStart.isError()) {{
 {II}return tryVStart.castTo({result_type}.class);
 {I}}}
@@ -307,7 +246,7 @@ private static _Result<{result_type}> {function_name}(XMLEventReader reader) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"Expected an XML content representing {result_type}, " +
 {III}"but got a self-closing <v /> element");
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}final {result_type} result;
@@ -317,15 +256,15 @@ private static _Result<{result_type}> {function_name}(XMLEventReader reader) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"The content of a <v> element could not be de-serialized " +
 {III}"as {result_type}: " + exception.getMessage());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
-{I}final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+{I}final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
 {I}if (tryVEnd.isError()) {{
 {II}return tryVEnd.castTo({result_type}.class);
 {I}}}
 
-{I}return _Result.success(result);
+{I}return Reporting.Result.success(result);
 }}"""
             )
         )
@@ -337,8 +276,8 @@ private static _Result<{result_type}> {function_name}(XMLEventReader reader) {{
 /**
  * Read the content of a {{@code <v>}} element and parse it as a string.
  */
-private static _Result<String> tryVElementAsString(XMLEventReader reader) {{
-{I}final _Result<Boolean> tryVStart = tryVStartElement(reader);
+private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {{
+{I}final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
 {I}if (tryVStart.isError()) {{
 {II}return tryVStart.castTo(String.class);
 {I}}}
@@ -353,7 +292,7 @@ private static _Result<String> tryVElementAsString(XMLEventReader reader) {{
 {III}final Reporting.Error error = new Reporting.Error(
 {IIII}"The content of a <v> element could not be de-serialized " +
 {IIII}"as String: " + exception.getMessage());
-{III}return _Result.failure(error);
+{III}return Reporting.Result.failure(error);
 {II}}}
 {I}}}
 
@@ -361,12 +300,12 @@ private static _Result<String> tryVElementAsString(XMLEventReader reader) {{
 {I}// A self-closing <v /> is represented as a pair of start and end events
 {I}// in StAX, so we need to consume the end element even if the <v /> was
 {I}// empty.
-{I}final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+{I}final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
 {I}if (tryVEnd.isError()) {{
 {II}return tryVEnd.castTo(String.class);
 {I}}}
 
-{I}return _Result.success(result);
+{I}return Reporting.Result.success(result);
 }}"""
         )
     )
@@ -378,8 +317,8 @@ private static _Result<String> tryVElementAsString(XMLEventReader reader) {{
 /**
  * Read a {{@code <v>}} element as base64-encoded bytes.
  */
-private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {{
-{I}final _Result<Boolean> tryVStart = tryVStartElement(reader);
+private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {{
+{I}final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
 {I}if (tryVStart.isError()) {{
 {II}return tryVStart.castTo(byte[].class);
 {I}}}
@@ -394,7 +333,7 @@ private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {{
 {III}final Reporting.Error error = new Reporting.Error(
 {IIII}"The content of a <v> element could not be de-serialized " +
 {IIII}"as base64-encoded bytes: " + exception.getMessage());
-{III}return _Result.failure(error);
+{III}return Reporting.Result.failure(error);
 {II}}}
 {I}}}
 
@@ -402,12 +341,12 @@ private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {{
 {I}// A self-closing <v /> is represented as a pair of start and end events
 {I}// in StAX, so we need to consume the end element even if the <v /> was
 {I}// empty.
-{I}final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+{I}final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
 {I}if (tryVEnd.isError()) {{
 {II}return tryVEnd.castTo(byte[].class);
 {I}}}
 
-{I}return _Result.success(result);
+{I}return Reporting.Result.success(result);
 }}"""
         )
     )
@@ -430,8 +369,8 @@ def _generate_try_v_element_as_enumeration(
  * Read a {{@code <v>}} element and parse its content as a literal
  * of {{@link {enum_name}}}.
  */
-private static _Result<{enum_name}> tryVElementAs{enum_name}(XMLEventReader reader) {{
-{I}final _Result<String> tryText = tryVElementAsString(reader);
+private static Reporting.Result<{enum_name}> tryVElementAs{enum_name}(XMLEventReader reader) {{
+{I}final Reporting.Result<String> tryText = tryVElementAsString(reader);
 {I}if (tryText.isError()) {{
 {II}return tryText.castTo({enum_name}.class);
 {I}}}
@@ -443,10 +382,10 @@ private static _Result<{enum_name}> tryVElementAs{enum_name}(XMLEventReader read
 {II}final Reporting.Error error = new Reporting.Error(
 {III}"The text could not be parsed as a literal of {enum_name}: " +
 {III}tryText.getResult());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
-{I}return _Result.success(result.get());
+{I}return Reporting.Result.success(result.get());
 }}"""
     )
 
@@ -461,14 +400,14 @@ def _generate_parse_list() -> Stripped:
  * <p>Every start element is considered to mark the start of an item. Parsing
  * stops as soon as a non-start element is encountered.
  */
-private static <T> _Result<List<T>> parseList(
+private static <T> Reporting.Result<List<T>> parseList(
 {I}XMLEventReader reader,
 {I}boolean isEmptyProperty,
 {I}Class<T> itemType,
-{I}Function<XMLEventReader, _Result<? extends T>> parseItem) {{
+{I}Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {{
 {I}final List<T> result = new ArrayList<>();
 {I}if (isEmptyProperty) {{
-{II}return _Result.success(result);
+{II}return Reporting.Result.success(result);
 {I}}}
 
 {I}skipWhitespaceAndComments(reader);
@@ -478,16 +417,16 @@ private static <T> _Result<List<T>> parseList(
 {III}"Expected a start element opening an instance of " + itemType.getSimpleName() +
 {IIII}", but got an XML " + getEventTypeAsString(currentEvent(reader)));
 {II}error.prependSegment(new Reporting.IndexSegment(index));
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}while (currentEvent(reader).isStartElement()) {{
-{II}final _Result<? extends T> itemResult = parseItem.apply(reader);
+{II}final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
 {II}if (itemResult.isError()) {{
 {III}itemResult.getError()
 {IIII}.prependSegment(
 {IIIII}new Reporting.IndexSegment(index));
-{III}return _Result.failure(itemResult.getError());
+{III}return Reporting.Result.failure(itemResult.getError());
 {II}}}
 
 {II}result.add(itemResult.getResult());
@@ -495,7 +434,7 @@ private static <T> _Result<List<T>> parseList(
 {II}skipWhitespaceAndComments(reader);
 {I}}}
 
-{I}return _Result.success(result);
+{I}return Reporting.Result.success(result);
 }}"""
     )
 
@@ -593,7 +532,7 @@ final Reporting.Error error = new Reporting.Error(
 error.prependSegment(
 {I}new Reporting.NameSegment(
 {II}{xml_prop_name_literal}));
-return _Result.failure(error);"""
+return Reporting.Result.failure(error);"""
         )
 
     return Stripped(
@@ -607,7 +546,7 @@ else {{
 {III}"Expected an XML content representing " +
 {III}"the property {prop_name} of an instance of class {cls_name}, " +
 {III}"but reached the end-of-file");
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}try {{
@@ -619,7 +558,7 @@ else {{
 {II}error.prependSegment(
 {III}new Reporting.NameSegment(
 {IIII}"{prop_name}"));
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 }}"""
     )
@@ -676,7 +615,7 @@ private static boolean invalidNameSpace(XMLEvent event) {{
 /**
  * Check the namespace and extract the element's name.
  */
-private static _Result<String> tryElementName(XMLEventReader reader) {{
+private static Reporting.Result<String> tryElementName(XMLEventReader reader) {{
 {I}final XMLEvent currentEvent = currentEvent(reader);
 {I}final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
 {I}if (!precondition) {{
@@ -691,9 +630,9 @@ private static _Result<String> tryElementName(XMLEventReader reader) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {IIII}"Expected an element within a namespace " +
 {IIII}AAS_NAME_SPACE + ", " + "but got: " + namespace);
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}return _Result.success(currentEvent.isStartElement()
+{I}return Reporting.Result.success(currentEvent.isStartElement()
 {III}? currentEvent.asStartElement().getName().getLocalPart()
 {III}: currentEvent.asEndElement().getName().getLocalPart());
 }}"""
@@ -703,17 +642,17 @@ private static _Result<String> tryElementName(XMLEventReader reader) {{
 def _generate_verify_closing_tag_for_class() -> Stripped:
     return Stripped(
         f"""\
-private static _Result<XMLEvent> verifyClosingTagForClass(
+private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
 {I}String className,
 {I}XMLEventReader reader,
-{I}_Result<String> tryElementName) {{
+{I}Reporting.Result<String> tryElementName) {{
 {I}final XMLEvent currentEvent = currentEvent(reader);
 {I}if (currentEvent.isEndDocument()) {{
 {II}final Reporting.Error error = new Reporting.Error(
 {IIII}"Expected an XML end element to conclude a property of class " + className
 {IIIIII}+ " with the element name " + tryElementName.getResult() + ", "
 {IIIIII}+ "but got the end-of-file.");
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
 {I}if (!currentEvent.isEndElement()) {{
@@ -722,9 +661,9 @@ private static _Result<XMLEvent> verifyClosingTagForClass(
 {IIIIII}+ " with the element name " + tryElementName.getResult() + ", "
 {IIIIII}+ "but got the node of type " + getEventTypeAsString(currentEvent)
 {IIIIII}+ " with the value " + currentEvent);
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
-{I}final _Result<String> tryEndElementName = tryElementName(reader);
+{I}final Reporting.Result<String> tryEndElementName = tryElementName(reader);
 {I}if (tryEndElementName.isError()) {{
 {II}return tryEndElementName.castTo(XMLEvent.class);
 {I}}}
@@ -733,10 +672,10 @@ private static _Result<XMLEvent> verifyClosingTagForClass(
 {IIII}"Expected an XML end element to conclude a property of class " + className
 {IIIIII}+ " with the element name " + tryElementName.getResult() + ", "
 {IIIIII}+ "but got the end element with the name " + tryEndElementName.getResult());
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 {I}try {{
-{II}return _Result.success(reader.nextEvent());
+{II}return Reporting.Result.success(reader.nextEvent());
 {I}}} catch (XMLStreamException xmlStreamException) {{
 {II}throw new Xmlization.DeserializeException("",
 {III}"Failed in method verifyClosingTagForClass because of: " +
@@ -757,45 +696,45 @@ def _generate_parse_instance_from_element_generic() -> Stripped:
  * the element is self-closing, and is expected to consume the properties of
  * the instance, but not the element's closing tag.
  */
-private static <T> _Result<? extends T> parseInstanceFromElement(
+private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
 {I}XMLEventReader reader,
 {I}Class<T> type,
-{I}BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {{
+{I}BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {{
 {I}skipWhitespaceAndComments(reader);
 
 {I}final XMLEvent currentEvent = currentEvent(reader);
 {I}if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {{
-{II}return _Result.failure(new Reporting.Error(
+{II}return Reporting.Result.failure(new Reporting.Error(
 {III}"Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
 {IIII}"but reached the end-of-file"));
 {I}}}
 
 {I}if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {{
-{II}return _Result.failure(new Reporting.Error(
+{II}return Reporting.Result.failure(new Reporting.Error(
 {III}"Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
 {IIII}"but got a node of type " + getEventTypeAsString(currentEvent) +
 {IIII}" with value " + currentEvent));
 {I}}}
 
-{I}final _Result<String> tryElementName = tryElementName(reader);
+{I}final Reporting.Result<String> tryElementName = tryElementName(reader);
 {I}if (tryElementName.isError()) {{
-{II}return _Result.failure(tryElementName.getError());
+{II}return Reporting.Result.failure(tryElementName.getError());
 {I}}}
 
 {I}final String elementName = tryElementName.getResult();
 {I}final boolean isEmptyElement = isEmptyElement(reader);
 
-{I}final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+{I}final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
 {I}if (result.isError()) {{
 {II}return result;
 {I}}}
 
-{I}final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+{I}final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
 {II}type.getSimpleName(),
 {II}reader,
 {II}tryElementName);
 {I}if (checkEndElement.isError()) {{
-{II}return _Result.failure(checkEndElement.getError());
+{II}return Reporting.Result.failure(checkEndElement.getError());
 {I}}}
 
 {I}return result;
@@ -835,7 +774,7 @@ if (isEmptyProperty) {{
 {I}error.prependSegment(
 {II}new Reporting.NameSegment(
 {III}{xml_prop_name_literal}));
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
 
 if (currentEvent(reader).isEndDocument()) {{
@@ -843,7 +782,7 @@ if (currentEvent(reader).isEndDocument()) {{
 {III}"Expected an XML content representing "
 {IIIII}+ "the property {prop_name} of an instance of class {cls_name}, "
 {IIIII}+ "but reached the end-of-file");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
 
 String {text_target_var};
@@ -856,7 +795,7 @@ try {{
 {I}error.prependSegment(
 {III}new Reporting.NameSegment(
 {IIIII}"{prop_name}"));
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
 
 final Optional<{prop_type_name}> {optional_target_var} =
@@ -873,7 +812,7 @@ if ({optional_target_var}.isPresent()) {{
 {I}error.prependSegment(
 {III}new Reporting.NameSegment(
 {IIIII}"{prop_name}"));
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}"""
     )
 
@@ -909,7 +848,7 @@ if (isEmptyProperty) {{
 {II}"Expected an XML element within the element " + tryElementName.getResult() + " representing " +
 {II}"the property {prop_name} of an instance of class {cls_name}, " +
 {II}"but encountered a self-closing element.");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
 
 // We need to skip the whitespace here in order to be able to look ahead
@@ -921,7 +860,7 @@ if (currentEvent(reader).isEndDocument()) {{
 {II}"Expected an XML element within the element " + tryElementName.getResult() + " representing " +
 {II}"the property {prop_name} of an instance of class {cls_name}, " +
 {II}"but reached the end-of-file");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}
 
 // Try to look ahead the discriminator name;
@@ -930,12 +869,12 @@ if (currentEvent(reader).isEndDocument()) {{
 // checks.
 String discriminatorElementName = null;
 if (currentEvent(reader).isStartElement()) {{
-{I}_Result<String> tryDiscriminatorElementName = tryElementName(reader);
+{I}Reporting.Result<String> tryDiscriminatorElementName = tryElementName(reader);
 {I}assert(!tryDiscriminatorElementName.isError());
 {I}discriminatorElementName = tryDiscriminatorElementName.getResult();
 }}
 
-_Result<? extends {interface_name}> {try_target_var} = try{interface_name}FromElement(reader);
+Reporting.Result<? extends {interface_name}> {try_target_var} = try{interface_name}FromElement(reader);
 
 if ({try_target_var}.isError()) {{
 {I}if (discriminatorElementName != null) {{
@@ -979,7 +918,7 @@ def _generate_deserialize_cls_property(
 
     return Stripped(
         f"""\
-_Result<{target_cls_name}> {try_target_var} = try{target_cls_name}FromSequence(
+Reporting.Result<{target_cls_name}> {try_target_var} = try{target_cls_name}FromSequence(
 {I}reader, isEmptyProperty);
 
 if ({try_target_var}.isError()) {{
@@ -1066,7 +1005,7 @@ def _generate_deserialize_list_property(
 
     return Stripped(
         f"""\
-final _Result<List<{item_type}>> {try_target_var} = parseList(
+final Reporting.Result<List<{item_type}>> {try_target_var} = parseList(
 {I}reader,
 {I}isEmptyProperty,
 {I}{item_type}.class,
@@ -1154,10 +1093,10 @@ def _generate_deserialize_impl_cls_from_sequence(
             Stripped(
                 f"""\
 {description}
-private static _Result<{name}> try{name}FromSequence(
+private static Reporting.Result<{name}> try{name}FromSequence(
 {I}XMLEventReader reader,
 {I}boolean isEmptySequence) {{
-{I}return _Result.success(new {name}());
+{I}return Reporting.Result.success(new {name}());
 }}"""
             ),
             None,
@@ -1199,7 +1138,7 @@ if (currentEvent(reader).isEndDocument()) {{
 {II}"Expected an XML element representing " +
 {II}"a property of an instance of class {name}, " +
 {II}"but reached the end-of-file");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}"""
         )
     )
@@ -1237,7 +1176,7 @@ default:
 {II}"We expected properties of the class {name}, " +
 {II}"but got an unexpected element " +
 {II}"with the name " + elementName);
-{I}return _Result.failure(error);"""
+{I}return Reporting.Result.failure(error);"""
         )
     )
 
@@ -1259,10 +1198,10 @@ while (true) {{
 {III}"a property of an instance of class {name}, " +
 {III}"but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
 {III}" with the value " + currentEvent(reader));
-{II}return _Result.failure(error);
+{II}return Reporting.Result.failure(error);
 {I}}}
 
-{I}final _Result<String> tryElementName = tryElementName(reader);
+{I}final Reporting.Result<String> tryElementName = tryElementName(reader);
 {I}if (tryElementName.isError()) {{
 {II}return tryElementName.castTo({name}.class);
 {I}}}
@@ -1277,7 +1216,7 @@ while (true) {{
 {I}skipWhitespaceAndComments(reader);
 
 
-{I}final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+{I}final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
 {II}"{name}",
 {II}reader,
 {II}tryElementName);
@@ -1311,7 +1250,7 @@ if ({target_var} == null) {{
 {I}final Reporting.Error error = new Reporting.Error(
 {II}"The required property {prop_java} has not been given " +
 {II}"in the XML representation of an instance of class {name}");
-{I}return _Result.failure(error);
+{I}return Reporting.Result.failure(error);
 }}"""
                 )
             )
@@ -1335,7 +1274,7 @@ if ({target_var} == null) {{
     # fmt: on
 
     init_writer = io.StringIO()
-    init_writer.write(f"return _Result.success(new {name}(\n")
+    init_writer.write(f"return Reporting.Result.success(new {name}(\n")
 
     for i, arg in enumerate(cls.constructor.arguments):
         prop = cls.properties_by_name[arg.name]
@@ -1390,7 +1329,7 @@ if ({target_var} == null) {{
     writer.write(
         f"""\
 {description}
-private static _Result<{name}> try{name}FromSequence(
+private static Reporting.Result<{name}> try{name}FromSequence(
 {I}XMLEventReader reader,
 {I}boolean isEmptySequence) {{
 """
@@ -1419,7 +1358,7 @@ def _generate_deserialize_impl_concrete_cls_from_element(
 /**
  * Deserialize an instance of class {name} from an XML element.
  */
-private static _Result<? extends {name}> try{name}FromElement(
+private static Reporting.Result<? extends {name}> try{name}FromElement(
 {I}XMLEventReader reader) {{
 {I}return parseInstanceFromElement(
 {II}reader,
@@ -1429,7 +1368,7 @@ private static _Result<? extends {name}> try{name}FromElement(
 {IIII}final Reporting.Error error = new Reporting.Error(
 {IIIII}"Expected an element representing an instance of class {name} " +
 {IIIII}"with element name {xml_name}, but got: " + elementName);
-{IIII}return _Result.failure(error);
+{IIII}return Reporting.Result.failure(error);
 {III}}}
 
 {III}return try{name}FromSequence(reader, isEmptyElement);
@@ -1466,7 +1405,7 @@ case {implementer_xml_name_literal}:
 default:
 {I}final Reporting.Error error = new Reporting.Error(
 {II}"Unexpected element with the name " + elementName);
-{I}return _Result.failure(error);"""
+{I}return Reporting.Result.failure(error);"""
         )
     )
 
@@ -1477,7 +1416,7 @@ default:
 /**
  * Deserialize an instance of {name} from an XML element.
  */
-private static _Result<? extends {name}> try{name}FromElement(
+private static Reporting.Result<? extends {name}> try{name}FromElement(
 {I}XMLEventReader reader) {{
 {I}return parseInstanceFromElement(
 {II}reader,
@@ -1640,7 +1579,7 @@ public static {name} deserialize{name}(
 {I}_DeserializeImplementation.skipStartDocument(reader);
 {I}_DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-{I}_Result<? extends {name}> result =
+{I}Reporting.Result<? extends {name}> result =
 {II}_DeserializeImplementation.try{name}FromElement(
 {III}reader);
 
@@ -1743,6 +1682,127 @@ public static class Deserialize
     return Stripped(writer.getvalue())
 
 
+def _generate_serialize_element() -> Stripped:
+    """Generate the generic helper to write a property as a named XML element."""
+    return Stripped(
+        f"""\
+@FunctionalInterface
+private interface ElementContentSerializer<T> {{
+{I}void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+}}
+
+/**
+ * Write {{@code that}} as an XML element named {{@code name}}, delegating
+ * the content in-between the start and the end tag to
+ * {{@code serializeContent}}.
+ *
+ * <p>This is shared by all the property kinds (primitive, enumeration,
+ * class, interface, list) as they all wrap their content in exactly the
+ * same way.
+ */
+private <T> void serializeElement(
+{I}String name,
+{I}T that,
+{I}XMLStreamWriter writer,
+{I}ElementContentSerializer<T> serializeContent) {{
+{I}try {{
+{II}writer.writeStartElement(name);
+{II}if (topLevel) {{
+{III}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+{III}topLevel = false;
+{II}}}
+{II}serializeContent.serialize(that, writer);
+{II}writer.writeEndElement();
+{I}}} catch (XMLStreamException exception) {{
+{II}throw new SerializeException("", exception.getMessage());
+{I}}}
+}}"""
+    )
+
+
+def _generate_serialize_items() -> Stripped:
+    """Generate the generic helper to write every item of a list property."""
+    return Stripped(
+        f"""\
+/**
+ * Adapt {{@code writeItem}} to serialize every item of an iterable.
+ *
+ * <p>This is shared by all the list-typed properties, which only need to
+ * supply how a single item is written.
+ */
+private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+{I}ElementContentSerializer<T> writeItem) {{
+{I}return (items, w) -> {{
+{II}for (T item : items) {{
+{III}writeItem.serialize(item, w);
+{II}}}
+{I}}};
+}}"""
+    )
+
+
+def _generate_write_stringified_content() -> Stripped:
+    """Generate the helper to write a value's ``toString()`` as XML content."""
+    return Stripped(
+        f"""\
+/**
+ * Write {{@code that.toString()}} as XML content.
+ *
+ * <p>This is shared by every {{@code boolean}}/{{@code long}}/{{@code double}}/
+ * {{@code String}}-typed property or list item, standing in for the property-
+ * or item-specific {{@link ElementContentSerializer}}.
+ */
+private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+{I}throws XMLStreamException {{
+{I}writer.writeCharacters(that.toString());
+}}"""
+    )
+
+
+def _generate_write_byte_array_content() -> Stripped:
+    """Generate the helper to write a byte array as base64-encoded XML content."""
+    return Stripped(
+        f"""\
+/**
+ * Write {{@code that}} as base64-encoded XML content.
+ *
+ * <p>This is shared by every {{@code byte[]}}-typed property or list item,
+ * standing in for the property- or item-specific
+ * {{@link ElementContentSerializer}}.
+ */
+private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+{I}throws XMLStreamException {{
+{I}writer.writeCharacters(
+{II}Base64.getEncoder().encodeToString(that));
+}}"""
+    )
+
+
+def _generate_write_enum_content(
+    enumeration: intermediate.Enumeration,
+) -> Stripped:
+    """Generate the helper to write a literal of ``enumeration`` as XML content."""
+    enum_name = java_naming.enum_name(enumeration.name)
+    method_name = java_naming.method_name(
+        Identifier(f"write_{enumeration.name}_content")
+    )
+
+    return Stripped(
+        f"""\
+/**
+ * Write a literal of {{@link {enum_name}}} as XML content.
+ *
+ * <p>This is shared by every {enum_name}-typed property or list item,
+ * standing in for the property- or item-specific
+ * {{@link ElementContentSerializer}}.
+ */
+private void {method_name}({enum_name} that, XMLStreamWriter writer)
+{I}throws XMLStreamException {{
+{I}writer.writeCharacters(Stringification.mustToString(that));
+}}"""
+    )
+
+
 def _generate_serialize_primitive_property_as_content(
     prop: intermediate.Property,
 ) -> Stripped:
@@ -1754,11 +1814,10 @@ def _generate_serialize_primitive_property_as_content(
         a_type is not None
     ), f"Unexpected non-primitive type of the property {prop.name!r}: {type_anno}"
 
-    prop_name = java_naming.property_name(prop.name)
     getter_name = java_naming.getter_name(prop.name)
     xml_prop_name_literal = java_common.string_literal(prop.xml_name)
 
-    write_value_block: Stripped
+    content_serializer: Stripped
 
     if (
         a_type is intermediate.PrimitiveType.BOOL
@@ -1766,87 +1825,32 @@ def _generate_serialize_primitive_property_as_content(
         or a_type is intermediate.PrimitiveType.FLOAT
         or a_type is intermediate.PrimitiveType.STR
     ):
-        if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-            write_value_block = Stripped(
-                f"""\
-if (that.{getter_name}().isPresent()) {{
-{I}writer.writeStartElement(
-{II}{xml_prop_name_literal});
-{I}if (topLevel) {{
-{II}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{II}topLevel = false;
-{I}}}
-
-{I}writer.writeCharacters(
-{II}that.{getter_name}().get().toString());
-
-{I}writer.writeEndElement();
-}}"""
-            )
-        else:
-            write_value_block = Stripped(
-                f"""\
-writer.writeStartElement(
-{I}{xml_prop_name_literal});
-if (topLevel) {{
-{I}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{I}topLevel = false;
-}}
-writer.writeCharacters(
-{I}that.{getter_name}().toString());
-writer.writeEndElement();"""
-            )
+        content_serializer = Stripped("this::writeStringifiedContent")
     elif a_type is intermediate.PrimitiveType.BYTEARRAY:
-        if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-            base64_prop_name = java_naming.property_name(
-                Identifier(f"the_b64_{prop_name}")
-            )
-            write_value_block = Stripped(
-                f"""\
-if (that.{getter_name}().isPresent()) {{
-{I}writer.writeStartElement({xml_prop_name_literal});
-{I}if (topLevel) {{
-{II}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{II}topLevel = false;
-{I}}}
-{I}String {base64_prop_name} = Base64.getEncoder().encodeToString(
-{II}that.{getter_name}().get());
-{I}writer.writeCharacters({base64_prop_name});
-{I}writer.writeEndElement();
-}}"""
-            )
-        else:
-            base64_prop_name = java_naming.property_name(
-                Identifier(f"the_b64_{prop_name}")
-            )
-            write_value_block = Stripped(
-                f"""\
-writer.writeStartElement(
-{I}{xml_prop_name_literal});
-if (topLevel) {{
-{I}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{I}topLevel = false;
-}}
-String {base64_prop_name} = Base64.getEncoder().encodeToString(
-{I}that.{getter_name}());
-writer.writeCharacters({base64_prop_name});
-writer.writeEndElement();"""
-            )
+        content_serializer = Stripped("this::writeByteArrayContent")
     else:
         assert_never(a_type)
 
-    assert write_value_block is not None
-
-    write_value_block = Stripped(
-        f"""\
-try {{
-{I}{indent_but_first_line(write_value_block, I)}
-}} catch (Exception exception) {{
-{I}throw new SerializeException("",exception.getMessage());
+    if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
+        return Stripped(
+            f"""\
+if (that.{getter_name}().isPresent()) {{
+{I}serializeElement(
+{II}{xml_prop_name_literal},
+{II}that.{getter_name}().get(),
+{II}writer,
+{II}{indent_but_first_line(content_serializer, II)});
 }}"""
-    )
+        )
 
-    return write_value_block
+    return Stripped(
+        f"""\
+serializeElement(
+{I}{xml_prop_name_literal},
+{I}that.{getter_name}(),
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
+    )
 
 
 def _generate_serialize_enumeration_property_as_content(
@@ -1864,76 +1868,35 @@ def _generate_serialize_enumeration_property_as_content(
         f"{prop.name!r} has the type {prop.type_annotation}."
     )
 
-    enumeration = type_anno.our_type
+    write_content_method = java_naming.method_name(
+        Identifier(f"write_{type_anno.our_type.name}_content")
+    )
 
     getter_name = java_naming.getter_name(prop.name)
     xml_prop_name_literal = java_common.string_literal(prop.xml_name)
 
-    enum_name = java_naming.enum_name(enumeration.name)
-
-    text_var = java_naming.variable_name(Identifier(f"text_{prop.name}"))
-
-    write_value_block: Stripped
+    content_serializer = Stripped(f"this::{write_content_method}")
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-        write_value_block = Stripped(
+        return Stripped(
             f"""\
 if (that.{getter_name}().isPresent()) {{
-{I}writer.writeStartElement(
-{II}{xml_prop_name_literal});
-{I}if (topLevel) {{
-{II}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{II}topLevel = false;
-{I}}}
-
-{I}Optional<String> {text_var} = Stringification.toString(
-{II}that.{getter_name}().get());
-
-{I}if (!{text_var}.isPresent()) {{
-{II}throw new IllegalArgumentException(
-{III}"Invalid literal for the enumeration {enum_name}: " +
-{III}that.{getter_name}().get().toString());
-{I}}}
-
-{I}writer.writeCharacters({text_var}.get());
-
-{I}writer.writeEndElement();
+{I}serializeElement(
+{II}{xml_prop_name_literal},
+{II}that.{getter_name}().get(),
+{II}writer,
+{II}{indent_but_first_line(content_serializer, II)});
 }}"""
         )
-    else:
-        write_value_block = Stripped(
-            f"""\
-writer.writeStartElement(
-{I}{xml_prop_name_literal});
-if (topLevel) {{
-{I}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{I}topLevel = false;
-}}
 
-Optional<String> {text_var} = Stringification.toString(
-{I}that.{getter_name}());
-
-if (!{text_var}.isPresent()) {{
-{I}throw new IllegalArgumentException(
-{II}"Invalid literal for the enumeration {enum_name}: " +
-{II}that.{getter_name}().toString());
-}}
-
-writer.writeCharacters({text_var}.get());
-
-writer.writeEndElement();"""
-        )
-
-    write_value_block = Stripped(
+    return Stripped(
         f"""\
-try {{
-{I}{indent_but_first_line(write_value_block, I)}
-}} catch (Exception exception) {{
-{I}throw new SerializeException("",exception.getMessage());
-}}"""
+serializeElement(
+{I}{xml_prop_name_literal},
+{I}that.{getter_name}(),
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
-
-    return write_value_block
 
 
 def _generate_serialize_interface_property_as_content(
@@ -1966,53 +1929,28 @@ def _generate_serialize_interface_property_as_content(
     getter_name = java_naming.getter_name(prop.name)
     xml_prop_name_literal = java_common.string_literal(prop.xml_name)
 
-    result: Stripped
+    content_serializer = Stripped("this::visit")
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-        result = Stripped(
+        return Stripped(
             f"""\
 if (that.{getter_name}().isPresent()) {{
-{I}writer.writeStartElement(
-{II}{xml_prop_name_literal});
-{I}if (topLevel) {{
-{II}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{II}topLevel = false;
-{I}}}
-
-{I}this.visit(
+{I}serializeElement(
+{II}{xml_prop_name_literal},
 {II}that.{getter_name}().get(),
-{II}writer);
-
-{I}writer.writeEndElement();
+{II}writer,
+{II}{indent_but_first_line(content_serializer, II)});
 }}"""
         )
-    else:
-        result = Stripped(
-            f"""\
-writer.writeStartElement(
-{I}{xml_prop_name_literal});
-if (topLevel) {{
-{I}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{I}topLevel = false;
-}}
 
-this.visit(
-{I}that.{getter_name}(),
-{I}writer);
-
-writer.writeEndElement();"""
-        )
-
-    result = Stripped(
+    return Stripped(
         f"""\
-try {{
-{I}{indent_but_first_line(result, I)}
-}} catch (XMLStreamException exception) {{
-{I}throw new SerializeException("",exception.getMessage());
-}}"""
+serializeElement(
+{I}{xml_prop_name_literal},
+{I}that.{getter_name}(),
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
-
-    return result
 
 
 def _generate_serialize_concrete_class_property_as_sequence(
@@ -2030,53 +1968,28 @@ def _generate_serialize_concrete_class_property_as_sequence(
     getter_name = java_naming.getter_name(prop.name)
     xml_prop_name_literal = java_common.string_literal(prop.xml_name)
 
-    result: Stripped
+    content_serializer = Stripped(f"(value, w) -> this.{cls_to_sequence}(value, w)")
 
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-        result = Stripped(
+        return Stripped(
             f"""\
 if (that.{getter_name}().isPresent()) {{
-{I}writer.writeStartElement(
-{II}{xml_prop_name_literal});
-{I}if (topLevel) {{
-{II}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{II}topLevel = false;
-{I}}}
-
-{I}this.{cls_to_sequence}(
+{I}serializeElement(
+{II}{xml_prop_name_literal},
 {II}that.{getter_name}().get(),
-{II}writer);
-
-{I}writer.writeEndElement();
+{II}writer,
+{II}{indent_but_first_line(content_serializer, II)});
 }}"""
         )
-    else:
-        result = Stripped(
-            f"""\
-writer.writeStartElement(
-{I}{xml_prop_name_literal});
-if (topLevel) {{
-{I}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{I}topLevel = false;
-}}
 
-this.{cls_to_sequence}(
-{I}that.{getter_name}(),
-{I}writer);
-
-writer.writeEndElement();"""
-        )
-
-    result = Stripped(
+    return Stripped(
         f"""\
-try {{
-{I}{indent_but_first_line(result, I)}
-}} catch (XMLStreamException exception) {{
-{I}throw new SerializeException("",exception.getMessage());
-}}"""
+serializeElement(
+{I}{xml_prop_name_literal},
+{I}that.{getter_name}(),
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
-
-    return result
 
 
 def _generate_serialize_list_property_as_content(
@@ -2095,54 +2008,55 @@ def _generate_serialize_list_property_as_content(
 
     primitive_type = intermediate.try_primitive_type(type_anno.items)
 
-    item_write_stmt: Stripped
+    content_serializer: Stripped
 
     if primitive_type is not None:
+        item_content_method_ref: Stripped
+
         if (
             primitive_type is intermediate.PrimitiveType.BOOL
             or primitive_type is intermediate.PrimitiveType.INT
             or primitive_type is intermediate.PrimitiveType.FLOAT
             or primitive_type is intermediate.PrimitiveType.STR
         ):
-            item_write_stmt = Stripped(
-                """\
-writer.writeStartElement("v");
-writer.writeCharacters(item.toString());
-writer.writeEndElement();"""
-            )
+            item_content_method_ref = Stripped("this::writeStringifiedContent")
         elif primitive_type is intermediate.PrimitiveType.BYTEARRAY:
-            item_write_stmt = Stripped(
-                f"""\
-writer.writeStartElement("v");
-writer.writeCharacters(
-{I}Base64.getEncoder().encodeToString(item));
-writer.writeEndElement();"""
-            )
+            item_content_method_ref = Stripped("this::writeByteArrayContent")
         else:
             assert_never(primitive_type)
+
+        # NOTE (mristin):
+        # An atomic item is wrapped in its own ``v`` element, exactly like a
+        # standalone atomic property is wrapped in its own named element --
+        # so we reuse ``serializeElement`` and the same content-writing
+        # method reference for both.
+        content_serializer = Stripped(
+            f"""\
+serializeItems((item, w) -> serializeElement(
+{I}"v", item, w, {item_content_method_ref}))"""
+        )
     elif isinstance(type_anno.items, intermediate.OurTypeAnnotation) and isinstance(
         type_anno.items.our_type, intermediate.Enumeration
     ):
-        enum_name = java_naming.enum_name(type_anno.items.our_type.name)
-        item_write_stmt = Stripped(
+        write_content_method = java_naming.method_name(
+            Identifier(f"write_{type_anno.items.our_type.name}_content")
+        )
+
+        content_serializer = Stripped(
             f"""\
-writer.writeStartElement("v");
-final Optional<String> itemText = Stringification.toString(item);
-if (!itemText.isPresent()) {{
-{I}throw new IllegalArgumentException(
-{II}"Invalid literal for the enumeration {enum_name}: " + item.toString());
-}}
-writer.writeCharacters(itemText.get());
-writer.writeEndElement();"""
+serializeItems((item, w) -> serializeElement(
+{I}"v", item, w, this::{write_content_method}))"""
         )
     elif isinstance(type_anno.items, intermediate.OurTypeAnnotation) and isinstance(
         type_anno.items.our_type,
         (intermediate.AbstractClass, intermediate.ConcreteClass),
     ):
-        item_write_stmt = Stripped(
-            """\
-this.visit(item, writer);"""
-        )
+        # NOTE (mristin):
+        # A class item is dispatched through ``this.visit``, which already
+        # matches the shape ``ElementContentSerializer<T>`` expects, so we
+        # pass it directly as a method reference instead of wrapping it in
+        # a lambda.
+        content_serializer = Stripped("serializeItems(this::visit)")
     else:
         raise NotImplementedError(
             f"We only handle XML de/serialization of lists containing atomic "
@@ -2152,56 +2066,29 @@ this.visit(item, writer);"""
             f"this feature."
         )
 
-    item_type = java_common.generate_type(type_anno.items)
-
     getter_name = java_naming.getter_name(prop.name)
     xml_prop_name_literal = java_common.string_literal(prop.xml_name)
 
-    result: Stripped
-
     if isinstance(prop.type_annotation, intermediate.OptionalTypeAnnotation):
-        result = Stripped(
+        return Stripped(
             f"""\
 if (that.{getter_name}().isPresent()) {{
-{I}writer.writeStartElement(
-{I}{xml_prop_name_literal});
-{I}if (topLevel) {{
-{II}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{II}topLevel = false;
-{I}}}
-{I}for ({item_type} item : that.{getter_name}().get()) {{
-{II}{indent_but_first_line(item_write_stmt, II)}
-{I}}}
-{I}writer.writeEndElement();
+{I}serializeElement(
+{II}{xml_prop_name_literal},
+{II}that.{getter_name}().get(),
+{II}writer,
+{II}{indent_but_first_line(content_serializer, II)});
 }}"""
         )
-    else:
-        result = Stripped(
-            f"""\
-writer.writeStartElement(
-{I}{xml_prop_name_literal});
-if (topLevel) {{
-{I}writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-{I}topLevel = false;
-}}
 
-for ({item_type} item : that.{getter_name}()) {{
-{I}{indent_but_first_line(item_write_stmt, I)}
-}}
-
-writer.writeEndElement();"""
-        )
-
-    result = Stripped(
+    return Stripped(
         f"""\
-try {{
-{I}{indent_but_first_line(result, I)}
-}} catch (XMLStreamException exception) {{
-{I}throw new SerializeException("",exception.getMessage());
-}}"""
+serializeElement(
+{I}{xml_prop_name_literal},
+{I}that.{getter_name}(),
+{I}writer,
+{I}{indent_but_first_line(content_serializer, I)});"""
     )
-
-    return result
 
 
 def _generate_serialize_property_as_content(prop: intermediate.Property) -> Stripped:
@@ -2327,7 +2214,15 @@ def _generate_visitor(
     """Generate a visitor which serializes instances of the meta-model to XML."""
     errors = []  # type: List[Error]
 
-    blocks = []  # type: List[Stripped]
+    blocks = [
+        _generate_serialize_element(),
+        _generate_serialize_items(),
+        _generate_write_stringified_content(),
+        _generate_write_byte_array_content(),
+    ]  # type: List[Stripped]
+
+    for enumeration in symbol_table.enumerations:
+        blocks.append(_generate_write_enum_content(enumeration=enumeration))
 
     # The abstract classes are directly dispatched by the transformer,
     # so we do not need to handle them separately.
@@ -2504,8 +2399,6 @@ def generate(
 
     # region Deserialization helpers
 
-    xml_result_class = _generate_result()
-
     xml_namespace_literal = java_common.string_literal(
         symbol_table.meta_model.xml_namespace
     )
@@ -2606,8 +2499,6 @@ public class Xmlization {{
 {I} */
 {I}public static final String AAS_NAME_SPACE =
 {II}{xml_namespace_literal};
-
-{I}{indent_but_first_line(xml_result_class, I)}
 
 {I}{indent_but_first_line(deserialize_impl_block, I)}
 

--- a/aas_core_codegen/python/lib/_generate_jsonization.py
+++ b/aas_core_codegen/python/lib/_generate_jsonization.py
@@ -2,7 +2,7 @@
 
 import io
 import textwrap
-from typing import Tuple, Optional, List, TypeVar
+from typing import Tuple, Optional, List
 
 from icontract import ensure, require
 

--- a/aas_core_codegen/python/lib/_generate_xmlization.py
+++ b/aas_core_codegen/python/lib/_generate_xmlization.py
@@ -2,7 +2,7 @@
 
 import io
 import textwrap
-from typing import Tuple, Optional, List, TypeVar, Union
+from typing import Tuple, Optional, List, Union
 
 from icontract import ensure, require
 

--- a/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,20 +151,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IHasSemantics> tryIHasSemanticsFrom(JsonNode node) {
+      public static Reporting.Result<? extends IHasSemantics> tryIHasSemanticsFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IHasSemantics.class);
         }
@@ -175,7 +210,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IHasSemantics: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -186,11 +221,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Extension> tryExtensionFrom(JsonNode node) {
+      private static Reporting.Result<Extension> tryExtensionFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theName = null;
@@ -209,7 +244,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
               if (theNameResult.isError()) {
                 theNameResult.getError()
                   .prependSegment(new Reporting.NameSegment("name"));
@@ -223,7 +258,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -244,42 +279,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Extension.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Extension.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "valueType": {
@@ -287,7 +299,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
+              final Reporting.Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
               if (theValueTypeResult.isError()) {
                 theValueTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueType"));
@@ -301,7 +313,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -322,48 +334,25 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "refersTo"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theRefersTo = new ArrayList<>(
-                arrayRefersTo.size());
-              int indexRefersTo = 0;
-              for (JsonNode item : arrayRefersTo) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexRefersTo));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theRefersToResult = parseArray(
+                arrayRefersTo,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theRefersToResult.isError()) {
+                theRefersToResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "refersTo"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexRefersTo));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "refersTo"));
-                  return parsedItemResult.castTo(Extension.class);
-                }
-                theRefersTo.add(
-                  parsedItemResult.getResult());
-                indexRefersTo++;
+                return theRefersToResult.castTo(Extension.class);
               }
+              theRefersTo = theRefersToResult.getResult();
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -371,10 +360,10 @@ public class Jsonization {
         if (theName == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"name\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Extension(
+        return Reporting.Result.success(new Extension(
           theName,
           theSemanticId,
           theSupplementalSemanticIds,
@@ -389,20 +378,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IHasExtensions> tryIHasExtensionsFrom(JsonNode node) {
+      public static Reporting.Result<? extends IHasExtensions> tryIHasExtensionsFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IHasExtensions.class);
         }
@@ -446,7 +435,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IHasExtensions: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -457,20 +446,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IReferable> tryIReferableFrom(JsonNode node) {
+      public static Reporting.Result<? extends IReferable> tryIReferableFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IReferable.class);
         }
@@ -514,7 +503,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IReferable: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -525,20 +514,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IIdentifiable> tryIIdentifiableFrom(JsonNode node) {
+      public static Reporting.Result<? extends IIdentifiable> tryIIdentifiableFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IIdentifiable.class);
         }
@@ -554,7 +543,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IIdentifiable: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -564,17 +553,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<ModellingKind> tryModellingKindFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<ModellingKind> tryModellingKindFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(ModellingKind.class);
         }
         final Optional<ModellingKind> modellingKind = Stringification.modellingKindFromString(textResult.getResult());
         if (!modellingKind.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of ModellingKind");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(modellingKind.get());
+        return Reporting.Result.success(modellingKind.get());
       }
 
       /**
@@ -583,20 +572,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IHasKind> tryIHasKindFrom(JsonNode node) {
+      public static Reporting.Result<? extends IHasKind> tryIHasKindFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IHasKind.class);
         }
@@ -608,7 +597,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IHasKind: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -619,20 +608,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IHasDataSpecification> tryIHasDataSpecificationFrom(JsonNode node) {
+      public static Reporting.Result<? extends IHasDataSpecification> tryIHasDataSpecificationFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IHasDataSpecification.class);
         }
@@ -678,7 +667,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IHasDataSpecification: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -689,11 +678,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<AdministrativeInformation> tryAdministrativeInformationFrom(JsonNode node) {
+      private static Reporting.Result<AdministrativeInformation> tryAdministrativeInformationFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
@@ -718,42 +707,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(AdministrativeInformation.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(AdministrativeInformation.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "version": {
@@ -761,7 +727,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theVersionResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theVersionResult = tryStringFrom(currentNode.getValue());
               if (theVersionResult.isError()) {
                 theVersionResult.getError()
                   .prependSegment(new Reporting.NameSegment("version"));
@@ -775,7 +741,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theRevisionResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theRevisionResult = tryStringFrom(currentNode.getValue());
               if (theRevisionResult.isError()) {
                 theRevisionResult.getError()
                   .prependSegment(new Reporting.NameSegment("revision"));
@@ -789,7 +755,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theCreatorResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theCreatorResult = tryReferenceFrom(currentNode.getValue());
               if (theCreatorResult.isError()) {
                 theCreatorResult.getError()
                   .prependSegment(new Reporting.NameSegment("creator"));
@@ -803,7 +769,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTemplateIdResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTemplateIdResult = tryStringFrom(currentNode.getValue());
               if (theTemplateIdResult.isError()) {
                 theTemplateIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("templateId"));
@@ -815,14 +781,14 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
 
 
 
-        return _Result.success(new AdministrativeInformation(
+        return Reporting.Result.success(new AdministrativeInformation(
           theEmbeddedDataSpecifications,
           theVersion,
           theRevision,
@@ -836,20 +802,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IQualifiable> tryIQualifiableFrom(JsonNode node) {
+      public static Reporting.Result<? extends IQualifiable> tryIQualifiableFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IQualifiable.class);
         }
@@ -889,7 +855,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IQualifiable: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -899,17 +865,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<QualifierKind> tryQualifierKindFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<QualifierKind> tryQualifierKindFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(QualifierKind.class);
         }
         final Optional<QualifierKind> qualifierKind = Stringification.qualifierKindFromString(textResult.getResult());
         if (!qualifierKind.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of QualifierKind");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(qualifierKind.get());
+        return Reporting.Result.success(qualifierKind.get());
       }
 
       /**
@@ -918,11 +884,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Qualifier> tryQualifierFrom(JsonNode node) {
+      private static Reporting.Result<Qualifier> tryQualifierFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theType = null;
@@ -942,7 +908,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTypeResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTypeResult = tryStringFrom(currentNode.getValue());
               if (theTypeResult.isError()) {
                 theTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("type"));
@@ -956,7 +922,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
+              final Reporting.Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
               if (theValueTypeResult.isError()) {
                 theValueTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueType"));
@@ -970,7 +936,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -991,42 +957,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Qualifier.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Qualifier.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "kind": {
@@ -1034,7 +977,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends QualifierKind> theKindResult = tryQualifierKindFrom(currentNode.getValue());
+              final Reporting.Result<? extends QualifierKind> theKindResult = tryQualifierKindFrom(currentNode.getValue());
               if (theKindResult.isError()) {
                 theKindResult.getError()
                   .prependSegment(new Reporting.NameSegment("kind"));
@@ -1048,7 +991,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -1062,7 +1005,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
               if (theValueIdResult.isError()) {
                 theValueIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueId"));
@@ -1074,7 +1017,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -1082,16 +1025,16 @@ public class Jsonization {
         if (theType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"type\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValueType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"valueType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Qualifier(
+        return Reporting.Result.success(new Qualifier(
           theType,
           theValueType,
           theSemanticId,
@@ -1107,11 +1050,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<AssetAdministrationShell> tryAssetAdministrationShellFrom(JsonNode node) {
+      private static Reporting.Result<AssetAdministrationShell> tryAssetAdministrationShellFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theId = null;
@@ -1137,7 +1080,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdResult = tryStringFrom(currentNode.getValue());
               if (theIdResult.isError()) {
                 theIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("id"));
@@ -1151,7 +1094,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IAssetInformation> theAssetInformationResult = tryAssetInformationFrom(currentNode.getValue());
+              final Reporting.Result<? extends IAssetInformation> theAssetInformationResult = tryAssetInformationFrom(currentNode.getValue());
               if (theAssetInformationResult.isError()) {
                 theAssetInformationResult.getError()
                   .prependSegment(new Reporting.NameSegment("assetInformation"));
@@ -1172,42 +1115,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(AssetAdministrationShell.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(AssetAdministrationShell.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -1215,7 +1135,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -1229,7 +1149,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -1250,42 +1170,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(AssetAdministrationShell.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(AssetAdministrationShell.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -1300,42 +1197,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(AssetAdministrationShell.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(AssetAdministrationShell.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "administration": {
@@ -1343,7 +1217,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IAdministrativeInformation> theAdministrationResult = tryAdministrativeInformationFrom(currentNode.getValue());
+              final Reporting.Result<? extends IAdministrativeInformation> theAdministrationResult = tryAdministrativeInformationFrom(currentNode.getValue());
               if (theAdministrationResult.isError()) {
                 theAdministrationResult.getError()
                   .prependSegment(new Reporting.NameSegment("administration"));
@@ -1364,42 +1238,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(AssetAdministrationShell.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(AssetAdministrationShell.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "derivedFrom": {
@@ -1407,7 +1258,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theDerivedFromResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theDerivedFromResult = tryReferenceFrom(currentNode.getValue());
               if (theDerivedFromResult.isError()) {
                 theDerivedFromResult.getError()
                   .prependSegment(new Reporting.NameSegment("derivedFrom"));
@@ -1428,51 +1279,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "submodels"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSubmodels = new ArrayList<>(
-                arraySubmodels.size());
-              int indexSubmodels = 0;
-              for (JsonNode item : arraySubmodels) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSubmodels));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSubmodelsResult = parseArray(
+                arraySubmodels,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSubmodelsResult.isError()) {
+                theSubmodelsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "submodels"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSubmodels));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "submodels"));
-                  return parsedItemResult.castTo(AssetAdministrationShell.class);
-                }
-                theSubmodels.add(
-                  parsedItemResult.getResult());
-                indexSubmodels++;
+                return theSubmodelsResult.castTo(AssetAdministrationShell.class);
               }
+              theSubmodels = theSubmodelsResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -1486,14 +1314,14 @@ public class Jsonization {
                   "Expected the model type 'AssetAdministrationShell', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -1501,22 +1329,22 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theId == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"id\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theAssetInformation == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"assetInformation\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new AssetAdministrationShell(
+        return Reporting.Result.success(new AssetAdministrationShell(
           theId,
           theAssetInformation,
           theExtensions,
@@ -1536,11 +1364,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<AssetInformation> tryAssetInformationFrom(JsonNode node) {
+      private static Reporting.Result<AssetInformation> tryAssetInformationFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         AssetKind theAssetKind = null;
@@ -1558,7 +1386,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends AssetKind> theAssetKindResult = tryAssetKindFrom(currentNode.getValue());
+              final Reporting.Result<? extends AssetKind> theAssetKindResult = tryAssetKindFrom(currentNode.getValue());
               if (theAssetKindResult.isError()) {
                 theAssetKindResult.getError()
                   .prependSegment(new Reporting.NameSegment("assetKind"));
@@ -1572,7 +1400,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theGlobalAssetIdResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theGlobalAssetIdResult = tryStringFrom(currentNode.getValue());
               if (theGlobalAssetIdResult.isError()) {
                 theGlobalAssetIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("globalAssetId"));
@@ -1593,42 +1421,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "specificAssetIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSpecificAssetIds = new ArrayList<>(
-                arraySpecificAssetIds.size());
-              int indexSpecificAssetIds = 0;
-              for (JsonNode item : arraySpecificAssetIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSpecificAssetIds));
-                  error.prependSegment(
+              final Reporting.Result<List<ISpecificAssetId>> theSpecificAssetIdsResult = parseArray(
+                arraySpecificAssetIds,
+                _DeserializeImplementation::trySpecificAssetIdFrom);
+              if (theSpecificAssetIdsResult.isError()) {
+                theSpecificAssetIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "specificAssetIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISpecificAssetId> parsedItemResult =
-                  trySpecificAssetIdFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSpecificAssetIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "specificAssetIds"));
-                  return parsedItemResult.castTo(AssetInformation.class);
-                }
-                theSpecificAssetIds.add(
-                  parsedItemResult.getResult());
-                indexSpecificAssetIds++;
+                return theSpecificAssetIdsResult.castTo(AssetInformation.class);
               }
+              theSpecificAssetIds = theSpecificAssetIdsResult.getResult();
               break;
             }
             case "assetType": {
@@ -1636,7 +1441,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theAssetTypeResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theAssetTypeResult = tryStringFrom(currentNode.getValue());
               if (theAssetTypeResult.isError()) {
                 theAssetTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("assetType"));
@@ -1650,7 +1455,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IResource> theDefaultThumbnailResult = tryResourceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IResource> theDefaultThumbnailResult = tryResourceFrom(currentNode.getValue());
               if (theDefaultThumbnailResult.isError()) {
                 theDefaultThumbnailResult.getError()
                   .prependSegment(new Reporting.NameSegment("defaultThumbnail"));
@@ -1662,7 +1467,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -1670,10 +1475,10 @@ public class Jsonization {
         if (theAssetKind == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"assetKind\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new AssetInformation(
+        return Reporting.Result.success(new AssetInformation(
           theAssetKind,
           theGlobalAssetId,
           theSpecificAssetIds,
@@ -1687,11 +1492,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Resource> tryResourceFrom(JsonNode node) {
+      private static Reporting.Result<Resource> tryResourceFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String thePath = null;
@@ -1706,7 +1511,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> thePathResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> thePathResult = tryStringFrom(currentNode.getValue());
               if (thePathResult.isError()) {
                 thePathResult.getError()
                   .prependSegment(new Reporting.NameSegment("path"));
@@ -1720,7 +1525,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theContentTypeResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theContentTypeResult = tryStringFrom(currentNode.getValue());
               if (theContentTypeResult.isError()) {
                 theContentTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("contentType"));
@@ -1732,7 +1537,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -1740,10 +1545,10 @@ public class Jsonization {
         if (thePath == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"path\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Resource(
+        return Reporting.Result.success(new Resource(
           thePath,
           theContentType));
       }
@@ -1753,17 +1558,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<AssetKind> tryAssetKindFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<AssetKind> tryAssetKindFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(AssetKind.class);
         }
         final Optional<AssetKind> assetKind = Stringification.assetKindFromString(textResult.getResult());
         if (!assetKind.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of AssetKind");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(assetKind.get());
+        return Reporting.Result.success(assetKind.get());
       }
 
       /**
@@ -1772,11 +1577,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<SpecificAssetId> trySpecificAssetIdFrom(JsonNode node) {
+      private static Reporting.Result<SpecificAssetId> trySpecificAssetIdFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theName = null;
@@ -1794,7 +1599,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
               if (theNameResult.isError()) {
                 theNameResult.getError()
                   .prependSegment(new Reporting.NameSegment("name"));
@@ -1808,7 +1613,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -1822,7 +1627,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -1843,42 +1648,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(SpecificAssetId.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(SpecificAssetId.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "externalSubjectId": {
@@ -1886,7 +1668,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theExternalSubjectIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theExternalSubjectIdResult = tryReferenceFrom(currentNode.getValue());
               if (theExternalSubjectIdResult.isError()) {
                 theExternalSubjectIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("externalSubjectId"));
@@ -1898,7 +1680,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -1906,16 +1688,16 @@ public class Jsonization {
         if (theName == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"name\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValue == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"value\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new SpecificAssetId(
+        return Reporting.Result.success(new SpecificAssetId(
           theName,
           theValue,
           theSemanticId,
@@ -1929,11 +1711,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Submodel> trySubmodelFrom(JsonNode node) {
+      private static Reporting.Result<Submodel> trySubmodelFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theId = null;
@@ -1961,7 +1743,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdResult = tryStringFrom(currentNode.getValue());
               if (theIdResult.isError()) {
                 theIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("id"));
@@ -1982,42 +1764,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(Submodel.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(Submodel.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -2025,7 +1784,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -2039,7 +1798,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -2060,42 +1819,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(Submodel.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(Submodel.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -2110,42 +1846,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(Submodel.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(Submodel.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "administration": {
@@ -2153,7 +1866,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IAdministrativeInformation> theAdministrationResult = tryAdministrativeInformationFrom(currentNode.getValue());
+              final Reporting.Result<? extends IAdministrativeInformation> theAdministrationResult = tryAdministrativeInformationFrom(currentNode.getValue());
               if (theAdministrationResult.isError()) {
                 theAdministrationResult.getError()
                   .prependSegment(new Reporting.NameSegment("administration"));
@@ -2167,7 +1880,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends ModellingKind> theKindResult = tryModellingKindFrom(currentNode.getValue());
+              final Reporting.Result<? extends ModellingKind> theKindResult = tryModellingKindFrom(currentNode.getValue());
               if (theKindResult.isError()) {
                 theKindResult.getError()
                   .prependSegment(new Reporting.NameSegment("kind"));
@@ -2181,7 +1894,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -2202,42 +1915,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Submodel.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Submodel.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -2252,42 +1942,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(Submodel.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(Submodel.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -2302,42 +1969,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(Submodel.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(Submodel.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "submodelElements": {
@@ -2352,51 +1996,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "submodelElements"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSubmodelElements = new ArrayList<>(
-                arraySubmodelElements.size());
-              int indexSubmodelElements = 0;
-              for (JsonNode item : arraySubmodelElements) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSubmodelElements));
-                  error.prependSegment(
+              final Reporting.Result<List<ISubmodelElement>> theSubmodelElementsResult = parseArray(
+                arraySubmodelElements,
+                _DeserializeImplementation::tryISubmodelElementFrom);
+              if (theSubmodelElementsResult.isError()) {
+                theSubmodelElementsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "submodelElements"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISubmodelElement> parsedItemResult =
-                  tryISubmodelElementFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSubmodelElements));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "submodelElements"));
-                  return parsedItemResult.castTo(Submodel.class);
-                }
-                theSubmodelElements.add(
-                  parsedItemResult.getResult());
-                indexSubmodelElements++;
+                return theSubmodelElementsResult.castTo(Submodel.class);
               }
+              theSubmodelElements = theSubmodelElementsResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -2410,14 +2031,14 @@ public class Jsonization {
                   "Expected the model type 'Submodel', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -2425,16 +2046,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theId == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"id\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Submodel(
+        return Reporting.Result.success(new Submodel(
           theId,
           theExtensions,
           theCategory,
@@ -2456,20 +2077,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends ISubmodelElement> tryISubmodelElementFrom(JsonNode node) {
+      public static Reporting.Result<? extends ISubmodelElement> tryISubmodelElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(ISubmodelElement.class);
         }
@@ -2507,7 +2128,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for ISubmodelElement: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -2518,20 +2139,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IRelationshipElement> tryIRelationshipElementFrom(JsonNode node) {
+      public static Reporting.Result<? extends IRelationshipElement> tryIRelationshipElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IRelationshipElement.class);
         }
@@ -2545,7 +2166,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IRelationshipElement: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -2556,11 +2177,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<RelationshipElement> tryRelationshipElementFrom(JsonNode node) {
+      private static Reporting.Result<RelationshipElement> tryRelationshipElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         IReference theFirst = null;
@@ -2586,7 +2207,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theFirstResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theFirstResult = tryReferenceFrom(currentNode.getValue());
               if (theFirstResult.isError()) {
                 theFirstResult.getError()
                   .prependSegment(new Reporting.NameSegment("first"));
@@ -2600,7 +2221,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSecondResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSecondResult = tryReferenceFrom(currentNode.getValue());
               if (theSecondResult.isError()) {
                 theSecondResult.getError()
                   .prependSegment(new Reporting.NameSegment("second"));
@@ -2621,42 +2242,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(RelationshipElement.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(RelationshipElement.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -2664,7 +2262,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -2678,7 +2276,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -2699,42 +2297,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(RelationshipElement.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(RelationshipElement.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -2749,42 +2324,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(RelationshipElement.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(RelationshipElement.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -2792,7 +2344,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -2813,42 +2365,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(RelationshipElement.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(RelationshipElement.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -2863,42 +2392,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(RelationshipElement.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(RelationshipElement.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -2913,51 +2419,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(RelationshipElement.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(RelationshipElement.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -2971,14 +2454,14 @@ public class Jsonization {
                   "Expected the model type 'RelationshipElement', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -2986,22 +2469,22 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theFirst == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"first\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSecond == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"second\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new RelationshipElement(
+        return Reporting.Result.success(new RelationshipElement(
           theFirst,
           theSecond,
           theExtensions,
@@ -3020,17 +2503,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<AasSubmodelElements> tryAasSubmodelElementsFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<AasSubmodelElements> tryAasSubmodelElementsFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(AasSubmodelElements.class);
         }
         final Optional<AasSubmodelElements> aasSubmodelElements = Stringification.aasSubmodelElementsFromString(textResult.getResult());
         if (!aasSubmodelElements.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of AasSubmodelElements");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(aasSubmodelElements.get());
+        return Reporting.Result.success(aasSubmodelElements.get());
       }
 
       /**
@@ -3039,11 +2522,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<SubmodelElementList> trySubmodelElementListFrom(JsonNode node) {
+      private static Reporting.Result<SubmodelElementList> trySubmodelElementListFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         AasSubmodelElements theTypeValueListElement = null;
@@ -3072,7 +2555,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends AasSubmodelElements> theTypeValueListElementResult = tryAasSubmodelElementsFrom(currentNode.getValue());
+              final Reporting.Result<? extends AasSubmodelElements> theTypeValueListElementResult = tryAasSubmodelElementsFrom(currentNode.getValue());
               if (theTypeValueListElementResult.isError()) {
                 theTypeValueListElementResult.getError()
                   .prependSegment(new Reporting.NameSegment("typeValueListElement"));
@@ -3093,42 +2576,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(SubmodelElementList.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(SubmodelElementList.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -3136,7 +2596,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -3150,7 +2610,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -3171,42 +2631,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(SubmodelElementList.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(SubmodelElementList.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -3221,42 +2658,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(SubmodelElementList.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(SubmodelElementList.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -3264,7 +2678,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -3285,42 +2699,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(SubmodelElementList.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(SubmodelElementList.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -3335,42 +2726,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(SubmodelElementList.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(SubmodelElementList.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -3385,42 +2753,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(SubmodelElementList.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(SubmodelElementList.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "orderRelevant": {
@@ -3428,7 +2773,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Boolean> theOrderRelevantResult = tryBooleanFrom(currentNode.getValue());
+              final Reporting.Result<? extends Boolean> theOrderRelevantResult = tryBooleanFrom(currentNode.getValue());
               if (theOrderRelevantResult.isError()) {
                 theOrderRelevantResult.getError()
                   .prependSegment(new Reporting.NameSegment("orderRelevant"));
@@ -3442,7 +2787,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdListElementResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdListElementResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdListElementResult.isError()) {
                 theSemanticIdListElementResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticIdListElement"));
@@ -3456,7 +2801,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends DataTypeDefXsd> theValueTypeListElementResult = tryDataTypeDefXsdFrom(currentNode.getValue());
+              final Reporting.Result<? extends DataTypeDefXsd> theValueTypeListElementResult = tryDataTypeDefXsdFrom(currentNode.getValue());
               if (theValueTypeListElementResult.isError()) {
                 theValueTypeListElementResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueTypeListElement"));
@@ -3477,51 +2822,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "value"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theValue = new ArrayList<>(
-                arrayValue.size());
-              int indexValue = 0;
-              for (JsonNode item : arrayValue) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValue));
-                  error.prependSegment(
+              final Reporting.Result<List<ISubmodelElement>> theValueResult = parseArray(
+                arrayValue,
+                _DeserializeImplementation::tryISubmodelElementFrom);
+              if (theValueResult.isError()) {
+                theValueResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISubmodelElement> parsedItemResult =
-                  tryISubmodelElementFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValue));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "value"));
-                  return parsedItemResult.castTo(SubmodelElementList.class);
-                }
-                theValue.add(
-                  parsedItemResult.getResult());
-                indexValue++;
+                return theValueResult.castTo(SubmodelElementList.class);
               }
+              theValue = theValueResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -3535,14 +2857,14 @@ public class Jsonization {
                   "Expected the model type 'SubmodelElementList', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -3550,16 +2872,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theTypeValueListElement == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"typeValueListElement\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new SubmodelElementList(
+        return Reporting.Result.success(new SubmodelElementList(
           theTypeValueListElement,
           theExtensions,
           theCategory,
@@ -3582,11 +2904,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<SubmodelElementCollection> trySubmodelElementCollectionFrom(JsonNode node) {
+      private static Reporting.Result<SubmodelElementCollection> trySubmodelElementCollectionFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IExtension> theExtensions = null;
@@ -3618,42 +2940,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(SubmodelElementCollection.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(SubmodelElementCollection.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -3661,7 +2960,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -3675,7 +2974,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -3696,42 +2995,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(SubmodelElementCollection.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(SubmodelElementCollection.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -3746,42 +3022,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(SubmodelElementCollection.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(SubmodelElementCollection.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -3789,7 +3042,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -3810,42 +3063,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(SubmodelElementCollection.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(SubmodelElementCollection.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -3860,42 +3090,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(SubmodelElementCollection.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(SubmodelElementCollection.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -3910,42 +3117,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(SubmodelElementCollection.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(SubmodelElementCollection.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "value": {
@@ -3960,51 +3144,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "value"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theValue = new ArrayList<>(
-                arrayValue.size());
-              int indexValue = 0;
-              for (JsonNode item : arrayValue) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValue));
-                  error.prependSegment(
+              final Reporting.Result<List<ISubmodelElement>> theValueResult = parseArray(
+                arrayValue,
+                _DeserializeImplementation::tryISubmodelElementFrom);
+              if (theValueResult.isError()) {
+                theValueResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISubmodelElement> parsedItemResult =
-                  tryISubmodelElementFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValue));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "value"));
-                  return parsedItemResult.castTo(SubmodelElementCollection.class);
-                }
-                theValue.add(
-                  parsedItemResult.getResult());
-                indexValue++;
+                return theValueResult.castTo(SubmodelElementCollection.class);
               }
+              theValue = theValueResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -4018,14 +3179,14 @@ public class Jsonization {
                   "Expected the model type 'SubmodelElementCollection', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -4033,12 +3194,12 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
 
 
-        return _Result.success(new SubmodelElementCollection(
+        return Reporting.Result.success(new SubmodelElementCollection(
           theExtensions,
           theCategory,
           theIdShort,
@@ -4057,20 +3218,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IDataElement> tryIDataElementFrom(JsonNode node) {
+      public static Reporting.Result<? extends IDataElement> tryIDataElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IDataElement.class);
         }
@@ -4092,7 +3253,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IDataElement: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -4103,11 +3264,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Property> tryPropertyFrom(JsonNode node) {
+      private static Reporting.Result<Property> tryPropertyFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         DataTypeDefXsd theValueType = null;
@@ -4134,7 +3295,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
+              final Reporting.Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
               if (theValueTypeResult.isError()) {
                 theValueTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueType"));
@@ -4155,42 +3316,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(Property.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(Property.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -4198,7 +3336,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -4212,7 +3350,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -4233,42 +3371,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(Property.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(Property.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -4283,42 +3398,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(Property.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(Property.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -4326,7 +3418,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -4347,42 +3439,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Property.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Property.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -4397,42 +3466,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(Property.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(Property.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -4447,42 +3493,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(Property.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(Property.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "value": {
@@ -4490,7 +3513,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -4504,7 +3527,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
               if (theValueIdResult.isError()) {
                 theValueIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueId"));
@@ -4517,9 +3540,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -4533,14 +3556,14 @@ public class Jsonization {
                   "Expected the model type 'Property', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -4548,16 +3571,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValueType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"valueType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Property(
+        return Reporting.Result.success(new Property(
           theValueType,
           theExtensions,
           theCategory,
@@ -4578,11 +3601,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<MultiLanguageProperty> tryMultiLanguagePropertyFrom(JsonNode node) {
+      private static Reporting.Result<MultiLanguageProperty> tryMultiLanguagePropertyFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IExtension> theExtensions = null;
@@ -4615,42 +3638,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(MultiLanguageProperty.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(MultiLanguageProperty.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -4658,7 +3658,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -4672,7 +3672,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -4693,42 +3693,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(MultiLanguageProperty.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(MultiLanguageProperty.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -4743,42 +3720,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(MultiLanguageProperty.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(MultiLanguageProperty.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -4786,7 +3740,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -4807,42 +3761,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(MultiLanguageProperty.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(MultiLanguageProperty.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -4857,42 +3788,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(MultiLanguageProperty.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(MultiLanguageProperty.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -4907,42 +3815,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(MultiLanguageProperty.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(MultiLanguageProperty.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "value": {
@@ -4957,42 +3842,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "value"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theValue = new ArrayList<>(
-                arrayValue.size());
-              int indexValue = 0;
-              for (JsonNode item : arrayValue) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValue));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theValueResult = parseArray(
+                arrayValue,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theValueResult.isError()) {
+                theValueResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValue));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "value"));
-                  return parsedItemResult.castTo(MultiLanguageProperty.class);
-                }
-                theValue.add(
-                  parsedItemResult.getResult());
-                indexValue++;
+                return theValueResult.castTo(MultiLanguageProperty.class);
               }
+              theValue = theValueResult.getResult();
               break;
             }
             case "valueId": {
@@ -5000,7 +3862,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
               if (theValueIdResult.isError()) {
                 theValueIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueId"));
@@ -5013,9 +3875,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -5029,14 +3891,14 @@ public class Jsonization {
                   "Expected the model type 'MultiLanguageProperty', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -5044,12 +3906,12 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
 
 
-        return _Result.success(new MultiLanguageProperty(
+        return Reporting.Result.success(new MultiLanguageProperty(
           theExtensions,
           theCategory,
           theIdShort,
@@ -5069,11 +3931,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Range> tryRangeFrom(JsonNode node) {
+      private static Reporting.Result<Range> tryRangeFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         DataTypeDefXsd theValueType = null;
@@ -5100,7 +3962,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
+              final Reporting.Result<? extends DataTypeDefXsd> theValueTypeResult = tryDataTypeDefXsdFrom(currentNode.getValue());
               if (theValueTypeResult.isError()) {
                 theValueTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueType"));
@@ -5121,42 +3983,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(Range.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(Range.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -5164,7 +4003,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -5178,7 +4017,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -5199,42 +4038,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(Range.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(Range.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -5249,42 +4065,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(Range.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(Range.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -5292,7 +4085,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -5313,42 +4106,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Range.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Range.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -5363,42 +4133,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(Range.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(Range.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -5413,42 +4160,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(Range.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(Range.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "min": {
@@ -5456,7 +4180,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theMinResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theMinResult = tryStringFrom(currentNode.getValue());
               if (theMinResult.isError()) {
                 theMinResult.getError()
                   .prependSegment(new Reporting.NameSegment("min"));
@@ -5470,7 +4194,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theMaxResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theMaxResult = tryStringFrom(currentNode.getValue());
               if (theMaxResult.isError()) {
                 theMaxResult.getError()
                   .prependSegment(new Reporting.NameSegment("max"));
@@ -5483,9 +4207,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -5499,14 +4223,14 @@ public class Jsonization {
                   "Expected the model type 'Range', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -5514,16 +4238,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValueType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"valueType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Range(
+        return Reporting.Result.success(new Range(
           theValueType,
           theExtensions,
           theCategory,
@@ -5544,11 +4268,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<ReferenceElement> tryReferenceElementFrom(JsonNode node) {
+      private static Reporting.Result<ReferenceElement> tryReferenceElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IExtension> theExtensions = null;
@@ -5580,42 +4304,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(ReferenceElement.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(ReferenceElement.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -5623,7 +4324,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -5637,7 +4338,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -5658,42 +4359,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(ReferenceElement.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(ReferenceElement.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -5708,42 +4386,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(ReferenceElement.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(ReferenceElement.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -5751,7 +4406,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -5772,42 +4427,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(ReferenceElement.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(ReferenceElement.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -5822,42 +4454,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(ReferenceElement.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(ReferenceElement.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -5872,42 +4481,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(ReferenceElement.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(ReferenceElement.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "value": {
@@ -5915,7 +4501,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theValueResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theValueResult = tryReferenceFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -5928,9 +4514,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -5944,14 +4530,14 @@ public class Jsonization {
                   "Expected the model type 'ReferenceElement', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -5959,12 +4545,12 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
 
 
-        return _Result.success(new ReferenceElement(
+        return Reporting.Result.success(new ReferenceElement(
           theExtensions,
           theCategory,
           theIdShort,
@@ -5983,11 +4569,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Blob> tryBlobFrom(JsonNode node) {
+      private static Reporting.Result<Blob> tryBlobFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theContentType = null;
@@ -6013,7 +4599,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theContentTypeResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theContentTypeResult = tryStringFrom(currentNode.getValue());
               if (theContentTypeResult.isError()) {
                 theContentTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("contentType"));
@@ -6034,42 +4620,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(Blob.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(Blob.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -6077,7 +4640,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -6091,7 +4654,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -6112,42 +4675,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(Blob.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(Blob.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -6162,42 +4702,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(Blob.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(Blob.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -6205,7 +4722,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -6226,42 +4743,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Blob.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Blob.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -6276,42 +4770,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(Blob.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(Blob.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -6326,42 +4797,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(Blob.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(Blob.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "value": {
@@ -6369,7 +4817,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends byte[]> theValueResult = tryBytesFrom(currentNode.getValue());
+              final Reporting.Result<? extends byte[]> theValueResult = tryBytesFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -6382,9 +4830,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -6398,14 +4846,14 @@ public class Jsonization {
                   "Expected the model type 'Blob', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -6413,16 +4861,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theContentType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"contentType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Blob(
+        return Reporting.Result.success(new Blob(
           theContentType,
           theExtensions,
           theCategory,
@@ -6442,11 +4890,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<File> tryFileFrom(JsonNode node) {
+      private static Reporting.Result<File> tryFileFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theContentType = null;
@@ -6472,7 +4920,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theContentTypeResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theContentTypeResult = tryStringFrom(currentNode.getValue());
               if (theContentTypeResult.isError()) {
                 theContentTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("contentType"));
@@ -6493,42 +4941,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(File.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(File.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -6536,7 +4961,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -6550,7 +4975,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -6571,42 +4996,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(File.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(File.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -6621,42 +5023,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(File.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(File.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -6664,7 +5043,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -6685,42 +5064,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(File.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(File.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -6735,42 +5091,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(File.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(File.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -6785,42 +5118,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(File.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(File.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "value": {
@@ -6828,7 +5138,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -6841,9 +5151,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -6857,14 +5167,14 @@ public class Jsonization {
                   "Expected the model type 'File', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -6872,16 +5182,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theContentType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"contentType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new File(
+        return Reporting.Result.success(new File(
           theContentType,
           theExtensions,
           theCategory,
@@ -6901,11 +5211,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<AnnotatedRelationshipElement> tryAnnotatedRelationshipElementFrom(JsonNode node) {
+      private static Reporting.Result<AnnotatedRelationshipElement> tryAnnotatedRelationshipElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         IReference theFirst = null;
@@ -6932,7 +5242,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theFirstResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theFirstResult = tryReferenceFrom(currentNode.getValue());
               if (theFirstResult.isError()) {
                 theFirstResult.getError()
                   .prependSegment(new Reporting.NameSegment("first"));
@@ -6946,7 +5256,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSecondResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSecondResult = tryReferenceFrom(currentNode.getValue());
               if (theSecondResult.isError()) {
                 theSecondResult.getError()
                   .prependSegment(new Reporting.NameSegment("second"));
@@ -6967,42 +5277,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(AnnotatedRelationshipElement.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(AnnotatedRelationshipElement.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -7010,7 +5297,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -7024,7 +5311,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -7045,42 +5332,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(AnnotatedRelationshipElement.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(AnnotatedRelationshipElement.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -7095,42 +5359,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(AnnotatedRelationshipElement.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(AnnotatedRelationshipElement.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -7138,7 +5379,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -7159,42 +5400,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(AnnotatedRelationshipElement.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(AnnotatedRelationshipElement.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -7209,42 +5427,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(AnnotatedRelationshipElement.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(AnnotatedRelationshipElement.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -7259,42 +5454,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(AnnotatedRelationshipElement.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(AnnotatedRelationshipElement.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "annotations": {
@@ -7309,51 +5481,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "annotations"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theAnnotations = new ArrayList<>(
-                arrayAnnotations.size());
-              int indexAnnotations = 0;
-              for (JsonNode item : arrayAnnotations) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexAnnotations));
-                  error.prependSegment(
+              final Reporting.Result<List<IDataElement>> theAnnotationsResult = parseArray(
+                arrayAnnotations,
+                _DeserializeImplementation::tryIDataElementFrom);
+              if (theAnnotationsResult.isError()) {
+                theAnnotationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "annotations"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IDataElement> parsedItemResult =
-                  tryIDataElementFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexAnnotations));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "annotations"));
-                  return parsedItemResult.castTo(AnnotatedRelationshipElement.class);
-                }
-                theAnnotations.add(
-                  parsedItemResult.getResult());
-                indexAnnotations++;
+                return theAnnotationsResult.castTo(AnnotatedRelationshipElement.class);
               }
+              theAnnotations = theAnnotationsResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -7367,14 +5516,14 @@ public class Jsonization {
                   "Expected the model type 'AnnotatedRelationshipElement', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -7382,22 +5531,22 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theFirst == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"first\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSecond == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"second\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new AnnotatedRelationshipElement(
+        return Reporting.Result.success(new AnnotatedRelationshipElement(
           theFirst,
           theSecond,
           theExtensions,
@@ -7418,11 +5567,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Entity> tryEntityFrom(JsonNode node) {
+      private static Reporting.Result<Entity> tryEntityFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         EntityType theEntityType = null;
@@ -7450,7 +5599,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends EntityType> theEntityTypeResult = tryEntityTypeFrom(currentNode.getValue());
+              final Reporting.Result<? extends EntityType> theEntityTypeResult = tryEntityTypeFrom(currentNode.getValue());
               if (theEntityTypeResult.isError()) {
                 theEntityTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("entityType"));
@@ -7471,42 +5620,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(Entity.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -7514,7 +5640,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -7528,7 +5654,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -7549,42 +5675,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(Entity.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -7599,42 +5702,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(Entity.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -7642,7 +5722,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -7663,42 +5743,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Entity.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -7713,42 +5770,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(Entity.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -7763,42 +5797,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(Entity.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "statements": {
@@ -7813,42 +5824,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "statements"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theStatements = new ArrayList<>(
-                arrayStatements.size());
-              int indexStatements = 0;
-              for (JsonNode item : arrayStatements) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexStatements));
-                  error.prependSegment(
+              final Reporting.Result<List<ISubmodelElement>> theStatementsResult = parseArray(
+                arrayStatements,
+                _DeserializeImplementation::tryISubmodelElementFrom);
+              if (theStatementsResult.isError()) {
+                theStatementsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "statements"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISubmodelElement> parsedItemResult =
-                  tryISubmodelElementFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexStatements));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "statements"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theStatements.add(
-                  parsedItemResult.getResult());
-                indexStatements++;
+                return theStatementsResult.castTo(Entity.class);
               }
+              theStatements = theStatementsResult.getResult();
               break;
             }
             case "globalAssetId": {
@@ -7856,7 +5844,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theGlobalAssetIdResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theGlobalAssetIdResult = tryStringFrom(currentNode.getValue());
               if (theGlobalAssetIdResult.isError()) {
                 theGlobalAssetIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("globalAssetId"));
@@ -7877,51 +5865,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "specificAssetIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSpecificAssetIds = new ArrayList<>(
-                arraySpecificAssetIds.size());
-              int indexSpecificAssetIds = 0;
-              for (JsonNode item : arraySpecificAssetIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSpecificAssetIds));
-                  error.prependSegment(
+              final Reporting.Result<List<ISpecificAssetId>> theSpecificAssetIdsResult = parseArray(
+                arraySpecificAssetIds,
+                _DeserializeImplementation::trySpecificAssetIdFrom);
+              if (theSpecificAssetIdsResult.isError()) {
+                theSpecificAssetIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "specificAssetIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISpecificAssetId> parsedItemResult =
-                  trySpecificAssetIdFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSpecificAssetIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "specificAssetIds"));
-                  return parsedItemResult.castTo(Entity.class);
-                }
-                theSpecificAssetIds.add(
-                  parsedItemResult.getResult());
-                indexSpecificAssetIds++;
+                return theSpecificAssetIdsResult.castTo(Entity.class);
               }
+              theSpecificAssetIds = theSpecificAssetIdsResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -7935,14 +5900,14 @@ public class Jsonization {
                   "Expected the model type 'Entity', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -7950,16 +5915,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theEntityType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"entityType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Entity(
+        return Reporting.Result.success(new Entity(
           theEntityType,
           theExtensions,
           theCategory,
@@ -7980,17 +5945,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<EntityType> tryEntityTypeFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<EntityType> tryEntityTypeFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(EntityType.class);
         }
         final Optional<EntityType> entityType = Stringification.entityTypeFromString(textResult.getResult());
         if (!entityType.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of EntityType");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(entityType.get());
+        return Reporting.Result.success(entityType.get());
       }
 
       /**
@@ -7998,17 +5963,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<Direction> tryDirectionFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<Direction> tryDirectionFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(Direction.class);
         }
         final Optional<Direction> direction = Stringification.directionFromString(textResult.getResult());
         if (!direction.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of Direction");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(direction.get());
+        return Reporting.Result.success(direction.get());
       }
 
       /**
@@ -8016,17 +5981,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<StateOfEvent> tryStateOfEventFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<StateOfEvent> tryStateOfEventFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(StateOfEvent.class);
         }
         final Optional<StateOfEvent> stateOfEvent = Stringification.stateOfEventFromString(textResult.getResult());
         if (!stateOfEvent.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of StateOfEvent");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(stateOfEvent.get());
+        return Reporting.Result.success(stateOfEvent.get());
       }
 
       /**
@@ -8035,11 +6000,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<EventPayload> tryEventPayloadFrom(JsonNode node) {
+      private static Reporting.Result<EventPayload> tryEventPayloadFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         IReference theSource = null;
@@ -8060,7 +6025,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSourceResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSourceResult = tryReferenceFrom(currentNode.getValue());
               if (theSourceResult.isError()) {
                 theSourceResult.getError()
                   .prependSegment(new Reporting.NameSegment("source"));
@@ -8074,7 +6039,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theObservableReferenceResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theObservableReferenceResult = tryReferenceFrom(currentNode.getValue());
               if (theObservableReferenceResult.isError()) {
                 theObservableReferenceResult.getError()
                   .prependSegment(new Reporting.NameSegment("observableReference"));
@@ -8088,7 +6053,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTimeStampResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTimeStampResult = tryStringFrom(currentNode.getValue());
               if (theTimeStampResult.isError()) {
                 theTimeStampResult.getError()
                   .prependSegment(new Reporting.NameSegment("timeStamp"));
@@ -8102,7 +6067,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSourceSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSourceSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSourceSemanticIdResult.isError()) {
                 theSourceSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("sourceSemanticId"));
@@ -8116,7 +6081,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theObservableSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theObservableSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theObservableSemanticIdResult.isError()) {
                 theObservableSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("observableSemanticId"));
@@ -8130,7 +6095,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTopicResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTopicResult = tryStringFrom(currentNode.getValue());
               if (theTopicResult.isError()) {
                 theTopicResult.getError()
                   .prependSegment(new Reporting.NameSegment("topic"));
@@ -8144,7 +6109,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSubjectIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSubjectIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSubjectIdResult.isError()) {
                 theSubjectIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("subjectId"));
@@ -8158,7 +6123,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends byte[]> thePayloadResult = tryBytesFrom(currentNode.getValue());
+              final Reporting.Result<? extends byte[]> thePayloadResult = tryBytesFrom(currentNode.getValue());
               if (thePayloadResult.isError()) {
                 thePayloadResult.getError()
                   .prependSegment(new Reporting.NameSegment("payload"));
@@ -8170,7 +6135,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -8178,22 +6143,22 @@ public class Jsonization {
         if (theSource == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"source\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theObservableReference == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"observableReference\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theTimeStamp == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"timeStamp\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new EventPayload(
+        return Reporting.Result.success(new EventPayload(
           theSource,
           theObservableReference,
           theTimeStamp,
@@ -8210,20 +6175,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IEventElement> tryIEventElementFrom(JsonNode node) {
+      public static Reporting.Result<? extends IEventElement> tryIEventElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IEventElement.class);
         }
@@ -8235,7 +6200,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IEventElement: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -8246,11 +6211,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<BasicEventElement> tryBasicEventElementFrom(JsonNode node) {
+      private static Reporting.Result<BasicEventElement> tryBasicEventElementFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         IReference theObserved = null;
@@ -8282,7 +6247,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theObservedResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theObservedResult = tryReferenceFrom(currentNode.getValue());
               if (theObservedResult.isError()) {
                 theObservedResult.getError()
                   .prependSegment(new Reporting.NameSegment("observed"));
@@ -8296,7 +6261,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Direction> theDirectionResult = tryDirectionFrom(currentNode.getValue());
+              final Reporting.Result<? extends Direction> theDirectionResult = tryDirectionFrom(currentNode.getValue());
               if (theDirectionResult.isError()) {
                 theDirectionResult.getError()
                   .prependSegment(new Reporting.NameSegment("direction"));
@@ -8310,7 +6275,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends StateOfEvent> theStateResult = tryStateOfEventFrom(currentNode.getValue());
+              final Reporting.Result<? extends StateOfEvent> theStateResult = tryStateOfEventFrom(currentNode.getValue());
               if (theStateResult.isError()) {
                 theStateResult.getError()
                   .prependSegment(new Reporting.NameSegment("state"));
@@ -8331,42 +6296,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(BasicEventElement.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(BasicEventElement.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -8374,7 +6316,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -8388,7 +6330,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -8409,42 +6351,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(BasicEventElement.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(BasicEventElement.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -8459,42 +6378,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(BasicEventElement.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(BasicEventElement.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -8502,7 +6398,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -8523,42 +6419,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(BasicEventElement.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(BasicEventElement.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -8573,42 +6446,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(BasicEventElement.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(BasicEventElement.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -8623,42 +6473,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(BasicEventElement.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(BasicEventElement.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "messageTopic": {
@@ -8666,7 +6493,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theMessageTopicResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theMessageTopicResult = tryStringFrom(currentNode.getValue());
               if (theMessageTopicResult.isError()) {
                 theMessageTopicResult.getError()
                   .prependSegment(new Reporting.NameSegment("messageTopic"));
@@ -8680,7 +6507,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theMessageBrokerResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theMessageBrokerResult = tryReferenceFrom(currentNode.getValue());
               if (theMessageBrokerResult.isError()) {
                 theMessageBrokerResult.getError()
                   .prependSegment(new Reporting.NameSegment("messageBroker"));
@@ -8694,7 +6521,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theLastUpdateResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theLastUpdateResult = tryStringFrom(currentNode.getValue());
               if (theLastUpdateResult.isError()) {
                 theLastUpdateResult.getError()
                   .prependSegment(new Reporting.NameSegment("lastUpdate"));
@@ -8708,7 +6535,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theMinIntervalResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theMinIntervalResult = tryStringFrom(currentNode.getValue());
               if (theMinIntervalResult.isError()) {
                 theMinIntervalResult.getError()
                   .prependSegment(new Reporting.NameSegment("minInterval"));
@@ -8722,7 +6549,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theMaxIntervalResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theMaxIntervalResult = tryStringFrom(currentNode.getValue());
               if (theMaxIntervalResult.isError()) {
                 theMaxIntervalResult.getError()
                   .prependSegment(new Reporting.NameSegment("maxInterval"));
@@ -8735,9 +6562,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -8751,14 +6578,14 @@ public class Jsonization {
                   "Expected the model type 'BasicEventElement', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -8766,28 +6593,28 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theObserved == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"observed\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theDirection == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"direction\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theState == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"state\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new BasicEventElement(
+        return Reporting.Result.success(new BasicEventElement(
           theObserved,
           theDirection,
           theState,
@@ -8813,11 +6640,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Operation> tryOperationFrom(JsonNode node) {
+      private static Reporting.Result<Operation> tryOperationFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IExtension> theExtensions = null;
@@ -8851,42 +6678,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(Operation.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -8894,7 +6698,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -8908,7 +6712,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -8929,42 +6733,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(Operation.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -8979,42 +6760,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(Operation.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -9022,7 +6780,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -9043,42 +6801,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Operation.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -9093,42 +6828,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(Operation.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -9143,42 +6855,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(Operation.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "inputVariables": {
@@ -9193,42 +6882,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "inputVariables"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theInputVariables = new ArrayList<>(
-                arrayInputVariables.size());
-              int indexInputVariables = 0;
-              for (JsonNode item : arrayInputVariables) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexInputVariables));
-                  error.prependSegment(
+              final Reporting.Result<List<IOperationVariable>> theInputVariablesResult = parseArray(
+                arrayInputVariables,
+                _DeserializeImplementation::tryOperationVariableFrom);
+              if (theInputVariablesResult.isError()) {
+                theInputVariablesResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "inputVariables"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IOperationVariable> parsedItemResult =
-                  tryOperationVariableFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexInputVariables));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "inputVariables"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theInputVariables.add(
-                  parsedItemResult.getResult());
-                indexInputVariables++;
+                return theInputVariablesResult.castTo(Operation.class);
               }
+              theInputVariables = theInputVariablesResult.getResult();
               break;
             }
             case "outputVariables": {
@@ -9243,42 +6909,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "outputVariables"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theOutputVariables = new ArrayList<>(
-                arrayOutputVariables.size());
-              int indexOutputVariables = 0;
-              for (JsonNode item : arrayOutputVariables) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexOutputVariables));
-                  error.prependSegment(
+              final Reporting.Result<List<IOperationVariable>> theOutputVariablesResult = parseArray(
+                arrayOutputVariables,
+                _DeserializeImplementation::tryOperationVariableFrom);
+              if (theOutputVariablesResult.isError()) {
+                theOutputVariablesResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "outputVariables"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IOperationVariable> parsedItemResult =
-                  tryOperationVariableFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexOutputVariables));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "outputVariables"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theOutputVariables.add(
-                  parsedItemResult.getResult());
-                indexOutputVariables++;
+                return theOutputVariablesResult.castTo(Operation.class);
               }
+              theOutputVariables = theOutputVariablesResult.getResult();
               break;
             }
             case "inoutputVariables": {
@@ -9293,51 +6936,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "inoutputVariables"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theInoutputVariables = new ArrayList<>(
-                arrayInoutputVariables.size());
-              int indexInoutputVariables = 0;
-              for (JsonNode item : arrayInoutputVariables) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexInoutputVariables));
-                  error.prependSegment(
+              final Reporting.Result<List<IOperationVariable>> theInoutputVariablesResult = parseArray(
+                arrayInoutputVariables,
+                _DeserializeImplementation::tryOperationVariableFrom);
+              if (theInoutputVariablesResult.isError()) {
+                theInoutputVariablesResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "inoutputVariables"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IOperationVariable> parsedItemResult =
-                  tryOperationVariableFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexInoutputVariables));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "inoutputVariables"));
-                  return parsedItemResult.castTo(Operation.class);
-                }
-                theInoutputVariables.add(
-                  parsedItemResult.getResult());
-                indexInoutputVariables++;
+                return theInoutputVariablesResult.castTo(Operation.class);
               }
+              theInoutputVariables = theInoutputVariablesResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -9351,14 +6971,14 @@ public class Jsonization {
                   "Expected the model type 'Operation', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -9366,12 +6986,12 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
 
 
-        return _Result.success(new Operation(
+        return Reporting.Result.success(new Operation(
           theExtensions,
           theCategory,
           theIdShort,
@@ -9392,11 +7012,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<OperationVariable> tryOperationVariableFrom(JsonNode node) {
+      private static Reporting.Result<OperationVariable> tryOperationVariableFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         ISubmodelElement theValue = null;
@@ -9410,7 +7030,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends ISubmodelElement> theValueResult = tryISubmodelElementFrom(currentNode.getValue());
+              final Reporting.Result<? extends ISubmodelElement> theValueResult = tryISubmodelElementFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -9422,7 +7042,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -9430,10 +7050,10 @@ public class Jsonization {
         if (theValue == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"value\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new OperationVariable(
+        return Reporting.Result.success(new OperationVariable(
           theValue));
       }
 
@@ -9443,11 +7063,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Capability> tryCapabilityFrom(JsonNode node) {
+      private static Reporting.Result<Capability> tryCapabilityFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IExtension> theExtensions = null;
@@ -9478,42 +7098,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(Capability.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(Capability.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -9521,7 +7118,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -9535,7 +7132,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -9556,42 +7153,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(Capability.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(Capability.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -9606,42 +7180,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(Capability.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(Capability.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "semanticId": {
@@ -9649,7 +7200,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theSemanticIdResult.isError()) {
                 theSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("semanticId"));
@@ -9670,42 +7221,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "supplementalSemanticIds"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSupplementalSemanticIds = new ArrayList<>(
-                arraySupplementalSemanticIds.size());
-              int indexSupplementalSemanticIds = 0;
-              for (JsonNode item : arraySupplementalSemanticIds) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theSupplementalSemanticIdsResult = parseArray(
+                arraySupplementalSemanticIds,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theSupplementalSemanticIdsResult.isError()) {
+                theSupplementalSemanticIdsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "supplementalSemanticIds"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSupplementalSemanticIds));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "supplementalSemanticIds"));
-                  return parsedItemResult.castTo(Capability.class);
-                }
-                theSupplementalSemanticIds.add(
-                  parsedItemResult.getResult());
-                indexSupplementalSemanticIds++;
+                return theSupplementalSemanticIdsResult.castTo(Capability.class);
               }
+              theSupplementalSemanticIds = theSupplementalSemanticIdsResult.getResult();
               break;
             }
             case "qualifiers": {
@@ -9720,42 +7248,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "qualifiers"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theQualifiers = new ArrayList<>(
-                arrayQualifiers.size());
-              int indexQualifiers = 0;
-              for (JsonNode item : arrayQualifiers) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  error.prependSegment(
+              final Reporting.Result<List<IQualifier>> theQualifiersResult = parseArray(
+                arrayQualifiers,
+                _DeserializeImplementation::tryQualifierFrom);
+              if (theQualifiersResult.isError()) {
+                theQualifiersResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "qualifiers"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IQualifier> parsedItemResult =
-                  tryQualifierFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexQualifiers));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "qualifiers"));
-                  return parsedItemResult.castTo(Capability.class);
-                }
-                theQualifiers.add(
-                  parsedItemResult.getResult());
-                indexQualifiers++;
+                return theQualifiersResult.castTo(Capability.class);
               }
+              theQualifiers = theQualifiersResult.getResult();
               break;
             }
             case "embeddedDataSpecifications": {
@@ -9770,51 +7275,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(Capability.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(Capability.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -9828,14 +7310,14 @@ public class Jsonization {
                   "Expected the model type 'Capability', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -9843,12 +7325,12 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
 
 
-        return _Result.success(new Capability(
+        return Reporting.Result.success(new Capability(
           theExtensions,
           theCategory,
           theIdShort,
@@ -9866,11 +7348,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<ConceptDescription> tryConceptDescriptionFrom(JsonNode node) {
+      private static Reporting.Result<ConceptDescription> tryConceptDescriptionFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theId = null;
@@ -9894,7 +7376,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdResult = tryStringFrom(currentNode.getValue());
               if (theIdResult.isError()) {
                 theIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("id"));
@@ -9915,42 +7397,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "extensions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theExtensions = new ArrayList<>(
-                arrayExtensions.size());
-              int indexExtensions = 0;
-              for (JsonNode item : arrayExtensions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  error.prependSegment(
+              final Reporting.Result<List<IExtension>> theExtensionsResult = parseArray(
+                arrayExtensions,
+                _DeserializeImplementation::tryExtensionFrom);
+              if (theExtensionsResult.isError()) {
+                theExtensionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "extensions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IExtension> parsedItemResult =
-                  tryExtensionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexExtensions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "extensions"));
-                  return parsedItemResult.castTo(ConceptDescription.class);
-                }
-                theExtensions.add(
-                  parsedItemResult.getResult());
-                indexExtensions++;
+                return theExtensionsResult.castTo(ConceptDescription.class);
               }
+              theExtensions = theExtensionsResult.getResult();
               break;
             }
             case "category": {
@@ -9958,7 +7417,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theCategoryResult = tryStringFrom(currentNode.getValue());
               if (theCategoryResult.isError()) {
                 theCategoryResult.getError()
                   .prependSegment(new Reporting.NameSegment("category"));
@@ -9972,7 +7431,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdShortResult = tryStringFrom(currentNode.getValue());
               if (theIdShortResult.isError()) {
                 theIdShortResult.getError()
                   .prependSegment(new Reporting.NameSegment("idShort"));
@@ -9993,42 +7452,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "displayName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDisplayName = new ArrayList<>(
-                arrayDisplayName.size());
-              int indexDisplayName = 0;
-              for (JsonNode item : arrayDisplayName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringNameType>> theDisplayNameResult = parseArray(
+                arrayDisplayName,
+                _DeserializeImplementation::tryLangStringNameTypeFrom);
+              if (theDisplayNameResult.isError()) {
+                theDisplayNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "displayName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringNameType> parsedItemResult =
-                  tryLangStringNameTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDisplayName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "displayName"));
-                  return parsedItemResult.castTo(ConceptDescription.class);
-                }
-                theDisplayName.add(
-                  parsedItemResult.getResult());
-                indexDisplayName++;
+                return theDisplayNameResult.castTo(ConceptDescription.class);
               }
+              theDisplayName = theDisplayNameResult.getResult();
               break;
             }
             case "description": {
@@ -10043,42 +7479,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "description"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDescription = new ArrayList<>(
-                arrayDescription.size());
-              int indexDescription = 0;
-              for (JsonNode item : arrayDescription) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringTextType>> theDescriptionResult = parseArray(
+                arrayDescription,
+                _DeserializeImplementation::tryLangStringTextTypeFrom);
+              if (theDescriptionResult.isError()) {
+                theDescriptionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringTextType> parsedItemResult =
-                  tryLangStringTextTypeFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDescription));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "description"));
-                  return parsedItemResult.castTo(ConceptDescription.class);
-                }
-                theDescription.add(
-                  parsedItemResult.getResult());
-                indexDescription++;
+                return theDescriptionResult.castTo(ConceptDescription.class);
               }
+              theDescription = theDescriptionResult.getResult();
               break;
             }
             case "administration": {
@@ -10086,7 +7499,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IAdministrativeInformation> theAdministrationResult = tryAdministrativeInformationFrom(currentNode.getValue());
+              final Reporting.Result<? extends IAdministrativeInformation> theAdministrationResult = tryAdministrativeInformationFrom(currentNode.getValue());
               if (theAdministrationResult.isError()) {
                 theAdministrationResult.getError()
                   .prependSegment(new Reporting.NameSegment("administration"));
@@ -10107,42 +7520,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "embeddedDataSpecifications"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theEmbeddedDataSpecifications = new ArrayList<>(
-                arrayEmbeddedDataSpecifications.size());
-              int indexEmbeddedDataSpecifications = 0;
-              for (JsonNode item : arrayEmbeddedDataSpecifications) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  error.prependSegment(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> theEmbeddedDataSpecificationsResult = parseArray(
+                arrayEmbeddedDataSpecifications,
+                _DeserializeImplementation::tryEmbeddedDataSpecificationFrom);
+              if (theEmbeddedDataSpecificationsResult.isError()) {
+                theEmbeddedDataSpecificationsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "embeddedDataSpecifications"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IEmbeddedDataSpecification> parsedItemResult =
-                  tryEmbeddedDataSpecificationFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexEmbeddedDataSpecifications));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "embeddedDataSpecifications"));
-                  return parsedItemResult.castTo(ConceptDescription.class);
-                }
-                theEmbeddedDataSpecifications.add(
-                  parsedItemResult.getResult());
-                indexEmbeddedDataSpecifications++;
+                return theEmbeddedDataSpecificationsResult.castTo(ConceptDescription.class);
               }
+              theEmbeddedDataSpecifications = theEmbeddedDataSpecificationsResult.getResult();
               break;
             }
             case "isCaseOf": {
@@ -10157,51 +7547,28 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "isCaseOf"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theIsCaseOf = new ArrayList<>(
-                arrayIsCaseOf.size());
-              int indexIsCaseOf = 0;
-              for (JsonNode item : arrayIsCaseOf) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexIsCaseOf));
-                  error.prependSegment(
+              final Reporting.Result<List<IReference>> theIsCaseOfResult = parseArray(
+                arrayIsCaseOf,
+                _DeserializeImplementation::tryReferenceFrom);
+              if (theIsCaseOfResult.isError()) {
+                theIsCaseOfResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "isCaseOf"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IReference> parsedItemResult =
-                  tryReferenceFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexIsCaseOf));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "isCaseOf"));
-                  return parsedItemResult.castTo(ConceptDescription.class);
-                }
-                theIsCaseOf.add(
-                  parsedItemResult.getResult());
-                indexIsCaseOf++;
+                return theIsCaseOfResult.castTo(ConceptDescription.class);
               }
+              theIsCaseOf = theIsCaseOfResult.getResult();
               break;
             }
             case "modelType": {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -10215,14 +7582,14 @@ public class Jsonization {
                   "Expected the model type 'ConceptDescription', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -10230,16 +7597,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theId == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"id\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new ConceptDescription(
+        return Reporting.Result.success(new ConceptDescription(
           theId,
           theExtensions,
           theCategory,
@@ -10256,17 +7623,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<ReferenceTypes> tryReferenceTypesFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<ReferenceTypes> tryReferenceTypesFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(ReferenceTypes.class);
         }
         final Optional<ReferenceTypes> referenceTypes = Stringification.referenceTypesFromString(textResult.getResult());
         if (!referenceTypes.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of ReferenceTypes");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(referenceTypes.get());
+        return Reporting.Result.success(referenceTypes.get());
       }
 
       /**
@@ -10275,11 +7642,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Reference> tryReferenceFrom(JsonNode node) {
+      private static Reporting.Result<Reference> tryReferenceFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         ReferenceTypes theType = null;
@@ -10295,7 +7662,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends ReferenceTypes> theTypeResult = tryReferenceTypesFrom(currentNode.getValue());
+              final Reporting.Result<? extends ReferenceTypes> theTypeResult = tryReferenceTypesFrom(currentNode.getValue());
               if (theTypeResult.isError()) {
                 theTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("type"));
@@ -10316,42 +7683,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "keys"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theKeys = new ArrayList<>(
-                arrayKeys.size());
-              int indexKeys = 0;
-              for (JsonNode item : arrayKeys) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexKeys));
-                  error.prependSegment(
+              final Reporting.Result<List<IKey>> theKeysResult = parseArray(
+                arrayKeys,
+                _DeserializeImplementation::tryKeyFrom);
+              if (theKeysResult.isError()) {
+                theKeysResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "keys"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IKey> parsedItemResult =
-                  tryKeyFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexKeys));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "keys"));
-                  return parsedItemResult.castTo(Reference.class);
-                }
-                theKeys.add(
-                  parsedItemResult.getResult());
-                indexKeys++;
+                return theKeysResult.castTo(Reference.class);
               }
+              theKeys = theKeysResult.getResult();
               break;
             }
             case "referredSemanticId": {
@@ -10359,7 +7703,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theReferredSemanticIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theReferredSemanticIdResult = tryReferenceFrom(currentNode.getValue());
               if (theReferredSemanticIdResult.isError()) {
                 theReferredSemanticIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("referredSemanticId"));
@@ -10371,7 +7715,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -10379,16 +7723,16 @@ public class Jsonization {
         if (theType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"type\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theKeys == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"keys\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Reference(
+        return Reporting.Result.success(new Reference(
           theType,
           theKeys,
           theReferredSemanticId));
@@ -10400,11 +7744,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Key> tryKeyFrom(JsonNode node) {
+      private static Reporting.Result<Key> tryKeyFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         KeyTypes theType = null;
@@ -10419,7 +7763,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends KeyTypes> theTypeResult = tryKeyTypesFrom(currentNode.getValue());
+              final Reporting.Result<? extends KeyTypes> theTypeResult = tryKeyTypesFrom(currentNode.getValue());
               if (theTypeResult.isError()) {
                 theTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("type"));
@@ -10433,7 +7777,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -10445,7 +7789,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -10453,16 +7797,16 @@ public class Jsonization {
         if (theType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"type\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValue == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"value\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Key(
+        return Reporting.Result.success(new Key(
           theType,
           theValue));
       }
@@ -10472,17 +7816,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<KeyTypes> tryKeyTypesFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<KeyTypes> tryKeyTypesFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(KeyTypes.class);
         }
         final Optional<KeyTypes> keyTypes = Stringification.keyTypesFromString(textResult.getResult());
         if (!keyTypes.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of KeyTypes");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(keyTypes.get());
+        return Reporting.Result.success(keyTypes.get());
       }
 
       /**
@@ -10490,17 +7834,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<DataTypeDefXsd> tryDataTypeDefXsdFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<DataTypeDefXsd> tryDataTypeDefXsdFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(DataTypeDefXsd.class);
         }
         final Optional<DataTypeDefXsd> dataTypeDefXsd = Stringification.dataTypeDefXsdFromString(textResult.getResult());
         if (!dataTypeDefXsd.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of DataTypeDefXsd");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(dataTypeDefXsd.get());
+        return Reporting.Result.success(dataTypeDefXsd.get());
       }
 
       /**
@@ -10509,20 +7853,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IAbstractLangString> tryIAbstractLangStringFrom(JsonNode node) {
+      public static Reporting.Result<? extends IAbstractLangString> tryIAbstractLangStringFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IAbstractLangString.class);
         }
@@ -10542,7 +7886,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IAbstractLangString: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -10553,11 +7897,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<LangStringNameType> tryLangStringNameTypeFrom(JsonNode node) {
+      private static Reporting.Result<LangStringNameType> tryLangStringNameTypeFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theLanguage = null;
@@ -10572,7 +7916,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
               if (theLanguageResult.isError()) {
                 theLanguageResult.getError()
                   .prependSegment(new Reporting.NameSegment("language"));
@@ -10586,7 +7930,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
               if (theTextResult.isError()) {
                 theTextResult.getError()
                   .prependSegment(new Reporting.NameSegment("text"));
@@ -10598,7 +7942,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -10606,16 +7950,16 @@ public class Jsonization {
         if (theLanguage == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"language\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theText == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"text\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new LangStringNameType(
+        return Reporting.Result.success(new LangStringNameType(
           theLanguage,
           theText));
       }
@@ -10626,11 +7970,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<LangStringTextType> tryLangStringTextTypeFrom(JsonNode node) {
+      private static Reporting.Result<LangStringTextType> tryLangStringTextTypeFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theLanguage = null;
@@ -10645,7 +7989,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
               if (theLanguageResult.isError()) {
                 theLanguageResult.getError()
                   .prependSegment(new Reporting.NameSegment("language"));
@@ -10659,7 +8003,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
               if (theTextResult.isError()) {
                 theTextResult.getError()
                   .prependSegment(new Reporting.NameSegment("text"));
@@ -10671,7 +8015,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -10679,16 +8023,16 @@ public class Jsonization {
         if (theLanguage == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"language\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theText == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"text\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new LangStringTextType(
+        return Reporting.Result.success(new LangStringTextType(
           theLanguage,
           theText));
       }
@@ -10699,11 +8043,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Environment> tryEnvironmentFrom(JsonNode node) {
+      private static Reporting.Result<Environment> tryEnvironmentFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IAssetAdministrationShell> theAssetAdministrationShells = null;
@@ -10726,42 +8070,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "assetAdministrationShells"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theAssetAdministrationShells = new ArrayList<>(
-                arrayAssetAdministrationShells.size());
-              int indexAssetAdministrationShells = 0;
-              for (JsonNode item : arrayAssetAdministrationShells) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexAssetAdministrationShells));
-                  error.prependSegment(
+              final Reporting.Result<List<IAssetAdministrationShell>> theAssetAdministrationShellsResult = parseArray(
+                arrayAssetAdministrationShells,
+                _DeserializeImplementation::tryAssetAdministrationShellFrom);
+              if (theAssetAdministrationShellsResult.isError()) {
+                theAssetAdministrationShellsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "assetAdministrationShells"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IAssetAdministrationShell> parsedItemResult =
-                  tryAssetAdministrationShellFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexAssetAdministrationShells));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "assetAdministrationShells"));
-                  return parsedItemResult.castTo(Environment.class);
-                }
-                theAssetAdministrationShells.add(
-                  parsedItemResult.getResult());
-                indexAssetAdministrationShells++;
+                return theAssetAdministrationShellsResult.castTo(Environment.class);
               }
+              theAssetAdministrationShells = theAssetAdministrationShellsResult.getResult();
               break;
             }
             case "submodels": {
@@ -10776,42 +8097,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "submodels"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSubmodels = new ArrayList<>(
-                arraySubmodels.size());
-              int indexSubmodels = 0;
-              for (JsonNode item : arraySubmodels) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSubmodels));
-                  error.prependSegment(
+              final Reporting.Result<List<ISubmodel>> theSubmodelsResult = parseArray(
+                arraySubmodels,
+                _DeserializeImplementation::trySubmodelFrom);
+              if (theSubmodelsResult.isError()) {
+                theSubmodelsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "submodels"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISubmodel> parsedItemResult =
-                  trySubmodelFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSubmodels));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "submodels"));
-                  return parsedItemResult.castTo(Environment.class);
-                }
-                theSubmodels.add(
-                  parsedItemResult.getResult());
-                indexSubmodels++;
+                return theSubmodelsResult.castTo(Environment.class);
               }
+              theSubmodels = theSubmodelsResult.getResult();
               break;
             }
             case "conceptDescriptions": {
@@ -10826,55 +8124,32 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "conceptDescriptions"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theConceptDescriptions = new ArrayList<>(
-                arrayConceptDescriptions.size());
-              int indexConceptDescriptions = 0;
-              for (JsonNode item : arrayConceptDescriptions) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexConceptDescriptions));
-                  error.prependSegment(
+              final Reporting.Result<List<IConceptDescription>> theConceptDescriptionsResult = parseArray(
+                arrayConceptDescriptions,
+                _DeserializeImplementation::tryConceptDescriptionFrom);
+              if (theConceptDescriptionsResult.isError()) {
+                theConceptDescriptionsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "conceptDescriptions"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IConceptDescription> parsedItemResult =
-                  tryConceptDescriptionFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexConceptDescriptions));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "conceptDescriptions"));
-                  return parsedItemResult.castTo(Environment.class);
-                }
-                theConceptDescriptions.add(
-                  parsedItemResult.getResult());
-                indexConceptDescriptions++;
+                return theConceptDescriptionsResult.castTo(Environment.class);
               }
+              theConceptDescriptions = theConceptDescriptionsResult.getResult();
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
 
 
 
-        return _Result.success(new Environment(
+        return Reporting.Result.success(new Environment(
           theAssetAdministrationShells,
           theSubmodels,
           theConceptDescriptions));
@@ -10886,20 +8161,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IDataSpecificationContent> tryIDataSpecificationContentFrom(JsonNode node) {
+      public static Reporting.Result<? extends IDataSpecificationContent> tryIDataSpecificationContentFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IDataSpecificationContent.class);
         }
@@ -10911,7 +8186,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IDataSpecificationContent: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -10922,11 +8197,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<EmbeddedDataSpecification> tryEmbeddedDataSpecificationFrom(JsonNode node) {
+      private static Reporting.Result<EmbeddedDataSpecification> tryEmbeddedDataSpecificationFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         IReference theDataSpecification = null;
@@ -10941,7 +8216,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theDataSpecificationResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theDataSpecificationResult = tryReferenceFrom(currentNode.getValue());
               if (theDataSpecificationResult.isError()) {
                 theDataSpecificationResult.getError()
                   .prependSegment(new Reporting.NameSegment("dataSpecification"));
@@ -10955,7 +8230,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IDataSpecificationContent> theDataSpecificationContentResult = tryIDataSpecificationContentFrom(currentNode.getValue());
+              final Reporting.Result<? extends IDataSpecificationContent> theDataSpecificationContentResult = tryIDataSpecificationContentFrom(currentNode.getValue());
               if (theDataSpecificationContentResult.isError()) {
                 theDataSpecificationContentResult.getError()
                   .prependSegment(new Reporting.NameSegment("dataSpecificationContent"));
@@ -10967,7 +8242,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -10975,16 +8250,16 @@ public class Jsonization {
         if (theDataSpecification == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"dataSpecification\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theDataSpecificationContent == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"dataSpecificationContent\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new EmbeddedDataSpecification(
+        return Reporting.Result.success(new EmbeddedDataSpecification(
           theDataSpecification,
           theDataSpecificationContent));
       }
@@ -10994,17 +8269,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<DataTypeIec61360> tryDataTypeIec61360From(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<DataTypeIec61360> tryDataTypeIec61360From(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(DataTypeIec61360.class);
         }
         final Optional<DataTypeIec61360> dataTypeIec61360 = Stringification.dataTypeIec61360FromString(textResult.getResult());
         if (!dataTypeIec61360.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of DataTypeIec61360");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(dataTypeIec61360.get());
+        return Reporting.Result.success(dataTypeIec61360.get());
       }
 
       /**
@@ -11013,11 +8288,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<LevelType> tryLevelTypeFrom(JsonNode node) {
+      private static Reporting.Result<LevelType> tryLevelTypeFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         Boolean theMin = null;
@@ -11034,7 +8309,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Boolean> theMinResult = tryBooleanFrom(currentNode.getValue());
+              final Reporting.Result<? extends Boolean> theMinResult = tryBooleanFrom(currentNode.getValue());
               if (theMinResult.isError()) {
                 theMinResult.getError()
                   .prependSegment(new Reporting.NameSegment("min"));
@@ -11048,7 +8323,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Boolean> theNomResult = tryBooleanFrom(currentNode.getValue());
+              final Reporting.Result<? extends Boolean> theNomResult = tryBooleanFrom(currentNode.getValue());
               if (theNomResult.isError()) {
                 theNomResult.getError()
                   .prependSegment(new Reporting.NameSegment("nom"));
@@ -11062,7 +8337,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Boolean> theTypResult = tryBooleanFrom(currentNode.getValue());
+              final Reporting.Result<? extends Boolean> theTypResult = tryBooleanFrom(currentNode.getValue());
               if (theTypResult.isError()) {
                 theTypResult.getError()
                   .prependSegment(new Reporting.NameSegment("typ"));
@@ -11076,7 +8351,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Boolean> theMaxResult = tryBooleanFrom(currentNode.getValue());
+              final Reporting.Result<? extends Boolean> theMaxResult = tryBooleanFrom(currentNode.getValue());
               if (theMaxResult.isError()) {
                 theMaxResult.getError()
                   .prependSegment(new Reporting.NameSegment("max"));
@@ -11088,7 +8363,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -11096,28 +8371,28 @@ public class Jsonization {
         if (theMin == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"min\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theNom == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"nom\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theTyp == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"typ\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theMax == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"max\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new LevelType(
+        return Reporting.Result.success(new LevelType(
           theMin,
           theNom,
           theTyp,
@@ -11130,11 +8405,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<ValueReferencePair> tryValueReferencePairFrom(JsonNode node) {
+      private static Reporting.Result<ValueReferencePair> tryValueReferencePairFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theValue = null;
@@ -11149,7 +8424,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -11163,7 +8438,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theValueIdResult = tryReferenceFrom(currentNode.getValue());
               if (theValueIdResult.isError()) {
                 theValueIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueId"));
@@ -11175,7 +8450,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -11183,16 +8458,16 @@ public class Jsonization {
         if (theValue == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"value\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValueId == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"valueId\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new ValueReferencePair(
+        return Reporting.Result.success(new ValueReferencePair(
           theValue,
           theValueId));
       }
@@ -11203,11 +8478,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<ValueList> tryValueListFrom(JsonNode node) {
+      private static Reporting.Result<ValueList> tryValueListFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IValueReferencePair> theValueReferencePairs = null;
@@ -11228,48 +8503,25 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "valueReferencePairs"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theValueReferencePairs = new ArrayList<>(
-                arrayValueReferencePairs.size());
-              int indexValueReferencePairs = 0;
-              for (JsonNode item : arrayValueReferencePairs) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValueReferencePairs));
-                  error.prependSegment(
+              final Reporting.Result<List<IValueReferencePair>> theValueReferencePairsResult = parseArray(
+                arrayValueReferencePairs,
+                _DeserializeImplementation::tryValueReferencePairFrom);
+              if (theValueReferencePairsResult.isError()) {
+                theValueReferencePairsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "valueReferencePairs"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IValueReferencePair> parsedItemResult =
-                  tryValueReferencePairFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexValueReferencePairs));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "valueReferencePairs"));
-                  return parsedItemResult.castTo(ValueList.class);
-                }
-                theValueReferencePairs.add(
-                  parsedItemResult.getResult());
-                indexValueReferencePairs++;
+                return theValueReferencePairsResult.castTo(ValueList.class);
               }
+              theValueReferencePairs = theValueReferencePairsResult.getResult();
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -11277,10 +8529,10 @@ public class Jsonization {
         if (theValueReferencePairs == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"valueReferencePairs\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new ValueList(
+        return Reporting.Result.success(new ValueList(
           theValueReferencePairs));
       }
 
@@ -11290,11 +8542,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<LangStringPreferredNameTypeIec61360> tryLangStringPreferredNameTypeIec61360From(JsonNode node) {
+      private static Reporting.Result<LangStringPreferredNameTypeIec61360> tryLangStringPreferredNameTypeIec61360From(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theLanguage = null;
@@ -11309,7 +8561,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
               if (theLanguageResult.isError()) {
                 theLanguageResult.getError()
                   .prependSegment(new Reporting.NameSegment("language"));
@@ -11323,7 +8575,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
               if (theTextResult.isError()) {
                 theTextResult.getError()
                   .prependSegment(new Reporting.NameSegment("text"));
@@ -11335,7 +8587,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -11343,16 +8595,16 @@ public class Jsonization {
         if (theLanguage == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"language\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theText == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"text\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new LangStringPreferredNameTypeIec61360(
+        return Reporting.Result.success(new LangStringPreferredNameTypeIec61360(
           theLanguage,
           theText));
       }
@@ -11363,11 +8615,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<LangStringShortNameTypeIec61360> tryLangStringShortNameTypeIec61360From(JsonNode node) {
+      private static Reporting.Result<LangStringShortNameTypeIec61360> tryLangStringShortNameTypeIec61360From(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theLanguage = null;
@@ -11382,7 +8634,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
               if (theLanguageResult.isError()) {
                 theLanguageResult.getError()
                   .prependSegment(new Reporting.NameSegment("language"));
@@ -11396,7 +8648,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
               if (theTextResult.isError()) {
                 theTextResult.getError()
                   .prependSegment(new Reporting.NameSegment("text"));
@@ -11408,7 +8660,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -11416,16 +8668,16 @@ public class Jsonization {
         if (theLanguage == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"language\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theText == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"text\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new LangStringShortNameTypeIec61360(
+        return Reporting.Result.success(new LangStringShortNameTypeIec61360(
           theLanguage,
           theText));
       }
@@ -11436,11 +8688,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<LangStringDefinitionTypeIec61360> tryLangStringDefinitionTypeIec61360From(JsonNode node) {
+      private static Reporting.Result<LangStringDefinitionTypeIec61360> tryLangStringDefinitionTypeIec61360From(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theLanguage = null;
@@ -11455,7 +8707,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theLanguageResult = tryStringFrom(currentNode.getValue());
               if (theLanguageResult.isError()) {
                 theLanguageResult.getError()
                   .prependSegment(new Reporting.NameSegment("language"));
@@ -11469,7 +8721,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTextResult = tryStringFrom(currentNode.getValue());
               if (theTextResult.isError()) {
                 theTextResult.getError()
                   .prependSegment(new Reporting.NameSegment("text"));
@@ -11481,7 +8733,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -11489,16 +8741,16 @@ public class Jsonization {
         if (theLanguage == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"language\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theText == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"text\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new LangStringDefinitionTypeIec61360(
+        return Reporting.Result.success(new LangStringDefinitionTypeIec61360(
           theLanguage,
           theText));
       }
@@ -11509,11 +8761,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<DataSpecificationIec61360> tryDataSpecificationIec61360From(JsonNode node) {
+      private static Reporting.Result<DataSpecificationIec61360> tryDataSpecificationIec61360From(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<ILangStringPreferredNameTypeIec61360> thePreferredName = null;
@@ -11547,42 +8799,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "preferredName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              thePreferredName = new ArrayList<>(
-                arrayPreferredName.size());
-              int indexPreferredName = 0;
-              for (JsonNode item : arrayPreferredName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexPreferredName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringPreferredNameTypeIec61360>> thePreferredNameResult = parseArray(
+                arrayPreferredName,
+                _DeserializeImplementation::tryLangStringPreferredNameTypeIec61360From);
+              if (thePreferredNameResult.isError()) {
+                thePreferredNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "preferredName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringPreferredNameTypeIec61360> parsedItemResult =
-                  tryLangStringPreferredNameTypeIec61360From(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexPreferredName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "preferredName"));
-                  return parsedItemResult.castTo(DataSpecificationIec61360.class);
-                }
-                thePreferredName.add(
-                  parsedItemResult.getResult());
-                indexPreferredName++;
+                return thePreferredNameResult.castTo(DataSpecificationIec61360.class);
               }
+              thePreferredName = thePreferredNameResult.getResult();
               break;
             }
             case "shortName": {
@@ -11597,42 +8826,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "shortName"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theShortName = new ArrayList<>(
-                arrayShortName.size());
-              int indexShortName = 0;
-              for (JsonNode item : arrayShortName) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexShortName));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringShortNameTypeIec61360>> theShortNameResult = parseArray(
+                arrayShortName,
+                _DeserializeImplementation::tryLangStringShortNameTypeIec61360From);
+              if (theShortNameResult.isError()) {
+                theShortNameResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "shortName"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringShortNameTypeIec61360> parsedItemResult =
-                  tryLangStringShortNameTypeIec61360From(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexShortName));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "shortName"));
-                  return parsedItemResult.castTo(DataSpecificationIec61360.class);
-                }
-                theShortName.add(
-                  parsedItemResult.getResult());
-                indexShortName++;
+                return theShortNameResult.castTo(DataSpecificationIec61360.class);
               }
+              theShortName = theShortNameResult.getResult();
               break;
             }
             case "unit": {
@@ -11640,7 +8846,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theUnitResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theUnitResult = tryStringFrom(currentNode.getValue());
               if (theUnitResult.isError()) {
                 theUnitResult.getError()
                   .prependSegment(new Reporting.NameSegment("unit"));
@@ -11654,7 +8860,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IReference> theUnitIdResult = tryReferenceFrom(currentNode.getValue());
+              final Reporting.Result<? extends IReference> theUnitIdResult = tryReferenceFrom(currentNode.getValue());
               if (theUnitIdResult.isError()) {
                 theUnitIdResult.getError()
                   .prependSegment(new Reporting.NameSegment("unitId"));
@@ -11668,7 +8874,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theSourceOfDefinitionResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theSourceOfDefinitionResult = tryStringFrom(currentNode.getValue());
               if (theSourceOfDefinitionResult.isError()) {
                 theSourceOfDefinitionResult.getError()
                   .prependSegment(new Reporting.NameSegment("sourceOfDefinition"));
@@ -11682,7 +8888,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theSymbolResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theSymbolResult = tryStringFrom(currentNode.getValue());
               if (theSymbolResult.isError()) {
                 theSymbolResult.getError()
                   .prependSegment(new Reporting.NameSegment("symbol"));
@@ -11696,7 +8902,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends DataTypeIec61360> theDataTypeResult = tryDataTypeIec61360From(currentNode.getValue());
+              final Reporting.Result<? extends DataTypeIec61360> theDataTypeResult = tryDataTypeIec61360From(currentNode.getValue());
               if (theDataTypeResult.isError()) {
                 theDataTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("dataType"));
@@ -11717,42 +8923,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "definition"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theDefinition = new ArrayList<>(
-                arrayDefinition.size());
-              int indexDefinition = 0;
-              for (JsonNode item : arrayDefinition) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDefinition));
-                  error.prependSegment(
+              final Reporting.Result<List<ILangStringDefinitionTypeIec61360>> theDefinitionResult = parseArray(
+                arrayDefinition,
+                _DeserializeImplementation::tryLangStringDefinitionTypeIec61360From);
+              if (theDefinitionResult.isError()) {
+                theDefinitionResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "definition"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ILangStringDefinitionTypeIec61360> parsedItemResult =
-                  tryLangStringDefinitionTypeIec61360From(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexDefinition));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "definition"));
-                  return parsedItemResult.castTo(DataSpecificationIec61360.class);
-                }
-                theDefinition.add(
-                  parsedItemResult.getResult());
-                indexDefinition++;
+                return theDefinitionResult.castTo(DataSpecificationIec61360.class);
               }
+              theDefinition = theDefinitionResult.getResult();
               break;
             }
             case "valueFormat": {
@@ -11760,7 +8943,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueFormatResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueFormatResult = tryStringFrom(currentNode.getValue());
               if (theValueFormatResult.isError()) {
                 theValueFormatResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueFormat"));
@@ -11774,7 +8957,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IValueList> theValueListResult = tryValueListFrom(currentNode.getValue());
+              final Reporting.Result<? extends IValueList> theValueListResult = tryValueListFrom(currentNode.getValue());
               if (theValueListResult.isError()) {
                 theValueListResult.getError()
                   .prependSegment(new Reporting.NameSegment("valueList"));
@@ -11788,7 +8971,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theValueResult = tryStringFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -11802,7 +8985,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends ILevelType> theLevelTypeResult = tryLevelTypeFrom(currentNode.getValue());
+              final Reporting.Result<? extends ILevelType> theLevelTypeResult = tryLevelTypeFrom(currentNode.getValue());
               if (theLevelTypeResult.isError()) {
                 theLevelTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("levelType"));
@@ -11815,9 +8998,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -11831,14 +9014,14 @@ public class Jsonization {
                   "Expected the model type 'DataSpecificationIec61360', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -11846,16 +9029,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (thePreferredName == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"preferredName\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new DataSpecificationIec61360(
+        return Reporting.Result.success(new DataSpecificationIec61360(
           thePreferredName,
           theShortName,
           theUnit,
@@ -11894,63 +9077,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -11971,7 +9097,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IHasSemantics deserializeIHasSemantics(JsonNode node) {
-        final _Result<? extends IHasSemantics> result =
+        final Reporting.Result<? extends IHasSemantics> result =
           _DeserializeImplementation.tryIHasSemanticsFrom(
             node);
 
@@ -11988,7 +9114,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Extension deserializeExtension(JsonNode node) {
-        final _Result<? extends Extension> result =
+        final Reporting.Result<? extends Extension> result =
           _DeserializeImplementation.tryExtensionFrom(
             node);
 
@@ -12005,7 +9131,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IHasExtensions deserializeIHasExtensions(JsonNode node) {
-        final _Result<? extends IHasExtensions> result =
+        final Reporting.Result<? extends IHasExtensions> result =
           _DeserializeImplementation.tryIHasExtensionsFrom(
             node);
 
@@ -12022,7 +9148,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IReferable deserializeIReferable(JsonNode node) {
-        final _Result<? extends IReferable> result =
+        final Reporting.Result<? extends IReferable> result =
           _DeserializeImplementation.tryIReferableFrom(
             node);
 
@@ -12039,7 +9165,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IIdentifiable deserializeIIdentifiable(JsonNode node) {
-        final _Result<? extends IIdentifiable> result =
+        final Reporting.Result<? extends IIdentifiable> result =
           _DeserializeImplementation.tryIIdentifiableFrom(
             node);
 
@@ -12056,7 +9182,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ModellingKind deserializeModellingKind(JsonNode node) {
-        final _Result<? extends ModellingKind> result =
+        final Reporting.Result<? extends ModellingKind> result =
           _DeserializeImplementation.tryModellingKindFrom(
             node);
 
@@ -12073,7 +9199,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IHasKind deserializeIHasKind(JsonNode node) {
-        final _Result<? extends IHasKind> result =
+        final Reporting.Result<? extends IHasKind> result =
           _DeserializeImplementation.tryIHasKindFrom(
             node);
 
@@ -12090,7 +9216,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IHasDataSpecification deserializeIHasDataSpecification(JsonNode node) {
-        final _Result<? extends IHasDataSpecification> result =
+        final Reporting.Result<? extends IHasDataSpecification> result =
           _DeserializeImplementation.tryIHasDataSpecificationFrom(
             node);
 
@@ -12107,7 +9233,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static AdministrativeInformation deserializeAdministrativeInformation(JsonNode node) {
-        final _Result<? extends AdministrativeInformation> result =
+        final Reporting.Result<? extends AdministrativeInformation> result =
           _DeserializeImplementation.tryAdministrativeInformationFrom(
             node);
 
@@ -12124,7 +9250,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IQualifiable deserializeIQualifiable(JsonNode node) {
-        final _Result<? extends IQualifiable> result =
+        final Reporting.Result<? extends IQualifiable> result =
           _DeserializeImplementation.tryIQualifiableFrom(
             node);
 
@@ -12141,7 +9267,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static QualifierKind deserializeQualifierKind(JsonNode node) {
-        final _Result<? extends QualifierKind> result =
+        final Reporting.Result<? extends QualifierKind> result =
           _DeserializeImplementation.tryQualifierKindFrom(
             node);
 
@@ -12158,7 +9284,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Qualifier deserializeQualifier(JsonNode node) {
-        final _Result<? extends Qualifier> result =
+        final Reporting.Result<? extends Qualifier> result =
           _DeserializeImplementation.tryQualifierFrom(
             node);
 
@@ -12175,7 +9301,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static AssetAdministrationShell deserializeAssetAdministrationShell(JsonNode node) {
-        final _Result<? extends AssetAdministrationShell> result =
+        final Reporting.Result<? extends AssetAdministrationShell> result =
           _DeserializeImplementation.tryAssetAdministrationShellFrom(
             node);
 
@@ -12192,7 +9318,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static AssetInformation deserializeAssetInformation(JsonNode node) {
-        final _Result<? extends AssetInformation> result =
+        final Reporting.Result<? extends AssetInformation> result =
           _DeserializeImplementation.tryAssetInformationFrom(
             node);
 
@@ -12209,7 +9335,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Resource deserializeResource(JsonNode node) {
-        final _Result<? extends Resource> result =
+        final Reporting.Result<? extends Resource> result =
           _DeserializeImplementation.tryResourceFrom(
             node);
 
@@ -12226,7 +9352,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static AssetKind deserializeAssetKind(JsonNode node) {
-        final _Result<? extends AssetKind> result =
+        final Reporting.Result<? extends AssetKind> result =
           _DeserializeImplementation.tryAssetKindFrom(
             node);
 
@@ -12243,7 +9369,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static SpecificAssetId deserializeSpecificAssetId(JsonNode node) {
-        final _Result<? extends SpecificAssetId> result =
+        final Reporting.Result<? extends SpecificAssetId> result =
           _DeserializeImplementation.trySpecificAssetIdFrom(
             node);
 
@@ -12260,7 +9386,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Submodel deserializeSubmodel(JsonNode node) {
-        final _Result<? extends Submodel> result =
+        final Reporting.Result<? extends Submodel> result =
           _DeserializeImplementation.trySubmodelFrom(
             node);
 
@@ -12277,7 +9403,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ISubmodelElement deserializeISubmodelElement(JsonNode node) {
-        final _Result<? extends ISubmodelElement> result =
+        final Reporting.Result<? extends ISubmodelElement> result =
           _DeserializeImplementation.tryISubmodelElementFrom(
             node);
 
@@ -12294,7 +9420,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IRelationshipElement deserializeIRelationshipElement(JsonNode node) {
-        final _Result<? extends IRelationshipElement> result =
+        final Reporting.Result<? extends IRelationshipElement> result =
           _DeserializeImplementation.tryIRelationshipElementFrom(
             node);
 
@@ -12311,7 +9437,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static RelationshipElement deserializeRelationshipElement(JsonNode node) {
-        final _Result<? extends RelationshipElement> result =
+        final Reporting.Result<? extends RelationshipElement> result =
           _DeserializeImplementation.tryRelationshipElementFrom(
             node);
 
@@ -12328,7 +9454,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static AasSubmodelElements deserializeAasSubmodelElements(JsonNode node) {
-        final _Result<? extends AasSubmodelElements> result =
+        final Reporting.Result<? extends AasSubmodelElements> result =
           _DeserializeImplementation.tryAasSubmodelElementsFrom(
             node);
 
@@ -12345,7 +9471,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static SubmodelElementList deserializeSubmodelElementList(JsonNode node) {
-        final _Result<? extends SubmodelElementList> result =
+        final Reporting.Result<? extends SubmodelElementList> result =
           _DeserializeImplementation.trySubmodelElementListFrom(
             node);
 
@@ -12362,7 +9488,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static SubmodelElementCollection deserializeSubmodelElementCollection(JsonNode node) {
-        final _Result<? extends SubmodelElementCollection> result =
+        final Reporting.Result<? extends SubmodelElementCollection> result =
           _DeserializeImplementation.trySubmodelElementCollectionFrom(
             node);
 
@@ -12379,7 +9505,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IDataElement deserializeIDataElement(JsonNode node) {
-        final _Result<? extends IDataElement> result =
+        final Reporting.Result<? extends IDataElement> result =
           _DeserializeImplementation.tryIDataElementFrom(
             node);
 
@@ -12396,7 +9522,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Property deserializeProperty(JsonNode node) {
-        final _Result<? extends Property> result =
+        final Reporting.Result<? extends Property> result =
           _DeserializeImplementation.tryPropertyFrom(
             node);
 
@@ -12413,7 +9539,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static MultiLanguageProperty deserializeMultiLanguageProperty(JsonNode node) {
-        final _Result<? extends MultiLanguageProperty> result =
+        final Reporting.Result<? extends MultiLanguageProperty> result =
           _DeserializeImplementation.tryMultiLanguagePropertyFrom(
             node);
 
@@ -12430,7 +9556,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Range deserializeRange(JsonNode node) {
-        final _Result<? extends Range> result =
+        final Reporting.Result<? extends Range> result =
           _DeserializeImplementation.tryRangeFrom(
             node);
 
@@ -12447,7 +9573,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ReferenceElement deserializeReferenceElement(JsonNode node) {
-        final _Result<? extends ReferenceElement> result =
+        final Reporting.Result<? extends ReferenceElement> result =
           _DeserializeImplementation.tryReferenceElementFrom(
             node);
 
@@ -12464,7 +9590,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Blob deserializeBlob(JsonNode node) {
-        final _Result<? extends Blob> result =
+        final Reporting.Result<? extends Blob> result =
           _DeserializeImplementation.tryBlobFrom(
             node);
 
@@ -12481,7 +9607,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static File deserializeFile(JsonNode node) {
-        final _Result<? extends File> result =
+        final Reporting.Result<? extends File> result =
           _DeserializeImplementation.tryFileFrom(
             node);
 
@@ -12498,7 +9624,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static AnnotatedRelationshipElement deserializeAnnotatedRelationshipElement(JsonNode node) {
-        final _Result<? extends AnnotatedRelationshipElement> result =
+        final Reporting.Result<? extends AnnotatedRelationshipElement> result =
           _DeserializeImplementation.tryAnnotatedRelationshipElementFrom(
             node);
 
@@ -12515,7 +9641,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Entity deserializeEntity(JsonNode node) {
-        final _Result<? extends Entity> result =
+        final Reporting.Result<? extends Entity> result =
           _DeserializeImplementation.tryEntityFrom(
             node);
 
@@ -12532,7 +9658,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static EntityType deserializeEntityType(JsonNode node) {
-        final _Result<? extends EntityType> result =
+        final Reporting.Result<? extends EntityType> result =
           _DeserializeImplementation.tryEntityTypeFrom(
             node);
 
@@ -12549,7 +9675,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Direction deserializeDirection(JsonNode node) {
-        final _Result<? extends Direction> result =
+        final Reporting.Result<? extends Direction> result =
           _DeserializeImplementation.tryDirectionFrom(
             node);
 
@@ -12566,7 +9692,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static StateOfEvent deserializeStateOfEvent(JsonNode node) {
-        final _Result<? extends StateOfEvent> result =
+        final Reporting.Result<? extends StateOfEvent> result =
           _DeserializeImplementation.tryStateOfEventFrom(
             node);
 
@@ -12583,7 +9709,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static EventPayload deserializeEventPayload(JsonNode node) {
-        final _Result<? extends EventPayload> result =
+        final Reporting.Result<? extends EventPayload> result =
           _DeserializeImplementation.tryEventPayloadFrom(
             node);
 
@@ -12600,7 +9726,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IEventElement deserializeIEventElement(JsonNode node) {
-        final _Result<? extends IEventElement> result =
+        final Reporting.Result<? extends IEventElement> result =
           _DeserializeImplementation.tryIEventElementFrom(
             node);
 
@@ -12617,7 +9743,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static BasicEventElement deserializeBasicEventElement(JsonNode node) {
-        final _Result<? extends BasicEventElement> result =
+        final Reporting.Result<? extends BasicEventElement> result =
           _DeserializeImplementation.tryBasicEventElementFrom(
             node);
 
@@ -12634,7 +9760,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Operation deserializeOperation(JsonNode node) {
-        final _Result<? extends Operation> result =
+        final Reporting.Result<? extends Operation> result =
           _DeserializeImplementation.tryOperationFrom(
             node);
 
@@ -12651,7 +9777,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static OperationVariable deserializeOperationVariable(JsonNode node) {
-        final _Result<? extends OperationVariable> result =
+        final Reporting.Result<? extends OperationVariable> result =
           _DeserializeImplementation.tryOperationVariableFrom(
             node);
 
@@ -12668,7 +9794,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Capability deserializeCapability(JsonNode node) {
-        final _Result<? extends Capability> result =
+        final Reporting.Result<? extends Capability> result =
           _DeserializeImplementation.tryCapabilityFrom(
             node);
 
@@ -12685,7 +9811,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ConceptDescription deserializeConceptDescription(JsonNode node) {
-        final _Result<? extends ConceptDescription> result =
+        final Reporting.Result<? extends ConceptDescription> result =
           _DeserializeImplementation.tryConceptDescriptionFrom(
             node);
 
@@ -12702,7 +9828,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ReferenceTypes deserializeReferenceTypes(JsonNode node) {
-        final _Result<? extends ReferenceTypes> result =
+        final Reporting.Result<? extends ReferenceTypes> result =
           _DeserializeImplementation.tryReferenceTypesFrom(
             node);
 
@@ -12719,7 +9845,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Reference deserializeReference(JsonNode node) {
-        final _Result<? extends Reference> result =
+        final Reporting.Result<? extends Reference> result =
           _DeserializeImplementation.tryReferenceFrom(
             node);
 
@@ -12736,7 +9862,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Key deserializeKey(JsonNode node) {
-        final _Result<? extends Key> result =
+        final Reporting.Result<? extends Key> result =
           _DeserializeImplementation.tryKeyFrom(
             node);
 
@@ -12753,7 +9879,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static KeyTypes deserializeKeyTypes(JsonNode node) {
-        final _Result<? extends KeyTypes> result =
+        final Reporting.Result<? extends KeyTypes> result =
           _DeserializeImplementation.tryKeyTypesFrom(
             node);
 
@@ -12770,7 +9896,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static DataTypeDefXsd deserializeDataTypeDefXsd(JsonNode node) {
-        final _Result<? extends DataTypeDefXsd> result =
+        final Reporting.Result<? extends DataTypeDefXsd> result =
           _DeserializeImplementation.tryDataTypeDefXsdFrom(
             node);
 
@@ -12787,7 +9913,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IAbstractLangString deserializeIAbstractLangString(JsonNode node) {
-        final _Result<? extends IAbstractLangString> result =
+        final Reporting.Result<? extends IAbstractLangString> result =
           _DeserializeImplementation.tryIAbstractLangStringFrom(
             node);
 
@@ -12804,7 +9930,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static LangStringNameType deserializeLangStringNameType(JsonNode node) {
-        final _Result<? extends LangStringNameType> result =
+        final Reporting.Result<? extends LangStringNameType> result =
           _DeserializeImplementation.tryLangStringNameTypeFrom(
             node);
 
@@ -12821,7 +9947,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static LangStringTextType deserializeLangStringTextType(JsonNode node) {
-        final _Result<? extends LangStringTextType> result =
+        final Reporting.Result<? extends LangStringTextType> result =
           _DeserializeImplementation.tryLangStringTextTypeFrom(
             node);
 
@@ -12838,7 +9964,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Environment deserializeEnvironment(JsonNode node) {
-        final _Result<? extends Environment> result =
+        final Reporting.Result<? extends Environment> result =
           _DeserializeImplementation.tryEnvironmentFrom(
             node);
 
@@ -12855,7 +9981,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IDataSpecificationContent deserializeIDataSpecificationContent(JsonNode node) {
-        final _Result<? extends IDataSpecificationContent> result =
+        final Reporting.Result<? extends IDataSpecificationContent> result =
           _DeserializeImplementation.tryIDataSpecificationContentFrom(
             node);
 
@@ -12872,7 +9998,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static EmbeddedDataSpecification deserializeEmbeddedDataSpecification(JsonNode node) {
-        final _Result<? extends EmbeddedDataSpecification> result =
+        final Reporting.Result<? extends EmbeddedDataSpecification> result =
           _DeserializeImplementation.tryEmbeddedDataSpecificationFrom(
             node);
 
@@ -12889,7 +10015,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static DataTypeIec61360 deserializeDataTypeIec61360(JsonNode node) {
-        final _Result<? extends DataTypeIec61360> result =
+        final Reporting.Result<? extends DataTypeIec61360> result =
           _DeserializeImplementation.tryDataTypeIec61360From(
             node);
 
@@ -12906,7 +10032,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static LevelType deserializeLevelType(JsonNode node) {
-        final _Result<? extends LevelType> result =
+        final Reporting.Result<? extends LevelType> result =
           _DeserializeImplementation.tryLevelTypeFrom(
             node);
 
@@ -12923,7 +10049,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ValueReferencePair deserializeValueReferencePair(JsonNode node) {
-        final _Result<? extends ValueReferencePair> result =
+        final Reporting.Result<? extends ValueReferencePair> result =
           _DeserializeImplementation.tryValueReferencePairFrom(
             node);
 
@@ -12940,7 +10066,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ValueList deserializeValueList(JsonNode node) {
-        final _Result<? extends ValueList> result =
+        final Reporting.Result<? extends ValueList> result =
           _DeserializeImplementation.tryValueListFrom(
             node);
 
@@ -12957,7 +10083,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static LangStringPreferredNameTypeIec61360 deserializeLangStringPreferredNameTypeIec61360(JsonNode node) {
-        final _Result<? extends LangStringPreferredNameTypeIec61360> result =
+        final Reporting.Result<? extends LangStringPreferredNameTypeIec61360> result =
           _DeserializeImplementation.tryLangStringPreferredNameTypeIec61360From(
             node);
 
@@ -12974,7 +10100,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static LangStringShortNameTypeIec61360 deserializeLangStringShortNameTypeIec61360(JsonNode node) {
-        final _Result<? extends LangStringShortNameTypeIec61360> result =
+        final Reporting.Result<? extends LangStringShortNameTypeIec61360> result =
           _DeserializeImplementation.tryLangStringShortNameTypeIec61360From(
             node);
 
@@ -12991,7 +10117,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static LangStringDefinitionTypeIec61360 deserializeLangStringDefinitionTypeIec61360(JsonNode node) {
-        final _Result<? extends LangStringDefinitionTypeIec61360> result =
+        final Reporting.Result<? extends LangStringDefinitionTypeIec61360> result =
           _DeserializeImplementation.tryLangStringDefinitionTypeIec61360From(
             node);
 
@@ -13008,7 +10134,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static DataSpecificationIec61360 deserializeDataSpecificationIec61360(JsonNode node) {
-        final _Result<? extends DataSpecificationIec61360> result =
+        final Reporting.Result<? extends DataSpecificationIec61360> result =
           _DeserializeImplementation.tryDataSpecificationIec61360From(
             node);
 
@@ -13036,6 +10162,34 @@ public class Jsonization {
         return JsonNodeFactory.instance.numberNode(that);
       }
 
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
+      }
+
       @Override
       public JsonNode transformExtension(
         IExtension that
@@ -13048,12 +10202,11 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
@@ -13071,12 +10224,11 @@ public class Jsonization {
         }
 
         if (that.getRefersTo().isPresent()) {
-          final ArrayNode arrayRefersTo = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getRefersTo().get()) {
-            arrayRefersTo.add(
+          final ArrayNode arrayRefersTo = serializeArray(
+            that.getRefersTo().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("refersTo", arrayRefersTo);
         }
 
@@ -13090,12 +10242,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -13134,12 +10285,11 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
@@ -13174,12 +10324,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13194,22 +10343,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -13222,12 +10369,11 @@ public class Jsonization {
           that.getId()));
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -13240,12 +10386,11 @@ public class Jsonization {
           that.getAssetInformation()));
 
         if (that.getSubmodels().isPresent()) {
-          final ArrayNode arraySubmodels = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSubmodels().get()) {
-            arraySubmodels.add(
+          final ArrayNode arraySubmodels = serializeArray(
+            that.getSubmodels().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("submodels", arraySubmodels);
         }
 
@@ -13269,12 +10414,11 @@ public class Jsonization {
         }
 
         if (that.getSpecificAssetIds().isPresent()) {
-          final ArrayNode arraySpecificAssetIds = JsonNodeFactory.instance.arrayNode();
-          for (ISpecificAssetId item : that.getSpecificAssetIds().get()) {
-            arraySpecificAssetIds.add(
+          final ArrayNode arraySpecificAssetIds = serializeArray(
+            that.getSpecificAssetIds().get(),
+            (ISpecificAssetId item) ->
               transform(
                 item));
-          }
           result.set("specificAssetIds", arraySpecificAssetIds);
         }
 
@@ -13320,12 +10464,11 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
@@ -13350,12 +10493,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13370,22 +10512,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -13408,42 +10548,38 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
         if (that.getSubmodelElements().isPresent()) {
-          final ArrayNode arraySubmodelElements = JsonNodeFactory.instance.arrayNode();
-          for (ISubmodelElement item : that.getSubmodelElements().get()) {
-            arraySubmodelElements.add(
+          final ArrayNode arraySubmodelElements = serializeArray(
+            that.getSubmodelElements().get(),
+            (ISubmodelElement item) ->
               transform(
                 item));
-          }
           result.set("submodelElements", arraySubmodelElements);
         }
 
@@ -13459,12 +10595,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13479,22 +10614,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -13504,32 +10637,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -13551,12 +10681,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13571,22 +10700,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -13596,32 +10723,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -13644,12 +10768,11 @@ public class Jsonization {
         }
 
         if (that.getValue().isPresent()) {
-          final ArrayNode arrayValue = JsonNodeFactory.instance.arrayNode();
-          for (ISubmodelElement item : that.getValue().get()) {
-            arrayValue.add(
+          final ArrayNode arrayValue = serializeArray(
+            that.getValue().get(),
+            (ISubmodelElement item) ->
               transform(
                 item));
-          }
           result.set("value", arrayValue);
         }
 
@@ -13665,12 +10788,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13685,22 +10807,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -13710,42 +10830,38 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
         if (that.getValue().isPresent()) {
-          final ArrayNode arrayValue = JsonNodeFactory.instance.arrayNode();
-          for (ISubmodelElement item : that.getValue().get()) {
-            arrayValue.add(
+          final ArrayNode arrayValue = serializeArray(
+            that.getValue().get(),
+            (ISubmodelElement item) ->
               transform(
                 item));
-          }
           result.set("value", arrayValue);
         }
 
@@ -13761,12 +10877,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13781,22 +10896,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -13806,32 +10919,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -13860,12 +10970,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13880,22 +10989,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -13905,42 +11012,38 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
         if (that.getValue().isPresent()) {
-          final ArrayNode arrayValue = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getValue().get()) {
-            arrayValue.add(
+          final ArrayNode arrayValue = serializeArray(
+            that.getValue().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("value", arrayValue);
         }
 
@@ -13961,12 +11064,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -13981,22 +11083,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14006,32 +11106,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -14060,12 +11157,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14080,22 +11176,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14105,32 +11199,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -14151,12 +11242,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14171,22 +11261,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14196,39 +11284,35 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
         if (that.getValue().isPresent()) {
-          result.set("value", JsonNodeFactory.instance.textNode(
-              Base64.getEncoder()
-                .encodeToString(that.getValue().get())));
+          result.set("value", _Transformer.bytesToJsonNode(
+            that.getValue().get()));
         }
 
         result.set("contentType", JsonNodeFactory.instance.textNode(
@@ -14246,12 +11330,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14266,22 +11349,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14291,32 +11372,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -14340,12 +11418,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14360,22 +11437,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14385,32 +11460,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -14421,12 +11493,11 @@ public class Jsonization {
           that.getSecond()));
 
         if (that.getAnnotations().isPresent()) {
-          final ArrayNode arrayAnnotations = JsonNodeFactory.instance.arrayNode();
-          for (IDataElement item : that.getAnnotations().get()) {
-            arrayAnnotations.add(
+          final ArrayNode arrayAnnotations = serializeArray(
+            that.getAnnotations().get(),
+            (IDataElement item) ->
               transform(
                 item));
-          }
           result.set("annotations", arrayAnnotations);
         }
 
@@ -14442,12 +11513,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14462,22 +11532,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14487,42 +11555,38 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
         if (that.getStatements().isPresent()) {
-          final ArrayNode arrayStatements = JsonNodeFactory.instance.arrayNode();
-          for (ISubmodelElement item : that.getStatements().get()) {
-            arrayStatements.add(
+          final ArrayNode arrayStatements = serializeArray(
+            that.getStatements().get(),
+            (ISubmodelElement item) ->
               transform(
                 item));
-          }
           result.set("statements", arrayStatements);
         }
 
@@ -14535,12 +11599,11 @@ public class Jsonization {
         }
 
         if (that.getSpecificAssetIds().isPresent()) {
-          final ArrayNode arraySpecificAssetIds = JsonNodeFactory.instance.arrayNode();
-          for (ISpecificAssetId item : that.getSpecificAssetIds().get()) {
-            arraySpecificAssetIds.add(
+          final ArrayNode arraySpecificAssetIds = serializeArray(
+            that.getSpecificAssetIds().get(),
+            (ISpecificAssetId item) ->
               transform(
                 item));
-          }
           result.set("specificAssetIds", arraySpecificAssetIds);
         }
 
@@ -14585,9 +11648,8 @@ public class Jsonization {
           that.getTimeStamp()));
 
         if (that.getPayload().isPresent()) {
-          result.set("payload", JsonNodeFactory.instance.textNode(
-              Base64.getEncoder()
-                .encodeToString(that.getPayload().get())));
+          result.set("payload", _Transformer.bytesToJsonNode(
+            that.getPayload().get()));
         }
 
         return result;
@@ -14600,12 +11662,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14620,22 +11681,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14645,32 +11704,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -14720,12 +11776,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14740,22 +11795,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14765,62 +11818,56 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
         if (that.getInputVariables().isPresent()) {
-          final ArrayNode arrayInputVariables = JsonNodeFactory.instance.arrayNode();
-          for (IOperationVariable item : that.getInputVariables().get()) {
-            arrayInputVariables.add(
+          final ArrayNode arrayInputVariables = serializeArray(
+            that.getInputVariables().get(),
+            (IOperationVariable item) ->
               transform(
                 item));
-          }
           result.set("inputVariables", arrayInputVariables);
         }
 
         if (that.getOutputVariables().isPresent()) {
-          final ArrayNode arrayOutputVariables = JsonNodeFactory.instance.arrayNode();
-          for (IOperationVariable item : that.getOutputVariables().get()) {
-            arrayOutputVariables.add(
+          final ArrayNode arrayOutputVariables = serializeArray(
+            that.getOutputVariables().get(),
+            (IOperationVariable item) ->
               transform(
                 item));
-          }
           result.set("outputVariables", arrayOutputVariables);
         }
 
         if (that.getInoutputVariables().isPresent()) {
-          final ArrayNode arrayInoutputVariables = JsonNodeFactory.instance.arrayNode();
-          for (IOperationVariable item : that.getInoutputVariables().get()) {
-            arrayInoutputVariables.add(
+          final ArrayNode arrayInoutputVariables = serializeArray(
+            that.getInoutputVariables().get(),
+            (IOperationVariable item) ->
               transform(
                 item));
-          }
           result.set("inoutputVariables", arrayInoutputVariables);
         }
 
@@ -14848,12 +11895,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14868,22 +11914,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14893,32 +11937,29 @@ public class Jsonization {
         }
 
         if (that.getSupplementalSemanticIds().isPresent()) {
-          final ArrayNode arraySupplementalSemanticIds = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            arraySupplementalSemanticIds.add(
+          final ArrayNode arraySupplementalSemanticIds = serializeArray(
+            that.getSupplementalSemanticIds().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("supplementalSemanticIds", arraySupplementalSemanticIds);
         }
 
         if (that.getQualifiers().isPresent()) {
-          final ArrayNode arrayQualifiers = JsonNodeFactory.instance.arrayNode();
-          for (IQualifier item : that.getQualifiers().get()) {
-            arrayQualifiers.add(
+          final ArrayNode arrayQualifiers = serializeArray(
+            that.getQualifiers().get(),
+            (IQualifier item) ->
               transform(
                 item));
-          }
           result.set("qualifiers", arrayQualifiers);
         }
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
@@ -14934,12 +11975,11 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getExtensions().isPresent()) {
-          final ArrayNode arrayExtensions = JsonNodeFactory.instance.arrayNode();
-          for (IExtension item : that.getExtensions().get()) {
-            arrayExtensions.add(
+          final ArrayNode arrayExtensions = serializeArray(
+            that.getExtensions().get(),
+            (IExtension item) ->
               transform(
                 item));
-          }
           result.set("extensions", arrayExtensions);
         }
 
@@ -14954,22 +11994,20 @@ public class Jsonization {
         }
 
         if (that.getDisplayName().isPresent()) {
-          final ArrayNode arrayDisplayName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            arrayDisplayName.add(
+          final ArrayNode arrayDisplayName = serializeArray(
+            that.getDisplayName().get(),
+            (ILangStringNameType item) ->
               transform(
                 item));
-          }
           result.set("displayName", arrayDisplayName);
         }
 
         if (that.getDescription().isPresent()) {
-          final ArrayNode arrayDescription = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringTextType item : that.getDescription().get()) {
-            arrayDescription.add(
+          final ArrayNode arrayDescription = serializeArray(
+            that.getDescription().get(),
+            (ILangStringTextType item) ->
               transform(
                 item));
-          }
           result.set("description", arrayDescription);
         }
 
@@ -14982,22 +12020,20 @@ public class Jsonization {
           that.getId()));
 
         if (that.getEmbeddedDataSpecifications().isPresent()) {
-          final ArrayNode arrayEmbeddedDataSpecifications = JsonNodeFactory.instance.arrayNode();
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            arrayEmbeddedDataSpecifications.add(
+          final ArrayNode arrayEmbeddedDataSpecifications = serializeArray(
+            that.getEmbeddedDataSpecifications().get(),
+            (IEmbeddedDataSpecification item) ->
               transform(
                 item));
-          }
           result.set("embeddedDataSpecifications", arrayEmbeddedDataSpecifications);
         }
 
         if (that.getIsCaseOf().isPresent()) {
-          final ArrayNode arrayIsCaseOf = JsonNodeFactory.instance.arrayNode();
-          for (IReference item : that.getIsCaseOf().get()) {
-            arrayIsCaseOf.add(
+          final ArrayNode arrayIsCaseOf = serializeArray(
+            that.getIsCaseOf().get(),
+            (IReference item) ->
               transform(
                 item));
-          }
           result.set("isCaseOf", arrayIsCaseOf);
         }
 
@@ -15020,12 +12056,11 @@ public class Jsonization {
             that.getReferredSemanticId().get()));
         }
 
-        final ArrayNode arrayKeys = JsonNodeFactory.instance.arrayNode();
-        for (IKey item : that.getKeys()) {
-          arrayKeys.add(
+        final ArrayNode arrayKeys = serializeArray(
+          that.getKeys(),
+          (IKey item) ->
             transform(
               item));
-        }
         result.set("keys", arrayKeys);
 
         return result;
@@ -15083,32 +12118,29 @@ public class Jsonization {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
         if (that.getAssetAdministrationShells().isPresent()) {
-          final ArrayNode arrayAssetAdministrationShells = JsonNodeFactory.instance.arrayNode();
-          for (IAssetAdministrationShell item : that.getAssetAdministrationShells().get()) {
-            arrayAssetAdministrationShells.add(
+          final ArrayNode arrayAssetAdministrationShells = serializeArray(
+            that.getAssetAdministrationShells().get(),
+            (IAssetAdministrationShell item) ->
               transform(
                 item));
-          }
           result.set("assetAdministrationShells", arrayAssetAdministrationShells);
         }
 
         if (that.getSubmodels().isPresent()) {
-          final ArrayNode arraySubmodels = JsonNodeFactory.instance.arrayNode();
-          for (ISubmodel item : that.getSubmodels().get()) {
-            arraySubmodels.add(
+          final ArrayNode arraySubmodels = serializeArray(
+            that.getSubmodels().get(),
+            (ISubmodel item) ->
               transform(
                 item));
-          }
           result.set("submodels", arraySubmodels);
         }
 
         if (that.getConceptDescriptions().isPresent()) {
-          final ArrayNode arrayConceptDescriptions = JsonNodeFactory.instance.arrayNode();
-          for (IConceptDescription item : that.getConceptDescriptions().get()) {
-            arrayConceptDescriptions.add(
+          final ArrayNode arrayConceptDescriptions = serializeArray(
+            that.getConceptDescriptions().get(),
+            (IConceptDescription item) ->
               transform(
                 item));
-          }
           result.set("conceptDescriptions", arrayConceptDescriptions);
         }
 
@@ -15172,12 +12204,11 @@ public class Jsonization {
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        final ArrayNode arrayValueReferencePairs = JsonNodeFactory.instance.arrayNode();
-        for (IValueReferencePair item : that.getValueReferencePairs()) {
-          arrayValueReferencePairs.add(
+        final ArrayNode arrayValueReferencePairs = serializeArray(
+          that.getValueReferencePairs(),
+          (IValueReferencePair item) ->
             transform(
               item));
-        }
         result.set("valueReferencePairs", arrayValueReferencePairs);
 
         return result;
@@ -15234,21 +12265,19 @@ public class Jsonization {
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        final ArrayNode arrayPreferredName = JsonNodeFactory.instance.arrayNode();
-        for (ILangStringPreferredNameTypeIec61360 item : that.getPreferredName()) {
-          arrayPreferredName.add(
+        final ArrayNode arrayPreferredName = serializeArray(
+          that.getPreferredName(),
+          (ILangStringPreferredNameTypeIec61360 item) ->
             transform(
               item));
-        }
         result.set("preferredName", arrayPreferredName);
 
         if (that.getShortName().isPresent()) {
-          final ArrayNode arrayShortName = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringShortNameTypeIec61360 item : that.getShortName().get()) {
-            arrayShortName.add(
+          final ArrayNode arrayShortName = serializeArray(
+            that.getShortName().get(),
+            (ILangStringShortNameTypeIec61360 item) ->
               transform(
                 item));
-          }
           result.set("shortName", arrayShortName);
         }
 
@@ -15278,12 +12307,11 @@ public class Jsonization {
         }
 
         if (that.getDefinition().isPresent()) {
-          final ArrayNode arrayDefinition = JsonNodeFactory.instance.arrayNode();
-          for (ILangStringDefinitionTypeIec61360 item : that.getDefinition().get()) {
-            arrayDefinition.add(
+          final ArrayNode arrayDefinition = serializeArray(
+            that.getDefinition().get(),
+            (ILangStringDefinitionTypeIec61360 item) ->
               transform(
                 item));
-          }
           result.set("definition", arrayDefinition);
         }
 
@@ -15340,132 +12368,77 @@ public class Jsonization {
        * Serialize a literal of ModellingKind into a JSON string.
        */
       public static JsonNode modellingKindToJsonValue(ModellingKind that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid ModellingKind: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of QualifierKind into a JSON string.
        */
       public static JsonNode qualifierKindToJsonValue(QualifierKind that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid QualifierKind: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of AssetKind into a JSON string.
        */
       public static JsonNode assetKindToJsonValue(AssetKind that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid AssetKind: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of AasSubmodelElements into a JSON string.
        */
       public static JsonNode aasSubmodelElementsToJsonValue(AasSubmodelElements that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid AasSubmodelElements: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of EntityType into a JSON string.
        */
       public static JsonNode entityTypeToJsonValue(EntityType that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid EntityType: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of Direction into a JSON string.
        */
       public static JsonNode directionToJsonValue(Direction that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid Direction: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of StateOfEvent into a JSON string.
        */
       public static JsonNode stateOfEventToJsonValue(StateOfEvent that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid StateOfEvent: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of ReferenceTypes into a JSON string.
        */
       public static JsonNode referenceTypesToJsonValue(ReferenceTypes that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid ReferenceTypes: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of KeyTypes into a JSON string.
        */
       public static JsonNode keyTypesToJsonValue(KeyTypes that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid KeyTypes: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of DataTypeDefXsd into a JSON string.
        */
       public static JsonNode dataTypeDefXsdToJsonValue(DataTypeDefXsd that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid DataTypeDefXsd: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
 
       /**
        * Serialize a literal of DataTypeIec61360 into a JSON string.
        */
       public static JsonNode dataTypeIec61360ToJsonValue(DataTypeIec61360 that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid DataTypeIec61360: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
     }
 }

--- a/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/stringification/Stringification.java
+++ b/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/stringification/Stringification.java
@@ -37,6 +37,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(modellingKindToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(ModellingKind that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of ModellingKind: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, ModellingKind> modellingKindFromString;
   static {
     final Map<String, ModellingKind> temp = new HashMap<>();
@@ -91,6 +105,20 @@ public class Stringification {
   public static Optional<String> toString(QualifierKind that)
   {
     return Optional.ofNullable(that).map(qualifierKindToString::get);
+  }
+
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(QualifierKind that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of QualifierKind: " + that);
+    }
+    return text.get();
   }
 
   private static final Map<String, QualifierKind> qualifierKindFromString;
@@ -148,6 +176,20 @@ public class Stringification {
   public static Optional<String> toString(AssetKind that)
   {
     return Optional.ofNullable(that).map(assetKindToString::get);
+  }
+
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(AssetKind that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of AssetKind: " + that);
+    }
+    return text.get();
   }
 
   private static final Map<String, AssetKind> assetKindFromString;
@@ -221,6 +263,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(aasSubmodelElementsToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(AasSubmodelElements that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of AasSubmodelElements: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, AasSubmodelElements> aasSubmodelElementsFromString;
   static {
     final Map<String, AasSubmodelElements> temp = new HashMap<>();
@@ -291,6 +347,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(entityTypeToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(EntityType that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of EntityType: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, EntityType> entityTypeFromString;
   static {
     final Map<String, EntityType> temp = new HashMap<>();
@@ -344,6 +414,20 @@ public class Stringification {
   public static Optional<String> toString(Direction that)
   {
     return Optional.ofNullable(that).map(directionToString::get);
+  }
+
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(Direction that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of Direction: " + that);
+    }
+    return text.get();
   }
 
   private static final Map<String, Direction> directionFromString;
@@ -401,6 +485,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(stateOfEventToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(StateOfEvent that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of StateOfEvent: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, StateOfEvent> stateOfEventFromString;
   static {
     final Map<String, StateOfEvent> temp = new HashMap<>();
@@ -454,6 +552,20 @@ public class Stringification {
   public static Optional<String> toString(ReferenceTypes that)
   {
     return Optional.ofNullable(that).map(referenceTypesToString::get);
+  }
+
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(ReferenceTypes that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of ReferenceTypes: " + that);
+    }
+    return text.get();
   }
 
   private static final Map<String, ReferenceTypes> referenceTypesFromString;
@@ -531,6 +643,20 @@ public class Stringification {
   public static Optional<String> toString(KeyTypes that)
   {
     return Optional.ofNullable(that).map(keyTypesToString::get);
+  }
+
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(KeyTypes that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of KeyTypes: " + that);
+    }
+    return text.get();
   }
 
   private static final Map<String, KeyTypes> keyTypesFromString;
@@ -638,6 +764,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(dataTypeDefXsdToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(DataTypeDefXsd that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of DataTypeDefXsd: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, DataTypeDefXsd> dataTypeDefXsdFromString;
   static {
     final Map<String, DataTypeDefXsd> temp = new HashMap<>();
@@ -736,6 +876,20 @@ public class Stringification {
   public static Optional<String> toString(DataTypeIec61360 that)
   {
     return Optional.ofNullable(that).map(dataTypeIec61360ToString::get);
+  }
+
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(DataTypeIec61360 that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of DataTypeIec61360: " + that);
+    }
+    return text.get();
   }
 
   private static final Map<String, DataTypeIec61360> dataTypeIec61360FromString;

--- a/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/aas_core_meta.v3/expected_output/src/main/java/aas_core/aas3_0/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://admin-shell.io/aas/3/0";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,15 +659,15 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link ModellingKind}.
      */
-    private static _Result<ModellingKind> tryVElementAsModellingKind(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<ModellingKind> tryVElementAsModellingKind(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(ModellingKind.class);
       }
@@ -734,18 +679,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of ModellingKind: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link QualifierKind}.
      */
-    private static _Result<QualifierKind> tryVElementAsQualifierKind(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<QualifierKind> tryVElementAsQualifierKind(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(QualifierKind.class);
       }
@@ -757,18 +702,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of QualifierKind: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link AssetKind}.
      */
-    private static _Result<AssetKind> tryVElementAsAssetKind(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<AssetKind> tryVElementAsAssetKind(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(AssetKind.class);
       }
@@ -780,18 +725,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of AssetKind: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link AasSubmodelElements}.
      */
-    private static _Result<AasSubmodelElements> tryVElementAsAasSubmodelElements(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<AasSubmodelElements> tryVElementAsAasSubmodelElements(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(AasSubmodelElements.class);
       }
@@ -803,18 +748,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of AasSubmodelElements: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link EntityType}.
      */
-    private static _Result<EntityType> tryVElementAsEntityType(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<EntityType> tryVElementAsEntityType(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(EntityType.class);
       }
@@ -826,18 +771,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of EntityType: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link Direction}.
      */
-    private static _Result<Direction> tryVElementAsDirection(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<Direction> tryVElementAsDirection(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(Direction.class);
       }
@@ -849,18 +794,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of Direction: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link StateOfEvent}.
      */
-    private static _Result<StateOfEvent> tryVElementAsStateOfEvent(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<StateOfEvent> tryVElementAsStateOfEvent(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(StateOfEvent.class);
       }
@@ -872,18 +817,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of StateOfEvent: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link ReferenceTypes}.
      */
-    private static _Result<ReferenceTypes> tryVElementAsReferenceTypes(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<ReferenceTypes> tryVElementAsReferenceTypes(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(ReferenceTypes.class);
       }
@@ -895,18 +840,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of ReferenceTypes: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link KeyTypes}.
      */
-    private static _Result<KeyTypes> tryVElementAsKeyTypes(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<KeyTypes> tryVElementAsKeyTypes(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(KeyTypes.class);
       }
@@ -918,18 +863,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of KeyTypes: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link DataTypeDefXsd}.
      */
-    private static _Result<DataTypeDefXsd> tryVElementAsDataTypeDefXsd(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<DataTypeDefXsd> tryVElementAsDataTypeDefXsd(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(DataTypeDefXsd.class);
       }
@@ -941,18 +886,18 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of DataTypeDefXsd: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link DataTypeIec61360}.
      */
-    private static _Result<DataTypeIec61360> tryVElementAsDataTypeIec61360(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<DataTypeIec61360> tryVElementAsDataTypeIec61360(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(DataTypeIec61360.class);
       }
@@ -964,16 +909,16 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of DataTypeIec61360: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
      * Deserialize an instance of IHasSemantics from an XML element.
      */
-    private static _Result<? extends IHasSemantics> tryIHasSemanticsFromElement(
+    private static Reporting.Result<? extends IHasSemantics> tryIHasSemanticsFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1019,7 +964,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1031,7 +976,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Extension> tryExtensionFromSequence(
+    private static Reporting.Result<Extension> tryExtensionFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       IReference theSemanticId = null;
@@ -1048,7 +993,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Extension, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1063,10 +1008,10 @@ public class Xmlization {
               "a property of an instance of class Extension, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Extension.class);
           }
@@ -1077,7 +1022,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -1093,7 +1038,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -1121,7 +1066,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property name of an instance of class Extension, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1133,7 +1078,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "name"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1148,7 +1093,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -1156,7 +1101,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property valueType of an instance of class Extension, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textValueType;
@@ -1169,7 +1114,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<DataTypeDefXsd> optionalValueType =
@@ -1186,7 +1131,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -1201,7 +1146,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class Extension, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1213,14 +1158,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "refersTo":
             {
-              final _Result<List<IReference>> tryRefersTo = parseList(
+              final Reporting.Result<List<IReference>> tryRefersTo = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -1242,13 +1187,13 @@ public class Xmlization {
                 "We expected properties of the class Extension, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Extension",
             reader,
             tryElementName);
@@ -1261,10 +1206,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property name has not been given " +
           "in the XML representation of an instance of class Extension");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Extension(
+      return Reporting.Result.success(new Extension(
         theName,
         theSemanticId,
         theSupplementalSemanticIds,
@@ -1276,7 +1221,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Extension from an XML element.
      */
-    private static _Result<? extends Extension> tryExtensionFromElement(
+    private static Reporting.Result<? extends Extension> tryExtensionFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1286,7 +1231,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Extension " +
               "with element name extension, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryExtensionFromSequence(reader, isEmptyElement);
@@ -1296,7 +1241,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IHasExtensions from an XML element.
      */
-    private static _Result<? extends IHasExtensions> tryIHasExtensionsFromElement(
+    private static Reporting.Result<? extends IHasExtensions> tryIHasExtensionsFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1340,7 +1285,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1348,7 +1293,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IReferable from an XML element.
      */
-    private static _Result<? extends IReferable> tryIReferableFromElement(
+    private static Reporting.Result<? extends IReferable> tryIReferableFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1392,7 +1337,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1400,7 +1345,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IIdentifiable from an XML element.
      */
-    private static _Result<? extends IIdentifiable> tryIIdentifiableFromElement(
+    private static Reporting.Result<? extends IIdentifiable> tryIIdentifiableFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1416,7 +1361,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1424,7 +1369,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IHasKind from an XML element.
      */
-    private static _Result<? extends IHasKind> tryIHasKindFromElement(
+    private static Reporting.Result<? extends IHasKind> tryIHasKindFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1436,7 +1381,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1444,7 +1389,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IHasDataSpecification from an XML element.
      */
-    private static _Result<? extends IHasDataSpecification> tryIHasDataSpecificationFromElement(
+    private static Reporting.Result<? extends IHasDataSpecification> tryIHasDataSpecificationFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1490,7 +1435,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1502,7 +1447,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<AdministrativeInformation> tryAdministrativeInformationFromSequence(
+    private static Reporting.Result<AdministrativeInformation> tryAdministrativeInformationFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IEmbeddedDataSpecification> theEmbeddedDataSpecifications = null;
@@ -1518,7 +1463,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class AdministrativeInformation, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1533,10 +1478,10 @@ public class Xmlization {
               "a property of an instance of class AdministrativeInformation, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(AdministrativeInformation.class);
           }
@@ -1547,7 +1492,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -1575,7 +1520,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property version of an instance of class AdministrativeInformation, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1587,7 +1532,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "version"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1603,7 +1548,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property revision of an instance of class AdministrativeInformation, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1615,14 +1560,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "revision"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "creator":
             {
-              _Result<Reference> tryCreator = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryCreator = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryCreator.isError()) {
@@ -1647,7 +1592,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property templateId of an instance of class AdministrativeInformation, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1659,7 +1604,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "templateId"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1669,13 +1614,13 @@ public class Xmlization {
                 "We expected properties of the class AdministrativeInformation, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "AdministrativeInformation",
             reader,
             tryElementName);
@@ -1684,7 +1629,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new AdministrativeInformation(
+      return Reporting.Result.success(new AdministrativeInformation(
         theEmbeddedDataSpecifications,
         theVersion,
         theRevision,
@@ -1695,7 +1640,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class AdministrativeInformation from an XML element.
      */
-    private static _Result<? extends AdministrativeInformation> tryAdministrativeInformationFromElement(
+    private static Reporting.Result<? extends AdministrativeInformation> tryAdministrativeInformationFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1705,7 +1650,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class AdministrativeInformation " +
               "with element name administrativeInformation, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryAdministrativeInformationFromSequence(reader, isEmptyElement);
@@ -1715,7 +1660,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IQualifiable from an XML element.
      */
-    private static _Result<? extends IQualifiable> tryIQualifiableFromElement(
+    private static Reporting.Result<? extends IQualifiable> tryIQualifiableFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1755,7 +1700,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1767,7 +1712,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Qualifier> tryQualifierFromSequence(
+    private static Reporting.Result<Qualifier> tryQualifierFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       IReference theSemanticId = null;
@@ -1785,7 +1730,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Qualifier, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1800,10 +1745,10 @@ public class Xmlization {
               "a property of an instance of class Qualifier, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Qualifier.class);
           }
@@ -1814,7 +1759,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -1830,7 +1775,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -1857,7 +1802,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "kind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -1865,7 +1810,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property kind of an instance of class Qualifier, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textKind;
@@ -1878,7 +1823,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "kind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<QualifierKind> optionalKind =
@@ -1895,7 +1840,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "kind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -1910,7 +1855,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property type of an instance of class Qualifier, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1922,7 +1867,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "type"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1937,7 +1882,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -1945,7 +1890,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property valueType of an instance of class Qualifier, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textValueType;
@@ -1958,7 +1903,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<DataTypeDefXsd> optionalValueType =
@@ -1975,7 +1920,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -1990,7 +1935,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class Qualifier, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2002,14 +1947,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "valueId":
             {
-              _Result<Reference> tryValueId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryValueId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryValueId.isError()) {
@@ -2028,13 +1973,13 @@ public class Xmlization {
                 "We expected properties of the class Qualifier, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Qualifier",
             reader,
             tryElementName);
@@ -2047,17 +1992,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property type has not been given " +
           "in the XML representation of an instance of class Qualifier");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theValueType == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property valueType has not been given " +
           "in the XML representation of an instance of class Qualifier");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Qualifier(
+      return Reporting.Result.success(new Qualifier(
         theType,
         theValueType,
         theSemanticId,
@@ -2070,7 +2015,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Qualifier from an XML element.
      */
-    private static _Result<? extends Qualifier> tryQualifierFromElement(
+    private static Reporting.Result<? extends Qualifier> tryQualifierFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -2080,7 +2025,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Qualifier " +
               "with element name qualifier, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryQualifierFromSequence(reader, isEmptyElement);
@@ -2094,7 +2039,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<AssetAdministrationShell> tryAssetAdministrationShellFromSequence(
+    private static Reporting.Result<AssetAdministrationShell> tryAssetAdministrationShellFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -2116,7 +2061,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class AssetAdministrationShell, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -2131,10 +2076,10 @@ public class Xmlization {
               "a property of an instance of class AssetAdministrationShell, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(AssetAdministrationShell.class);
           }
@@ -2145,7 +2090,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -2173,7 +2118,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class AssetAdministrationShell, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2185,7 +2130,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -2201,7 +2146,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class AssetAdministrationShell, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2213,14 +2158,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -2239,7 +2184,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -2258,7 +2203,7 @@ public class Xmlization {
             }
             case "administration":
             {
-              _Result<AdministrativeInformation> tryAdministration = tryAdministrativeInformationFromSequence(
+              Reporting.Result<AdministrativeInformation> tryAdministration = tryAdministrativeInformationFromSequence(
                 reader, isEmptyProperty);
 
               if (tryAdministration.isError()) {
@@ -2283,7 +2228,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property id of an instance of class AssetAdministrationShell, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2295,14 +2240,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "id"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -2321,7 +2266,7 @@ public class Xmlization {
             }
             case "derivedFrom":
             {
-              _Result<Reference> tryDerivedFrom = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryDerivedFrom = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryDerivedFrom.isError()) {
@@ -2337,7 +2282,7 @@ public class Xmlization {
             }
             case "assetInformation":
             {
-              _Result<AssetInformation> tryAssetInformation = tryAssetInformationFromSequence(
+              Reporting.Result<AssetInformation> tryAssetInformation = tryAssetInformationFromSequence(
                 reader, isEmptyProperty);
 
               if (tryAssetInformation.isError()) {
@@ -2353,7 +2298,7 @@ public class Xmlization {
             }
             case "submodels":
             {
-              final _Result<List<IReference>> trySubmodels = parseList(
+              final Reporting.Result<List<IReference>> trySubmodels = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -2375,13 +2320,13 @@ public class Xmlization {
                 "We expected properties of the class AssetAdministrationShell, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "AssetAdministrationShell",
             reader,
             tryElementName);
@@ -2394,17 +2339,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property id has not been given " +
           "in the XML representation of an instance of class AssetAdministrationShell");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theAssetInformation == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property assetInformation has not been given " +
           "in the XML representation of an instance of class AssetAdministrationShell");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new AssetAdministrationShell(
+      return Reporting.Result.success(new AssetAdministrationShell(
         theId,
         theAssetInformation,
         theExtensions,
@@ -2421,7 +2366,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class AssetAdministrationShell from an XML element.
      */
-    private static _Result<? extends AssetAdministrationShell> tryAssetAdministrationShellFromElement(
+    private static Reporting.Result<? extends AssetAdministrationShell> tryAssetAdministrationShellFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -2431,7 +2376,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class AssetAdministrationShell " +
               "with element name assetAdministrationShell, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryAssetAdministrationShellFromSequence(reader, isEmptyElement);
@@ -2445,7 +2390,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<AssetInformation> tryAssetInformationFromSequence(
+    private static Reporting.Result<AssetInformation> tryAssetInformationFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       AssetKind theAssetKind = null;
@@ -2461,7 +2406,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class AssetInformation, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -2476,10 +2421,10 @@ public class Xmlization {
               "a property of an instance of class AssetInformation, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(AssetInformation.class);
           }
@@ -2498,7 +2443,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "assetKind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -2506,7 +2451,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property assetKind of an instance of class AssetInformation, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textAssetKind;
@@ -2519,7 +2464,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "assetKind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<AssetKind> optionalAssetKind =
@@ -2536,7 +2481,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "assetKind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -2551,7 +2496,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property globalAssetId of an instance of class AssetInformation, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2563,14 +2508,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "globalAssetId"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "specificAssetIds":
             {
-              final _Result<List<ISpecificAssetId>> trySpecificAssetIds = parseList(
+              final Reporting.Result<List<ISpecificAssetId>> trySpecificAssetIds = parseList(
                 reader,
                 isEmptyProperty,
                 ISpecificAssetId.class,
@@ -2598,7 +2543,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property assetType of an instance of class AssetInformation, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2610,14 +2555,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "assetType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "defaultThumbnail":
             {
-              _Result<Resource> tryDefaultThumbnail = tryResourceFromSequence(
+              Reporting.Result<Resource> tryDefaultThumbnail = tryResourceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryDefaultThumbnail.isError()) {
@@ -2636,13 +2581,13 @@ public class Xmlization {
                 "We expected properties of the class AssetInformation, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "AssetInformation",
             reader,
             tryElementName);
@@ -2655,10 +2600,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property assetKind has not been given " +
           "in the XML representation of an instance of class AssetInformation");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new AssetInformation(
+      return Reporting.Result.success(new AssetInformation(
         theAssetKind,
         theGlobalAssetId,
         theSpecificAssetIds,
@@ -2669,7 +2614,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class AssetInformation from an XML element.
      */
-    private static _Result<? extends AssetInformation> tryAssetInformationFromElement(
+    private static Reporting.Result<? extends AssetInformation> tryAssetInformationFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -2679,7 +2624,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class AssetInformation " +
               "with element name assetInformation, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryAssetInformationFromSequence(reader, isEmptyElement);
@@ -2693,7 +2638,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Resource> tryResourceFromSequence(
+    private static Reporting.Result<Resource> tryResourceFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String thePath = null;
@@ -2706,7 +2651,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Resource, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -2721,10 +2666,10 @@ public class Xmlization {
               "a property of an instance of class Resource, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Resource.class);
           }
@@ -2744,7 +2689,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property path of an instance of class Resource, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2756,7 +2701,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "path"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -2772,7 +2717,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property contentType of an instance of class Resource, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2784,7 +2729,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "contentType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -2794,13 +2739,13 @@ public class Xmlization {
                 "We expected properties of the class Resource, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Resource",
             reader,
             tryElementName);
@@ -2813,10 +2758,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property path has not been given " +
           "in the XML representation of an instance of class Resource");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Resource(
+      return Reporting.Result.success(new Resource(
         thePath,
         theContentType));
     }
@@ -2824,7 +2769,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Resource from an XML element.
      */
-    private static _Result<? extends Resource> tryResourceFromElement(
+    private static Reporting.Result<? extends Resource> tryResourceFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -2834,7 +2779,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Resource " +
               "with element name resource, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryResourceFromSequence(reader, isEmptyElement);
@@ -2848,7 +2793,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<SpecificAssetId> trySpecificAssetIdFromSequence(
+    private static Reporting.Result<SpecificAssetId> trySpecificAssetIdFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       IReference theSemanticId = null;
@@ -2864,7 +2809,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class SpecificAssetId, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -2879,10 +2824,10 @@ public class Xmlization {
               "a property of an instance of class SpecificAssetId, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(SpecificAssetId.class);
           }
@@ -2893,7 +2838,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -2909,7 +2854,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -2937,7 +2882,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property name of an instance of class SpecificAssetId, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2949,7 +2894,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "name"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -2965,7 +2910,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class SpecificAssetId, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -2977,14 +2922,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "externalSubjectId":
             {
-              _Result<Reference> tryExternalSubjectId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryExternalSubjectId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryExternalSubjectId.isError()) {
@@ -3003,13 +2948,13 @@ public class Xmlization {
                 "We expected properties of the class SpecificAssetId, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "SpecificAssetId",
             reader,
             tryElementName);
@@ -3022,17 +2967,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property name has not been given " +
           "in the XML representation of an instance of class SpecificAssetId");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theValue == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property value has not been given " +
           "in the XML representation of an instance of class SpecificAssetId");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new SpecificAssetId(
+      return Reporting.Result.success(new SpecificAssetId(
         theName,
         theValue,
         theSemanticId,
@@ -3043,7 +2988,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class SpecificAssetId from an XML element.
      */
-    private static _Result<? extends SpecificAssetId> trySpecificAssetIdFromElement(
+    private static Reporting.Result<? extends SpecificAssetId> trySpecificAssetIdFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -3053,7 +2998,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class SpecificAssetId " +
               "with element name specificAssetId, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySpecificAssetIdFromSequence(reader, isEmptyElement);
@@ -3067,7 +3012,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Submodel> trySubmodelFromSequence(
+    private static Reporting.Result<Submodel> trySubmodelFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -3091,7 +3036,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Submodel, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -3106,10 +3051,10 @@ public class Xmlization {
               "a property of an instance of class Submodel, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Submodel.class);
           }
@@ -3120,7 +3065,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -3148,7 +3093,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class Submodel, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -3160,7 +3105,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -3176,7 +3121,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class Submodel, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -3188,14 +3133,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -3214,7 +3159,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -3233,7 +3178,7 @@ public class Xmlization {
             }
             case "administration":
             {
-              _Result<AdministrativeInformation> tryAdministration = tryAdministrativeInformationFromSequence(
+              Reporting.Result<AdministrativeInformation> tryAdministration = tryAdministrativeInformationFromSequence(
                 reader, isEmptyProperty);
 
               if (tryAdministration.isError()) {
@@ -3258,7 +3203,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property id of an instance of class Submodel, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -3270,7 +3215,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "id"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -3285,7 +3230,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "kind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -3293,7 +3238,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property kind of an instance of class Submodel, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textKind;
@@ -3306,7 +3251,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "kind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<ModellingKind> optionalKind =
@@ -3323,13 +3268,13 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "kind"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -3345,7 +3290,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -3364,7 +3309,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -3383,7 +3328,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -3402,7 +3347,7 @@ public class Xmlization {
             }
             case "submodelElements":
             {
-              final _Result<List<ISubmodelElement>> trySubmodelElements = parseList(
+              final Reporting.Result<List<ISubmodelElement>> trySubmodelElements = parseList(
                 reader,
                 isEmptyProperty,
                 ISubmodelElement.class,
@@ -3424,13 +3369,13 @@ public class Xmlization {
                 "We expected properties of the class Submodel, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Submodel",
             reader,
             tryElementName);
@@ -3443,10 +3388,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property id has not been given " +
           "in the XML representation of an instance of class Submodel");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Submodel(
+      return Reporting.Result.success(new Submodel(
         theId,
         theExtensions,
         theCategory,
@@ -3465,7 +3410,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Submodel from an XML element.
      */
-    private static _Result<? extends Submodel> trySubmodelFromElement(
+    private static Reporting.Result<? extends Submodel> trySubmodelFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -3475,7 +3420,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Submodel " +
               "with element name submodel, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySubmodelFromSequence(reader, isEmptyElement);
@@ -3485,7 +3430,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of ISubmodelElement from an XML element.
      */
-    private static _Result<? extends ISubmodelElement> tryISubmodelElementFromElement(
+    private static Reporting.Result<? extends ISubmodelElement> tryISubmodelElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -3523,7 +3468,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -3535,7 +3480,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<RelationshipElement> tryRelationshipElementFromSequence(
+    private static Reporting.Result<RelationshipElement> tryRelationshipElementFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -3557,7 +3502,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class RelationshipElement, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -3572,10 +3517,10 @@ public class Xmlization {
               "a property of an instance of class RelationshipElement, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(RelationshipElement.class);
           }
@@ -3586,7 +3531,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -3614,7 +3559,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class RelationshipElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -3626,7 +3571,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -3642,7 +3587,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class RelationshipElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -3654,14 +3599,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -3680,7 +3625,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -3699,7 +3644,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -3715,7 +3660,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -3734,7 +3679,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -3753,7 +3698,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -3772,7 +3717,7 @@ public class Xmlization {
             }
             case "first":
             {
-              _Result<Reference> tryFirst = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryFirst = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryFirst.isError()) {
@@ -3788,7 +3733,7 @@ public class Xmlization {
             }
             case "second":
             {
-              _Result<Reference> trySecond = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySecond = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySecond.isError()) {
@@ -3807,13 +3752,13 @@ public class Xmlization {
                 "We expected properties of the class RelationshipElement, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "RelationshipElement",
             reader,
             tryElementName);
@@ -3826,17 +3771,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property first has not been given " +
           "in the XML representation of an instance of class RelationshipElement");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSecond == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property second has not been given " +
           "in the XML representation of an instance of class RelationshipElement");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new RelationshipElement(
+      return Reporting.Result.success(new RelationshipElement(
         theFirst,
         theSecond,
         theExtensions,
@@ -3853,7 +3798,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IRelationshipElement from an XML element.
      */
-    private static _Result<? extends IRelationshipElement> tryIRelationshipElementFromElement(
+    private static Reporting.Result<? extends IRelationshipElement> tryIRelationshipElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -3867,7 +3812,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -3875,7 +3820,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class RelationshipElement from an XML element.
      */
-    private static _Result<? extends RelationshipElement> tryRelationshipElementFromElement(
+    private static Reporting.Result<? extends RelationshipElement> tryRelationshipElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -3885,7 +3830,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class RelationshipElement " +
               "with element name relationshipElement, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryRelationshipElementFromSequence(reader, isEmptyElement);
@@ -3899,7 +3844,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<SubmodelElementList> trySubmodelElementListFromSequence(
+    private static Reporting.Result<SubmodelElementList> trySubmodelElementListFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -3924,7 +3869,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class SubmodelElementList, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -3939,10 +3884,10 @@ public class Xmlization {
               "a property of an instance of class SubmodelElementList, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(SubmodelElementList.class);
           }
@@ -3953,7 +3898,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -3981,7 +3926,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class SubmodelElementList, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -3993,7 +3938,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -4009,7 +3954,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class SubmodelElementList, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -4021,14 +3966,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -4047,7 +3992,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -4066,7 +4011,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -4082,7 +4027,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -4101,7 +4046,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -4120,7 +4065,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -4147,7 +4092,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "orderRelevant"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -4155,7 +4100,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property orderRelevant of an instance of class SubmodelElementList, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -4167,14 +4112,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "orderRelevant"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "semanticIdListElement":
             {
-              _Result<Reference> trySemanticIdListElement = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticIdListElement = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticIdListElement.isError()) {
@@ -4198,7 +4143,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "typeValueListElement"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -4206,7 +4151,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property typeValueListElement of an instance of class SubmodelElementList, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textTypeValueListElement;
@@ -4219,7 +4164,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "typeValueListElement"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<AasSubmodelElements> optionalTypeValueListElement =
@@ -4236,7 +4181,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "typeValueListElement"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -4250,7 +4195,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "valueTypeListElement"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -4258,7 +4203,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property valueTypeListElement of an instance of class SubmodelElementList, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textValueTypeListElement;
@@ -4271,7 +4216,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueTypeListElement"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<DataTypeDefXsd> optionalValueTypeListElement =
@@ -4288,13 +4233,13 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueTypeListElement"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
             case "value":
             {
-              final _Result<List<ISubmodelElement>> tryValue = parseList(
+              final Reporting.Result<List<ISubmodelElement>> tryValue = parseList(
                 reader,
                 isEmptyProperty,
                 ISubmodelElement.class,
@@ -4316,13 +4261,13 @@ public class Xmlization {
                 "We expected properties of the class SubmodelElementList, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "SubmodelElementList",
             reader,
             tryElementName);
@@ -4335,10 +4280,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property typeValueListElement has not been given " +
           "in the XML representation of an instance of class SubmodelElementList");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new SubmodelElementList(
+      return Reporting.Result.success(new SubmodelElementList(
         theTypeValueListElement,
         theExtensions,
         theCategory,
@@ -4358,7 +4303,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class SubmodelElementList from an XML element.
      */
-    private static _Result<? extends SubmodelElementList> trySubmodelElementListFromElement(
+    private static Reporting.Result<? extends SubmodelElementList> trySubmodelElementListFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -4368,7 +4313,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class SubmodelElementList " +
               "with element name submodelElementList, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySubmodelElementListFromSequence(reader, isEmptyElement);
@@ -4382,7 +4327,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<SubmodelElementCollection> trySubmodelElementCollectionFromSequence(
+    private static Reporting.Result<SubmodelElementCollection> trySubmodelElementCollectionFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -4403,7 +4348,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class SubmodelElementCollection, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -4418,10 +4363,10 @@ public class Xmlization {
               "a property of an instance of class SubmodelElementCollection, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(SubmodelElementCollection.class);
           }
@@ -4432,7 +4377,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -4460,7 +4405,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class SubmodelElementCollection, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -4472,7 +4417,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -4488,7 +4433,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class SubmodelElementCollection, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -4500,14 +4445,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -4526,7 +4471,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -4545,7 +4490,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -4561,7 +4506,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -4580,7 +4525,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -4599,7 +4544,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -4618,7 +4563,7 @@ public class Xmlization {
             }
             case "value":
             {
-              final _Result<List<ISubmodelElement>> tryValue = parseList(
+              final Reporting.Result<List<ISubmodelElement>> tryValue = parseList(
                 reader,
                 isEmptyProperty,
                 ISubmodelElement.class,
@@ -4640,13 +4585,13 @@ public class Xmlization {
                 "We expected properties of the class SubmodelElementCollection, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "SubmodelElementCollection",
             reader,
             tryElementName);
@@ -4655,7 +4600,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new SubmodelElementCollection(
+      return Reporting.Result.success(new SubmodelElementCollection(
         theExtensions,
         theCategory,
         theIdShort,
@@ -4671,7 +4616,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class SubmodelElementCollection from an XML element.
      */
-    private static _Result<? extends SubmodelElementCollection> trySubmodelElementCollectionFromElement(
+    private static Reporting.Result<? extends SubmodelElementCollection> trySubmodelElementCollectionFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -4681,7 +4626,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class SubmodelElementCollection " +
               "with element name submodelElementCollection, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySubmodelElementCollectionFromSequence(reader, isEmptyElement);
@@ -4691,7 +4636,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IDataElement from an XML element.
      */
-    private static _Result<? extends IDataElement> tryIDataElementFromElement(
+    private static Reporting.Result<? extends IDataElement> tryIDataElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -4713,7 +4658,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -4725,7 +4670,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Property> tryPropertyFromSequence(
+    private static Reporting.Result<Property> tryPropertyFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -4748,7 +4693,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Property, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -4763,10 +4708,10 @@ public class Xmlization {
               "a property of an instance of class Property, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Property.class);
           }
@@ -4777,7 +4722,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -4805,7 +4750,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class Property, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -4817,7 +4762,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -4833,7 +4778,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class Property, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -4845,14 +4790,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -4871,7 +4816,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -4890,7 +4835,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -4906,7 +4851,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -4925,7 +4870,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -4944,7 +4889,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -4971,7 +4916,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -4979,7 +4924,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property valueType of an instance of class Property, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textValueType;
@@ -4992,7 +4937,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<DataTypeDefXsd> optionalValueType =
@@ -5009,7 +4954,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -5024,7 +4969,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class Property, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5036,14 +4981,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "valueId":
             {
-              _Result<Reference> tryValueId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryValueId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryValueId.isError()) {
@@ -5062,13 +5007,13 @@ public class Xmlization {
                 "We expected properties of the class Property, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Property",
             reader,
             tryElementName);
@@ -5081,10 +5026,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property valueType has not been given " +
           "in the XML representation of an instance of class Property");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Property(
+      return Reporting.Result.success(new Property(
         theValueType,
         theExtensions,
         theCategory,
@@ -5102,7 +5047,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Property from an XML element.
      */
-    private static _Result<? extends Property> tryPropertyFromElement(
+    private static Reporting.Result<? extends Property> tryPropertyFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -5112,7 +5057,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Property " +
               "with element name property, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryPropertyFromSequence(reader, isEmptyElement);
@@ -5126,7 +5071,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<MultiLanguageProperty> tryMultiLanguagePropertyFromSequence(
+    private static Reporting.Result<MultiLanguageProperty> tryMultiLanguagePropertyFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -5148,7 +5093,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class MultiLanguageProperty, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -5163,10 +5108,10 @@ public class Xmlization {
               "a property of an instance of class MultiLanguageProperty, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(MultiLanguageProperty.class);
           }
@@ -5177,7 +5122,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -5205,7 +5150,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class MultiLanguageProperty, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5217,7 +5162,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -5233,7 +5178,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class MultiLanguageProperty, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5245,14 +5190,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -5271,7 +5216,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -5290,7 +5235,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -5306,7 +5251,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -5325,7 +5270,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -5344,7 +5289,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -5363,7 +5308,7 @@ public class Xmlization {
             }
             case "value":
             {
-              final _Result<List<ILangStringTextType>> tryValue = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryValue = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -5382,7 +5327,7 @@ public class Xmlization {
             }
             case "valueId":
             {
-              _Result<Reference> tryValueId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryValueId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryValueId.isError()) {
@@ -5401,13 +5346,13 @@ public class Xmlization {
                 "We expected properties of the class MultiLanguageProperty, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "MultiLanguageProperty",
             reader,
             tryElementName);
@@ -5416,7 +5361,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new MultiLanguageProperty(
+      return Reporting.Result.success(new MultiLanguageProperty(
         theExtensions,
         theCategory,
         theIdShort,
@@ -5433,7 +5378,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class MultiLanguageProperty from an XML element.
      */
-    private static _Result<? extends MultiLanguageProperty> tryMultiLanguagePropertyFromElement(
+    private static Reporting.Result<? extends MultiLanguageProperty> tryMultiLanguagePropertyFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -5443,7 +5388,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class MultiLanguageProperty " +
               "with element name multiLanguageProperty, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryMultiLanguagePropertyFromSequence(reader, isEmptyElement);
@@ -5457,7 +5402,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Range> tryRangeFromSequence(
+    private static Reporting.Result<Range> tryRangeFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -5480,7 +5425,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Range, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -5495,10 +5440,10 @@ public class Xmlization {
               "a property of an instance of class Range, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Range.class);
           }
@@ -5509,7 +5454,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -5537,7 +5482,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class Range, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5549,7 +5494,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -5565,7 +5510,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class Range, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5577,14 +5522,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -5603,7 +5548,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -5622,7 +5567,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -5638,7 +5583,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -5657,7 +5602,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -5676,7 +5621,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -5703,7 +5648,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -5711,7 +5656,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property valueType of an instance of class Range, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textValueType;
@@ -5724,7 +5669,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<DataTypeDefXsd> optionalValueType =
@@ -5741,7 +5686,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "valueType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -5756,7 +5701,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property min of an instance of class Range, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5768,7 +5713,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "min"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -5784,7 +5729,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property max of an instance of class Range, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5796,7 +5741,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "max"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -5806,13 +5751,13 @@ public class Xmlization {
                 "We expected properties of the class Range, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Range",
             reader,
             tryElementName);
@@ -5825,10 +5770,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property valueType has not been given " +
           "in the XML representation of an instance of class Range");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Range(
+      return Reporting.Result.success(new Range(
         theValueType,
         theExtensions,
         theCategory,
@@ -5846,7 +5791,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Range from an XML element.
      */
-    private static _Result<? extends Range> tryRangeFromElement(
+    private static Reporting.Result<? extends Range> tryRangeFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -5856,7 +5801,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Range " +
               "with element name range, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryRangeFromSequence(reader, isEmptyElement);
@@ -5870,7 +5815,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<ReferenceElement> tryReferenceElementFromSequence(
+    private static Reporting.Result<ReferenceElement> tryReferenceElementFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -5891,7 +5836,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class ReferenceElement, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -5906,10 +5851,10 @@ public class Xmlization {
               "a property of an instance of class ReferenceElement, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(ReferenceElement.class);
           }
@@ -5920,7 +5865,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -5948,7 +5893,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class ReferenceElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5960,7 +5905,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -5976,7 +5921,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class ReferenceElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -5988,14 +5933,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -6014,7 +5959,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -6033,7 +5978,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -6049,7 +5994,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -6068,7 +6013,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -6087,7 +6032,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -6106,7 +6051,7 @@ public class Xmlization {
             }
             case "value":
             {
-              _Result<Reference> tryValue = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryValue = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryValue.isError()) {
@@ -6125,13 +6070,13 @@ public class Xmlization {
                 "We expected properties of the class ReferenceElement, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "ReferenceElement",
             reader,
             tryElementName);
@@ -6140,7 +6085,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new ReferenceElement(
+      return Reporting.Result.success(new ReferenceElement(
         theExtensions,
         theCategory,
         theIdShort,
@@ -6156,7 +6101,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class ReferenceElement from an XML element.
      */
-    private static _Result<? extends ReferenceElement> tryReferenceElementFromElement(
+    private static Reporting.Result<? extends ReferenceElement> tryReferenceElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -6166,7 +6111,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class ReferenceElement " +
               "with element name referenceElement, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryReferenceElementFromSequence(reader, isEmptyElement);
@@ -6180,7 +6125,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Blob> tryBlobFromSequence(
+    private static Reporting.Result<Blob> tryBlobFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -6202,7 +6147,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Blob, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -6217,10 +6162,10 @@ public class Xmlization {
               "a property of an instance of class Blob, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Blob.class);
           }
@@ -6231,7 +6176,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -6259,7 +6204,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class Blob, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6271,7 +6216,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -6287,7 +6232,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class Blob, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6299,14 +6244,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -6325,7 +6270,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -6344,7 +6289,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -6360,7 +6305,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -6379,7 +6324,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -6398,7 +6343,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -6425,7 +6370,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "value"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -6433,7 +6378,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class Blob, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6445,7 +6390,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -6461,7 +6406,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property contentType of an instance of class Blob, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6473,7 +6418,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "contentType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -6483,13 +6428,13 @@ public class Xmlization {
                 "We expected properties of the class Blob, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Blob",
             reader,
             tryElementName);
@@ -6502,10 +6447,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property contentType has not been given " +
           "in the XML representation of an instance of class Blob");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Blob(
+      return Reporting.Result.success(new Blob(
         theContentType,
         theExtensions,
         theCategory,
@@ -6522,7 +6467,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Blob from an XML element.
      */
-    private static _Result<? extends Blob> tryBlobFromElement(
+    private static Reporting.Result<? extends Blob> tryBlobFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -6532,7 +6477,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Blob " +
               "with element name blob, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryBlobFromSequence(reader, isEmptyElement);
@@ -6546,7 +6491,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<File> tryFileFromSequence(
+    private static Reporting.Result<File> tryFileFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -6568,7 +6513,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class File, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -6583,10 +6528,10 @@ public class Xmlization {
               "a property of an instance of class File, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(File.class);
           }
@@ -6597,7 +6542,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -6625,7 +6570,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class File, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6637,7 +6582,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -6653,7 +6598,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class File, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6665,14 +6610,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -6691,7 +6636,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -6710,7 +6655,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -6726,7 +6671,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -6745,7 +6690,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -6764,7 +6709,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -6792,7 +6737,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class File, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6804,7 +6749,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -6820,7 +6765,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property contentType of an instance of class File, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6832,7 +6777,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "contentType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -6842,13 +6787,13 @@ public class Xmlization {
                 "We expected properties of the class File, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "File",
             reader,
             tryElementName);
@@ -6861,10 +6806,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property contentType has not been given " +
           "in the XML representation of an instance of class File");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new File(
+      return Reporting.Result.success(new File(
         theContentType,
         theExtensions,
         theCategory,
@@ -6881,7 +6826,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class File from an XML element.
      */
-    private static _Result<? extends File> tryFileFromElement(
+    private static Reporting.Result<? extends File> tryFileFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -6891,7 +6836,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class File " +
               "with element name file, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryFileFromSequence(reader, isEmptyElement);
@@ -6905,7 +6850,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<AnnotatedRelationshipElement> tryAnnotatedRelationshipElementFromSequence(
+    private static Reporting.Result<AnnotatedRelationshipElement> tryAnnotatedRelationshipElementFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -6928,7 +6873,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class AnnotatedRelationshipElement, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -6943,10 +6888,10 @@ public class Xmlization {
               "a property of an instance of class AnnotatedRelationshipElement, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(AnnotatedRelationshipElement.class);
           }
@@ -6957,7 +6902,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -6985,7 +6930,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class AnnotatedRelationshipElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -6997,7 +6942,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -7013,7 +6958,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class AnnotatedRelationshipElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -7025,14 +6970,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -7051,7 +6996,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -7070,7 +7015,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -7086,7 +7031,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -7105,7 +7050,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -7124,7 +7069,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -7143,7 +7088,7 @@ public class Xmlization {
             }
             case "first":
             {
-              _Result<Reference> tryFirst = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryFirst = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryFirst.isError()) {
@@ -7159,7 +7104,7 @@ public class Xmlization {
             }
             case "second":
             {
-              _Result<Reference> trySecond = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySecond = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySecond.isError()) {
@@ -7175,7 +7120,7 @@ public class Xmlization {
             }
             case "annotations":
             {
-              final _Result<List<IDataElement>> tryAnnotations = parseList(
+              final Reporting.Result<List<IDataElement>> tryAnnotations = parseList(
                 reader,
                 isEmptyProperty,
                 IDataElement.class,
@@ -7197,13 +7142,13 @@ public class Xmlization {
                 "We expected properties of the class AnnotatedRelationshipElement, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "AnnotatedRelationshipElement",
             reader,
             tryElementName);
@@ -7216,17 +7161,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property first has not been given " +
           "in the XML representation of an instance of class AnnotatedRelationshipElement");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSecond == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property second has not been given " +
           "in the XML representation of an instance of class AnnotatedRelationshipElement");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new AnnotatedRelationshipElement(
+      return Reporting.Result.success(new AnnotatedRelationshipElement(
         theFirst,
         theSecond,
         theExtensions,
@@ -7244,7 +7189,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class AnnotatedRelationshipElement from an XML element.
      */
-    private static _Result<? extends AnnotatedRelationshipElement> tryAnnotatedRelationshipElementFromElement(
+    private static Reporting.Result<? extends AnnotatedRelationshipElement> tryAnnotatedRelationshipElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -7254,7 +7199,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class AnnotatedRelationshipElement " +
               "with element name annotatedRelationshipElement, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryAnnotatedRelationshipElementFromSequence(reader, isEmptyElement);
@@ -7268,7 +7213,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Entity> tryEntityFromSequence(
+    private static Reporting.Result<Entity> tryEntityFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -7292,7 +7237,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Entity, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -7307,10 +7252,10 @@ public class Xmlization {
               "a property of an instance of class Entity, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Entity.class);
           }
@@ -7321,7 +7266,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -7349,7 +7294,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class Entity, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -7361,7 +7306,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -7377,7 +7322,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class Entity, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -7389,14 +7334,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -7415,7 +7360,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -7434,7 +7379,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -7450,7 +7395,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -7469,7 +7414,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -7488,7 +7433,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -7507,7 +7452,7 @@ public class Xmlization {
             }
             case "statements":
             {
-              final _Result<List<ISubmodelElement>> tryStatements = parseList(
+              final Reporting.Result<List<ISubmodelElement>> tryStatements = parseList(
                 reader,
                 isEmptyProperty,
                 ISubmodelElement.class,
@@ -7534,7 +7479,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "entityType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -7542,7 +7487,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property entityType of an instance of class Entity, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textEntityType;
@@ -7555,7 +7500,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "entityType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<EntityType> optionalEntityType =
@@ -7572,7 +7517,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "entityType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -7587,7 +7532,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property globalAssetId of an instance of class Entity, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -7599,14 +7544,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "globalAssetId"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "specificAssetIds":
             {
-              final _Result<List<ISpecificAssetId>> trySpecificAssetIds = parseList(
+              final Reporting.Result<List<ISpecificAssetId>> trySpecificAssetIds = parseList(
                 reader,
                 isEmptyProperty,
                 ISpecificAssetId.class,
@@ -7628,13 +7573,13 @@ public class Xmlization {
                 "We expected properties of the class Entity, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Entity",
             reader,
             tryElementName);
@@ -7647,10 +7592,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property entityType has not been given " +
           "in the XML representation of an instance of class Entity");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Entity(
+      return Reporting.Result.success(new Entity(
         theEntityType,
         theExtensions,
         theCategory,
@@ -7669,7 +7614,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Entity from an XML element.
      */
-    private static _Result<? extends Entity> tryEntityFromElement(
+    private static Reporting.Result<? extends Entity> tryEntityFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -7679,7 +7624,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Entity " +
               "with element name entity, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryEntityFromSequence(reader, isEmptyElement);
@@ -7693,7 +7638,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<EventPayload> tryEventPayloadFromSequence(
+    private static Reporting.Result<EventPayload> tryEventPayloadFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       IReference theSource = null;
@@ -7712,7 +7657,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class EventPayload, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -7727,10 +7672,10 @@ public class Xmlization {
               "a property of an instance of class EventPayload, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(EventPayload.class);
           }
@@ -7741,7 +7686,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "source":
             {
-              _Result<Reference> trySource = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySource = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySource.isError()) {
@@ -7757,7 +7702,7 @@ public class Xmlization {
             }
             case "sourceSemanticId":
             {
-              _Result<Reference> trySourceSemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySourceSemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySourceSemanticId.isError()) {
@@ -7773,7 +7718,7 @@ public class Xmlization {
             }
             case "observableReference":
             {
-              _Result<Reference> tryObservableReference = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryObservableReference = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryObservableReference.isError()) {
@@ -7789,7 +7734,7 @@ public class Xmlization {
             }
             case "observableSemanticId":
             {
-              _Result<Reference> tryObservableSemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryObservableSemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryObservableSemanticId.isError()) {
@@ -7814,7 +7759,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property topic of an instance of class EventPayload, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -7826,14 +7771,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "topic"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "subjectId":
             {
-              _Result<Reference> trySubjectId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySubjectId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySubjectId.isError()) {
@@ -7858,7 +7803,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property timeStamp of an instance of class EventPayload, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -7870,7 +7815,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "timeStamp"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -7885,7 +7830,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "payload"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -7893,7 +7838,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property payload of an instance of class EventPayload, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -7905,7 +7850,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "payload"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -7915,13 +7860,13 @@ public class Xmlization {
                 "We expected properties of the class EventPayload, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "EventPayload",
             reader,
             tryElementName);
@@ -7934,24 +7879,24 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property source has not been given " +
           "in the XML representation of an instance of class EventPayload");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theObservableReference == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property observableReference has not been given " +
           "in the XML representation of an instance of class EventPayload");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theTimeStamp == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property timeStamp has not been given " +
           "in the XML representation of an instance of class EventPayload");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new EventPayload(
+      return Reporting.Result.success(new EventPayload(
         theSource,
         theObservableReference,
         theTimeStamp,
@@ -7965,7 +7910,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class EventPayload from an XML element.
      */
-    private static _Result<? extends EventPayload> tryEventPayloadFromElement(
+    private static Reporting.Result<? extends EventPayload> tryEventPayloadFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -7975,7 +7920,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class EventPayload " +
               "with element name eventPayload, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryEventPayloadFromSequence(reader, isEmptyElement);
@@ -7985,7 +7930,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IEventElement from an XML element.
      */
-    private static _Result<? extends IEventElement> tryIEventElementFromElement(
+    private static Reporting.Result<? extends IEventElement> tryIEventElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -7997,7 +7942,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -8009,7 +7954,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<BasicEventElement> tryBasicEventElementFromSequence(
+    private static Reporting.Result<BasicEventElement> tryBasicEventElementFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -8037,7 +7982,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class BasicEventElement, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -8052,10 +7997,10 @@ public class Xmlization {
               "a property of an instance of class BasicEventElement, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(BasicEventElement.class);
           }
@@ -8066,7 +8011,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -8094,7 +8039,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class BasicEventElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8106,7 +8051,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -8122,7 +8067,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class BasicEventElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8134,14 +8079,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -8160,7 +8105,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -8179,7 +8124,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -8195,7 +8140,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -8214,7 +8159,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -8233,7 +8178,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -8252,7 +8197,7 @@ public class Xmlization {
             }
             case "observed":
             {
-              _Result<Reference> tryObserved = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryObserved = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryObserved.isError()) {
@@ -8276,7 +8221,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "direction"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -8284,7 +8229,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property direction of an instance of class BasicEventElement, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textDirection;
@@ -8297,7 +8242,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "direction"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<Direction> optionalDirection =
@@ -8314,7 +8259,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "direction"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -8328,7 +8273,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "state"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -8336,7 +8281,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property state of an instance of class BasicEventElement, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textState;
@@ -8349,7 +8294,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "state"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<StateOfEvent> optionalState =
@@ -8366,7 +8311,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "state"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -8381,7 +8326,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property messageTopic of an instance of class BasicEventElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8393,14 +8338,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "messageTopic"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "messageBroker":
             {
-              _Result<Reference> tryMessageBroker = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryMessageBroker = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryMessageBroker.isError()) {
@@ -8425,7 +8370,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property lastUpdate of an instance of class BasicEventElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8437,7 +8382,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "lastUpdate"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -8453,7 +8398,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property minInterval of an instance of class BasicEventElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8465,7 +8410,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "minInterval"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -8481,7 +8426,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property maxInterval of an instance of class BasicEventElement, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8493,7 +8438,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "maxInterval"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -8503,13 +8448,13 @@ public class Xmlization {
                 "We expected properties of the class BasicEventElement, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "BasicEventElement",
             reader,
             tryElementName);
@@ -8522,24 +8467,24 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property observed has not been given " +
           "in the XML representation of an instance of class BasicEventElement");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theDirection == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property direction has not been given " +
           "in the XML representation of an instance of class BasicEventElement");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theState == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property state has not been given " +
           "in the XML representation of an instance of class BasicEventElement");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new BasicEventElement(
+      return Reporting.Result.success(new BasicEventElement(
         theObserved,
         theDirection,
         theState,
@@ -8562,7 +8507,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class BasicEventElement from an XML element.
      */
-    private static _Result<? extends BasicEventElement> tryBasicEventElementFromElement(
+    private static Reporting.Result<? extends BasicEventElement> tryBasicEventElementFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -8572,7 +8517,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class BasicEventElement " +
               "with element name basicEventElement, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryBasicEventElementFromSequence(reader, isEmptyElement);
@@ -8586,7 +8531,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Operation> tryOperationFromSequence(
+    private static Reporting.Result<Operation> tryOperationFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -8609,7 +8554,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Operation, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -8624,10 +8569,10 @@ public class Xmlization {
               "a property of an instance of class Operation, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Operation.class);
           }
@@ -8638,7 +8583,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -8666,7 +8611,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class Operation, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8678,7 +8623,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -8694,7 +8639,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class Operation, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -8706,14 +8651,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -8732,7 +8677,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -8751,7 +8696,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -8767,7 +8712,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -8786,7 +8731,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -8805,7 +8750,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -8824,7 +8769,7 @@ public class Xmlization {
             }
             case "inputVariables":
             {
-              final _Result<List<IOperationVariable>> tryInputVariables = parseList(
+              final Reporting.Result<List<IOperationVariable>> tryInputVariables = parseList(
                 reader,
                 isEmptyProperty,
                 IOperationVariable.class,
@@ -8843,7 +8788,7 @@ public class Xmlization {
             }
             case "outputVariables":
             {
-              final _Result<List<IOperationVariable>> tryOutputVariables = parseList(
+              final Reporting.Result<List<IOperationVariable>> tryOutputVariables = parseList(
                 reader,
                 isEmptyProperty,
                 IOperationVariable.class,
@@ -8862,7 +8807,7 @@ public class Xmlization {
             }
             case "inoutputVariables":
             {
-              final _Result<List<IOperationVariable>> tryInoutputVariables = parseList(
+              final Reporting.Result<List<IOperationVariable>> tryInoutputVariables = parseList(
                 reader,
                 isEmptyProperty,
                 IOperationVariable.class,
@@ -8884,13 +8829,13 @@ public class Xmlization {
                 "We expected properties of the class Operation, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Operation",
             reader,
             tryElementName);
@@ -8899,7 +8844,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new Operation(
+      return Reporting.Result.success(new Operation(
         theExtensions,
         theCategory,
         theIdShort,
@@ -8917,7 +8862,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Operation from an XML element.
      */
-    private static _Result<? extends Operation> tryOperationFromElement(
+    private static Reporting.Result<? extends Operation> tryOperationFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -8927,7 +8872,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Operation " +
               "with element name operation, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryOperationFromSequence(reader, isEmptyElement);
@@ -8941,7 +8886,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<OperationVariable> tryOperationVariableFromSequence(
+    private static Reporting.Result<OperationVariable> tryOperationVariableFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       ISubmodelElement theValue = null;
@@ -8953,7 +8898,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class OperationVariable, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -8968,10 +8913,10 @@ public class Xmlization {
               "a property of an instance of class OperationVariable, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(OperationVariable.class);
           }
@@ -8987,7 +8932,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property value of an instance of class OperationVariable, " +
                   "but encountered a self-closing element.");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // We need to skip the whitespace here in order to be able to look ahead
@@ -8999,7 +8944,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property value of an instance of class OperationVariable, " +
                   "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // Try to look ahead the discriminator name;
@@ -9008,12 +8953,12 @@ public class Xmlization {
               // checks.
               String discriminatorElementName = null;
               if (currentEvent(reader).isStartElement()) {
-                _Result<String> tryDiscriminatorElementName = tryElementName(reader);
+                Reporting.Result<String> tryDiscriminatorElementName = tryElementName(reader);
                 assert(!tryDiscriminatorElementName.isError());
                 discriminatorElementName = tryDiscriminatorElementName.getResult();
               }
 
-              _Result<? extends ISubmodelElement> tryValue = tryISubmodelElementFromElement(reader);
+              Reporting.Result<? extends ISubmodelElement> tryValue = tryISubmodelElementFromElement(reader);
 
               if (tryValue.isError()) {
                 if (discriminatorElementName != null) {
@@ -9038,13 +8983,13 @@ public class Xmlization {
                 "We expected properties of the class OperationVariable, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "OperationVariable",
             reader,
             tryElementName);
@@ -9057,17 +9002,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property value has not been given " +
           "in the XML representation of an instance of class OperationVariable");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new OperationVariable(
+      return Reporting.Result.success(new OperationVariable(
         theValue));
     }
 
     /**
      * Deserialize an instance of class OperationVariable from an XML element.
      */
-    private static _Result<? extends OperationVariable> tryOperationVariableFromElement(
+    private static Reporting.Result<? extends OperationVariable> tryOperationVariableFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -9077,7 +9022,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class OperationVariable " +
               "with element name operationVariable, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryOperationVariableFromSequence(reader, isEmptyElement);
@@ -9091,7 +9036,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Capability> tryCapabilityFromSequence(
+    private static Reporting.Result<Capability> tryCapabilityFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -9111,7 +9056,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Capability, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -9126,10 +9071,10 @@ public class Xmlization {
               "a property of an instance of class Capability, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Capability.class);
           }
@@ -9140,7 +9085,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -9168,7 +9113,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class Capability, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -9180,7 +9125,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -9196,7 +9141,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class Capability, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -9208,14 +9153,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -9234,7 +9179,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -9253,7 +9198,7 @@ public class Xmlization {
             }
             case "semanticId":
             {
-              _Result<Reference> trySemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> trySemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (trySemanticId.isError()) {
@@ -9269,7 +9214,7 @@ public class Xmlization {
             }
             case "supplementalSemanticIds":
             {
-              final _Result<List<IReference>> trySupplementalSemanticIds = parseList(
+              final Reporting.Result<List<IReference>> trySupplementalSemanticIds = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -9288,7 +9233,7 @@ public class Xmlization {
             }
             case "qualifiers":
             {
-              final _Result<List<IQualifier>> tryQualifiers = parseList(
+              final Reporting.Result<List<IQualifier>> tryQualifiers = parseList(
                 reader,
                 isEmptyProperty,
                 IQualifier.class,
@@ -9307,7 +9252,7 @@ public class Xmlization {
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -9329,13 +9274,13 @@ public class Xmlization {
                 "We expected properties of the class Capability, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Capability",
             reader,
             tryElementName);
@@ -9344,7 +9289,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new Capability(
+      return Reporting.Result.success(new Capability(
         theExtensions,
         theCategory,
         theIdShort,
@@ -9359,7 +9304,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Capability from an XML element.
      */
-    private static _Result<? extends Capability> tryCapabilityFromElement(
+    private static Reporting.Result<? extends Capability> tryCapabilityFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -9369,7 +9314,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Capability " +
               "with element name capability, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryCapabilityFromSequence(reader, isEmptyElement);
@@ -9383,7 +9328,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<ConceptDescription> tryConceptDescriptionFromSequence(
+    private static Reporting.Result<ConceptDescription> tryConceptDescriptionFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IExtension> theExtensions = null;
@@ -9403,7 +9348,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class ConceptDescription, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -9418,10 +9363,10 @@ public class Xmlization {
               "a property of an instance of class ConceptDescription, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(ConceptDescription.class);
           }
@@ -9432,7 +9377,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "extensions":
             {
-              final _Result<List<IExtension>> tryExtensions = parseList(
+              final Reporting.Result<List<IExtension>> tryExtensions = parseList(
                 reader,
                 isEmptyProperty,
                 IExtension.class,
@@ -9460,7 +9405,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property category of an instance of class ConceptDescription, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -9472,7 +9417,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "category"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -9488,7 +9433,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property idShort of an instance of class ConceptDescription, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -9500,14 +9445,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "idShort"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "displayName":
             {
-              final _Result<List<ILangStringNameType>> tryDisplayName = parseList(
+              final Reporting.Result<List<ILangStringNameType>> tryDisplayName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringNameType.class,
@@ -9526,7 +9471,7 @@ public class Xmlization {
             }
             case "description":
             {
-              final _Result<List<ILangStringTextType>> tryDescription = parseList(
+              final Reporting.Result<List<ILangStringTextType>> tryDescription = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringTextType.class,
@@ -9545,7 +9490,7 @@ public class Xmlization {
             }
             case "administration":
             {
-              _Result<AdministrativeInformation> tryAdministration = tryAdministrativeInformationFromSequence(
+              Reporting.Result<AdministrativeInformation> tryAdministration = tryAdministrativeInformationFromSequence(
                 reader, isEmptyProperty);
 
               if (tryAdministration.isError()) {
@@ -9570,7 +9515,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property id of an instance of class ConceptDescription, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -9582,14 +9527,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "id"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "embeddedDataSpecifications":
             {
-              final _Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
+              final Reporting.Result<List<IEmbeddedDataSpecification>> tryEmbeddedDataSpecifications = parseList(
                 reader,
                 isEmptyProperty,
                 IEmbeddedDataSpecification.class,
@@ -9608,7 +9553,7 @@ public class Xmlization {
             }
             case "isCaseOf":
             {
-              final _Result<List<IReference>> tryIsCaseOf = parseList(
+              final Reporting.Result<List<IReference>> tryIsCaseOf = parseList(
                 reader,
                 isEmptyProperty,
                 IReference.class,
@@ -9630,13 +9575,13 @@ public class Xmlization {
                 "We expected properties of the class ConceptDescription, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "ConceptDescription",
             reader,
             tryElementName);
@@ -9649,10 +9594,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property id has not been given " +
           "in the XML representation of an instance of class ConceptDescription");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new ConceptDescription(
+      return Reporting.Result.success(new ConceptDescription(
         theId,
         theExtensions,
         theCategory,
@@ -9667,7 +9612,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class ConceptDescription from an XML element.
      */
-    private static _Result<? extends ConceptDescription> tryConceptDescriptionFromElement(
+    private static Reporting.Result<? extends ConceptDescription> tryConceptDescriptionFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -9677,7 +9622,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class ConceptDescription " +
               "with element name conceptDescription, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryConceptDescriptionFromSequence(reader, isEmptyElement);
@@ -9691,7 +9636,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Reference> tryReferenceFromSequence(
+    private static Reporting.Result<Reference> tryReferenceFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       ReferenceTypes theType = null;
@@ -9705,7 +9650,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Reference, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -9720,10 +9665,10 @@ public class Xmlization {
               "a property of an instance of class Reference, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Reference.class);
           }
@@ -9742,7 +9687,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "type"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -9750,7 +9695,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property type of an instance of class Reference, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textType;
@@ -9763,7 +9708,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "type"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<ReferenceTypes> optionalType =
@@ -9780,13 +9725,13 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "type"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
             case "referredSemanticId":
             {
-              _Result<Reference> tryReferredSemanticId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryReferredSemanticId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryReferredSemanticId.isError()) {
@@ -9802,7 +9747,7 @@ public class Xmlization {
             }
             case "keys":
             {
-              final _Result<List<IKey>> tryKeys = parseList(
+              final Reporting.Result<List<IKey>> tryKeys = parseList(
                 reader,
                 isEmptyProperty,
                 IKey.class,
@@ -9824,13 +9769,13 @@ public class Xmlization {
                 "We expected properties of the class Reference, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Reference",
             reader,
             tryElementName);
@@ -9843,17 +9788,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property type has not been given " +
           "in the XML representation of an instance of class Reference");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theKeys == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property keys has not been given " +
           "in the XML representation of an instance of class Reference");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Reference(
+      return Reporting.Result.success(new Reference(
         theType,
         theKeys,
         theReferredSemanticId));
@@ -9862,7 +9807,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Reference from an XML element.
      */
-    private static _Result<? extends Reference> tryReferenceFromElement(
+    private static Reporting.Result<? extends Reference> tryReferenceFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -9872,7 +9817,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Reference " +
               "with element name reference, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryReferenceFromSequence(reader, isEmptyElement);
@@ -9886,7 +9831,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Key> tryKeyFromSequence(
+    private static Reporting.Result<Key> tryKeyFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       KeyTypes theType = null;
@@ -9899,7 +9844,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Key, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -9914,10 +9859,10 @@ public class Xmlization {
               "a property of an instance of class Key, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Key.class);
           }
@@ -9936,7 +9881,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "type"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -9944,7 +9889,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property type of an instance of class Key, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textType;
@@ -9957,7 +9902,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "type"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<KeyTypes> optionalType =
@@ -9974,7 +9919,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "type"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -9989,7 +9934,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class Key, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10001,7 +9946,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10011,13 +9956,13 @@ public class Xmlization {
                 "We expected properties of the class Key, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Key",
             reader,
             tryElementName);
@@ -10030,17 +9975,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property type has not been given " +
           "in the XML representation of an instance of class Key");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theValue == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property value has not been given " +
           "in the XML representation of an instance of class Key");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Key(
+      return Reporting.Result.success(new Key(
         theType,
         theValue));
     }
@@ -10048,7 +9993,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Key from an XML element.
      */
-    private static _Result<? extends Key> tryKeyFromElement(
+    private static Reporting.Result<? extends Key> tryKeyFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -10058,7 +10003,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Key " +
               "with element name key, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryKeyFromSequence(reader, isEmptyElement);
@@ -10068,7 +10013,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IAbstractLangString from an XML element.
      */
-    private static _Result<? extends IAbstractLangString> tryIAbstractLangStringFromElement(
+    private static Reporting.Result<? extends IAbstractLangString> tryIAbstractLangStringFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -10088,7 +10033,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -10100,7 +10045,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<LangStringNameType> tryLangStringNameTypeFromSequence(
+    private static Reporting.Result<LangStringNameType> tryLangStringNameTypeFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theLanguage = null;
@@ -10113,7 +10058,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class LangStringNameType, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -10128,10 +10073,10 @@ public class Xmlization {
               "a property of an instance of class LangStringNameType, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(LangStringNameType.class);
           }
@@ -10151,7 +10096,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property language of an instance of class LangStringNameType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10163,7 +10108,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "language"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10179,7 +10124,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property text of an instance of class LangStringNameType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10191,7 +10136,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "text"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10201,13 +10146,13 @@ public class Xmlization {
                 "We expected properties of the class LangStringNameType, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "LangStringNameType",
             reader,
             tryElementName);
@@ -10220,17 +10165,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property language has not been given " +
           "in the XML representation of an instance of class LangStringNameType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theText == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property text has not been given " +
           "in the XML representation of an instance of class LangStringNameType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new LangStringNameType(
+      return Reporting.Result.success(new LangStringNameType(
         theLanguage,
         theText));
     }
@@ -10238,7 +10183,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class LangStringNameType from an XML element.
      */
-    private static _Result<? extends LangStringNameType> tryLangStringNameTypeFromElement(
+    private static Reporting.Result<? extends LangStringNameType> tryLangStringNameTypeFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -10248,7 +10193,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class LangStringNameType " +
               "with element name langStringNameType, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryLangStringNameTypeFromSequence(reader, isEmptyElement);
@@ -10262,7 +10207,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<LangStringTextType> tryLangStringTextTypeFromSequence(
+    private static Reporting.Result<LangStringTextType> tryLangStringTextTypeFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theLanguage = null;
@@ -10275,7 +10220,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class LangStringTextType, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -10290,10 +10235,10 @@ public class Xmlization {
               "a property of an instance of class LangStringTextType, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(LangStringTextType.class);
           }
@@ -10313,7 +10258,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property language of an instance of class LangStringTextType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10325,7 +10270,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "language"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10341,7 +10286,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property text of an instance of class LangStringTextType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10353,7 +10298,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "text"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10363,13 +10308,13 @@ public class Xmlization {
                 "We expected properties of the class LangStringTextType, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "LangStringTextType",
             reader,
             tryElementName);
@@ -10382,17 +10327,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property language has not been given " +
           "in the XML representation of an instance of class LangStringTextType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theText == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property text has not been given " +
           "in the XML representation of an instance of class LangStringTextType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new LangStringTextType(
+      return Reporting.Result.success(new LangStringTextType(
         theLanguage,
         theText));
     }
@@ -10400,7 +10345,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class LangStringTextType from an XML element.
      */
-    private static _Result<? extends LangStringTextType> tryLangStringTextTypeFromElement(
+    private static Reporting.Result<? extends LangStringTextType> tryLangStringTextTypeFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -10410,7 +10355,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class LangStringTextType " +
               "with element name langStringTextType, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryLangStringTextTypeFromSequence(reader, isEmptyElement);
@@ -10424,7 +10369,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Environment> tryEnvironmentFromSequence(
+    private static Reporting.Result<Environment> tryEnvironmentFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IAssetAdministrationShell> theAssetAdministrationShells = null;
@@ -10438,7 +10383,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Environment, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -10453,10 +10398,10 @@ public class Xmlization {
               "a property of an instance of class Environment, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Environment.class);
           }
@@ -10467,7 +10412,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "assetAdministrationShells":
             {
-              final _Result<List<IAssetAdministrationShell>> tryAssetAdministrationShells = parseList(
+              final Reporting.Result<List<IAssetAdministrationShell>> tryAssetAdministrationShells = parseList(
                 reader,
                 isEmptyProperty,
                 IAssetAdministrationShell.class,
@@ -10486,7 +10431,7 @@ public class Xmlization {
             }
             case "submodels":
             {
-              final _Result<List<ISubmodel>> trySubmodels = parseList(
+              final Reporting.Result<List<ISubmodel>> trySubmodels = parseList(
                 reader,
                 isEmptyProperty,
                 ISubmodel.class,
@@ -10505,7 +10450,7 @@ public class Xmlization {
             }
             case "conceptDescriptions":
             {
-              final _Result<List<IConceptDescription>> tryConceptDescriptions = parseList(
+              final Reporting.Result<List<IConceptDescription>> tryConceptDescriptions = parseList(
                 reader,
                 isEmptyProperty,
                 IConceptDescription.class,
@@ -10527,13 +10472,13 @@ public class Xmlization {
                 "We expected properties of the class Environment, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Environment",
             reader,
             tryElementName);
@@ -10542,7 +10487,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new Environment(
+      return Reporting.Result.success(new Environment(
         theAssetAdministrationShells,
         theSubmodels,
         theConceptDescriptions));
@@ -10551,7 +10496,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Environment from an XML element.
      */
-    private static _Result<? extends Environment> tryEnvironmentFromElement(
+    private static Reporting.Result<? extends Environment> tryEnvironmentFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -10561,7 +10506,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Environment " +
               "with element name environment, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryEnvironmentFromSequence(reader, isEmptyElement);
@@ -10571,7 +10516,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IDataSpecificationContent from an XML element.
      */
-    private static _Result<? extends IDataSpecificationContent> tryIDataSpecificationContentFromElement(
+    private static Reporting.Result<? extends IDataSpecificationContent> tryIDataSpecificationContentFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -10583,7 +10528,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -10595,7 +10540,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<EmbeddedDataSpecification> tryEmbeddedDataSpecificationFromSequence(
+    private static Reporting.Result<EmbeddedDataSpecification> tryEmbeddedDataSpecificationFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       IReference theDataSpecification = null;
@@ -10608,7 +10553,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class EmbeddedDataSpecification, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -10623,10 +10568,10 @@ public class Xmlization {
               "a property of an instance of class EmbeddedDataSpecification, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(EmbeddedDataSpecification.class);
           }
@@ -10637,7 +10582,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "dataSpecification":
             {
-              _Result<Reference> tryDataSpecification = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryDataSpecification = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryDataSpecification.isError()) {
@@ -10658,7 +10603,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property dataSpecificationContent of an instance of class EmbeddedDataSpecification, " +
                   "but encountered a self-closing element.");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // We need to skip the whitespace here in order to be able to look ahead
@@ -10670,7 +10615,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property dataSpecificationContent of an instance of class EmbeddedDataSpecification, " +
                   "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // Try to look ahead the discriminator name;
@@ -10679,12 +10624,12 @@ public class Xmlization {
               // checks.
               String discriminatorElementName = null;
               if (currentEvent(reader).isStartElement()) {
-                _Result<String> tryDiscriminatorElementName = tryElementName(reader);
+                Reporting.Result<String> tryDiscriminatorElementName = tryElementName(reader);
                 assert(!tryDiscriminatorElementName.isError());
                 discriminatorElementName = tryDiscriminatorElementName.getResult();
               }
 
-              _Result<? extends IDataSpecificationContent> tryDataSpecificationContent = tryIDataSpecificationContentFromElement(reader);
+              Reporting.Result<? extends IDataSpecificationContent> tryDataSpecificationContent = tryIDataSpecificationContentFromElement(reader);
 
               if (tryDataSpecificationContent.isError()) {
                 if (discriminatorElementName != null) {
@@ -10709,13 +10654,13 @@ public class Xmlization {
                 "We expected properties of the class EmbeddedDataSpecification, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "EmbeddedDataSpecification",
             reader,
             tryElementName);
@@ -10728,17 +10673,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property dataSpecification has not been given " +
           "in the XML representation of an instance of class EmbeddedDataSpecification");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theDataSpecificationContent == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property dataSpecificationContent has not been given " +
           "in the XML representation of an instance of class EmbeddedDataSpecification");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new EmbeddedDataSpecification(
+      return Reporting.Result.success(new EmbeddedDataSpecification(
         theDataSpecification,
         theDataSpecificationContent));
     }
@@ -10746,7 +10691,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class EmbeddedDataSpecification from an XML element.
      */
-    private static _Result<? extends EmbeddedDataSpecification> tryEmbeddedDataSpecificationFromElement(
+    private static Reporting.Result<? extends EmbeddedDataSpecification> tryEmbeddedDataSpecificationFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -10756,7 +10701,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class EmbeddedDataSpecification " +
               "with element name embeddedDataSpecification, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryEmbeddedDataSpecificationFromSequence(reader, isEmptyElement);
@@ -10770,7 +10715,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<LevelType> tryLevelTypeFromSequence(
+    private static Reporting.Result<LevelType> tryLevelTypeFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       Boolean theMin = null;
@@ -10785,7 +10730,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class LevelType, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -10800,10 +10745,10 @@ public class Xmlization {
               "a property of an instance of class LevelType, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(LevelType.class);
           }
@@ -10822,7 +10767,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "min"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -10830,7 +10775,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property min of an instance of class LevelType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10842,7 +10787,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "min"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10857,7 +10802,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "nom"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -10865,7 +10810,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property nom of an instance of class LevelType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10877,7 +10822,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "nom"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10892,7 +10837,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "typ"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -10900,7 +10845,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property typ of an instance of class LevelType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10912,7 +10857,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "typ"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10927,7 +10872,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "max"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -10935,7 +10880,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property max of an instance of class LevelType, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -10947,7 +10892,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "max"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -10957,13 +10902,13 @@ public class Xmlization {
                 "We expected properties of the class LevelType, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "LevelType",
             reader,
             tryElementName);
@@ -10976,31 +10921,31 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property min has not been given " +
           "in the XML representation of an instance of class LevelType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theNom == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property nom has not been given " +
           "in the XML representation of an instance of class LevelType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theTyp == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property typ has not been given " +
           "in the XML representation of an instance of class LevelType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theMax == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property max has not been given " +
           "in the XML representation of an instance of class LevelType");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new LevelType(
+      return Reporting.Result.success(new LevelType(
         theMin,
         theNom,
         theTyp,
@@ -11010,7 +10955,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class LevelType from an XML element.
      */
-    private static _Result<? extends LevelType> tryLevelTypeFromElement(
+    private static Reporting.Result<? extends LevelType> tryLevelTypeFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -11020,7 +10965,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class LevelType " +
               "with element name levelType, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryLevelTypeFromSequence(reader, isEmptyElement);
@@ -11034,7 +10979,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<ValueReferencePair> tryValueReferencePairFromSequence(
+    private static Reporting.Result<ValueReferencePair> tryValueReferencePairFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theValue = null;
@@ -11047,7 +10992,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class ValueReferencePair, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -11062,10 +11007,10 @@ public class Xmlization {
               "a property of an instance of class ValueReferencePair, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(ValueReferencePair.class);
           }
@@ -11085,7 +11030,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class ValueReferencePair, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11097,14 +11042,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "valueId":
             {
-              _Result<Reference> tryValueId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryValueId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryValueId.isError()) {
@@ -11123,13 +11068,13 @@ public class Xmlization {
                 "We expected properties of the class ValueReferencePair, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "ValueReferencePair",
             reader,
             tryElementName);
@@ -11142,17 +11087,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property value has not been given " +
           "in the XML representation of an instance of class ValueReferencePair");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theValueId == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property valueId has not been given " +
           "in the XML representation of an instance of class ValueReferencePair");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new ValueReferencePair(
+      return Reporting.Result.success(new ValueReferencePair(
         theValue,
         theValueId));
     }
@@ -11160,7 +11105,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class ValueReferencePair from an XML element.
      */
-    private static _Result<? extends ValueReferencePair> tryValueReferencePairFromElement(
+    private static Reporting.Result<? extends ValueReferencePair> tryValueReferencePairFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -11170,7 +11115,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class ValueReferencePair " +
               "with element name valueReferencePair, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryValueReferencePairFromSequence(reader, isEmptyElement);
@@ -11184,7 +11129,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<ValueList> tryValueListFromSequence(
+    private static Reporting.Result<ValueList> tryValueListFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IValueReferencePair> theValueReferencePairs = null;
@@ -11196,7 +11141,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class ValueList, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -11211,10 +11156,10 @@ public class Xmlization {
               "a property of an instance of class ValueList, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(ValueList.class);
           }
@@ -11225,7 +11170,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "valueReferencePairs":
             {
-              final _Result<List<IValueReferencePair>> tryValueReferencePairs = parseList(
+              final Reporting.Result<List<IValueReferencePair>> tryValueReferencePairs = parseList(
                 reader,
                 isEmptyProperty,
                 IValueReferencePair.class,
@@ -11247,13 +11192,13 @@ public class Xmlization {
                 "We expected properties of the class ValueList, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "ValueList",
             reader,
             tryElementName);
@@ -11266,17 +11211,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property valueReferencePairs has not been given " +
           "in the XML representation of an instance of class ValueList");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new ValueList(
+      return Reporting.Result.success(new ValueList(
         theValueReferencePairs));
     }
 
     /**
      * Deserialize an instance of class ValueList from an XML element.
      */
-    private static _Result<? extends ValueList> tryValueListFromElement(
+    private static Reporting.Result<? extends ValueList> tryValueListFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -11286,7 +11231,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class ValueList " +
               "with element name valueList, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryValueListFromSequence(reader, isEmptyElement);
@@ -11300,7 +11245,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<LangStringPreferredNameTypeIec61360> tryLangStringPreferredNameTypeIec61360FromSequence(
+    private static Reporting.Result<LangStringPreferredNameTypeIec61360> tryLangStringPreferredNameTypeIec61360FromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theLanguage = null;
@@ -11313,7 +11258,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class LangStringPreferredNameTypeIec61360, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -11328,10 +11273,10 @@ public class Xmlization {
               "a property of an instance of class LangStringPreferredNameTypeIec61360, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(LangStringPreferredNameTypeIec61360.class);
           }
@@ -11351,7 +11296,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property language of an instance of class LangStringPreferredNameTypeIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11363,7 +11308,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "language"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11379,7 +11324,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property text of an instance of class LangStringPreferredNameTypeIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11391,7 +11336,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "text"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11401,13 +11346,13 @@ public class Xmlization {
                 "We expected properties of the class LangStringPreferredNameTypeIec61360, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "LangStringPreferredNameTypeIec61360",
             reader,
             tryElementName);
@@ -11420,17 +11365,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property language has not been given " +
           "in the XML representation of an instance of class LangStringPreferredNameTypeIec61360");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theText == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property text has not been given " +
           "in the XML representation of an instance of class LangStringPreferredNameTypeIec61360");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new LangStringPreferredNameTypeIec61360(
+      return Reporting.Result.success(new LangStringPreferredNameTypeIec61360(
         theLanguage,
         theText));
     }
@@ -11438,7 +11383,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class LangStringPreferredNameTypeIec61360 from an XML element.
      */
-    private static _Result<? extends LangStringPreferredNameTypeIec61360> tryLangStringPreferredNameTypeIec61360FromElement(
+    private static Reporting.Result<? extends LangStringPreferredNameTypeIec61360> tryLangStringPreferredNameTypeIec61360FromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -11448,7 +11393,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class LangStringPreferredNameTypeIec61360 " +
               "with element name langStringPreferredNameTypeIec61360, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryLangStringPreferredNameTypeIec61360FromSequence(reader, isEmptyElement);
@@ -11462,7 +11407,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<LangStringShortNameTypeIec61360> tryLangStringShortNameTypeIec61360FromSequence(
+    private static Reporting.Result<LangStringShortNameTypeIec61360> tryLangStringShortNameTypeIec61360FromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theLanguage = null;
@@ -11475,7 +11420,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class LangStringShortNameTypeIec61360, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -11490,10 +11435,10 @@ public class Xmlization {
               "a property of an instance of class LangStringShortNameTypeIec61360, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(LangStringShortNameTypeIec61360.class);
           }
@@ -11513,7 +11458,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property language of an instance of class LangStringShortNameTypeIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11525,7 +11470,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "language"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11541,7 +11486,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property text of an instance of class LangStringShortNameTypeIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11553,7 +11498,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "text"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11563,13 +11508,13 @@ public class Xmlization {
                 "We expected properties of the class LangStringShortNameTypeIec61360, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "LangStringShortNameTypeIec61360",
             reader,
             tryElementName);
@@ -11582,17 +11527,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property language has not been given " +
           "in the XML representation of an instance of class LangStringShortNameTypeIec61360");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theText == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property text has not been given " +
           "in the XML representation of an instance of class LangStringShortNameTypeIec61360");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new LangStringShortNameTypeIec61360(
+      return Reporting.Result.success(new LangStringShortNameTypeIec61360(
         theLanguage,
         theText));
     }
@@ -11600,7 +11545,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class LangStringShortNameTypeIec61360 from an XML element.
      */
-    private static _Result<? extends LangStringShortNameTypeIec61360> tryLangStringShortNameTypeIec61360FromElement(
+    private static Reporting.Result<? extends LangStringShortNameTypeIec61360> tryLangStringShortNameTypeIec61360FromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -11610,7 +11555,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class LangStringShortNameTypeIec61360 " +
               "with element name langStringShortNameTypeIec61360, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryLangStringShortNameTypeIec61360FromSequence(reader, isEmptyElement);
@@ -11624,7 +11569,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<LangStringDefinitionTypeIec61360> tryLangStringDefinitionTypeIec61360FromSequence(
+    private static Reporting.Result<LangStringDefinitionTypeIec61360> tryLangStringDefinitionTypeIec61360FromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theLanguage = null;
@@ -11637,7 +11582,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class LangStringDefinitionTypeIec61360, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -11652,10 +11597,10 @@ public class Xmlization {
               "a property of an instance of class LangStringDefinitionTypeIec61360, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(LangStringDefinitionTypeIec61360.class);
           }
@@ -11675,7 +11620,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property language of an instance of class LangStringDefinitionTypeIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11687,7 +11632,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "language"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11703,7 +11648,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property text of an instance of class LangStringDefinitionTypeIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11715,7 +11660,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "text"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11725,13 +11670,13 @@ public class Xmlization {
                 "We expected properties of the class LangStringDefinitionTypeIec61360, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "LangStringDefinitionTypeIec61360",
             reader,
             tryElementName);
@@ -11744,17 +11689,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property language has not been given " +
           "in the XML representation of an instance of class LangStringDefinitionTypeIec61360");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theText == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property text has not been given " +
           "in the XML representation of an instance of class LangStringDefinitionTypeIec61360");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new LangStringDefinitionTypeIec61360(
+      return Reporting.Result.success(new LangStringDefinitionTypeIec61360(
         theLanguage,
         theText));
     }
@@ -11762,7 +11707,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class LangStringDefinitionTypeIec61360 from an XML element.
      */
-    private static _Result<? extends LangStringDefinitionTypeIec61360> tryLangStringDefinitionTypeIec61360FromElement(
+    private static Reporting.Result<? extends LangStringDefinitionTypeIec61360> tryLangStringDefinitionTypeIec61360FromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -11772,7 +11717,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class LangStringDefinitionTypeIec61360 " +
               "with element name langStringDefinitionTypeIec61360, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryLangStringDefinitionTypeIec61360FromSequence(reader, isEmptyElement);
@@ -11786,7 +11731,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<DataSpecificationIec61360> tryDataSpecificationIec61360FromSequence(
+    private static Reporting.Result<DataSpecificationIec61360> tryDataSpecificationIec61360FromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<ILangStringPreferredNameTypeIec61360> thePreferredName = null;
@@ -11809,7 +11754,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class DataSpecificationIec61360, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -11824,10 +11769,10 @@ public class Xmlization {
               "a property of an instance of class DataSpecificationIec61360, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(DataSpecificationIec61360.class);
           }
@@ -11838,7 +11783,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "preferredName":
             {
-              final _Result<List<ILangStringPreferredNameTypeIec61360>> tryPreferredName = parseList(
+              final Reporting.Result<List<ILangStringPreferredNameTypeIec61360>> tryPreferredName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringPreferredNameTypeIec61360.class,
@@ -11857,7 +11802,7 @@ public class Xmlization {
             }
             case "shortName":
             {
-              final _Result<List<ILangStringShortNameTypeIec61360>> tryShortName = parseList(
+              final Reporting.Result<List<ILangStringShortNameTypeIec61360>> tryShortName = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringShortNameTypeIec61360.class,
@@ -11885,7 +11830,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property unit of an instance of class DataSpecificationIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11897,14 +11842,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "unit"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "unitId":
             {
-              _Result<Reference> tryUnitId = tryReferenceFromSequence(
+              Reporting.Result<Reference> tryUnitId = tryReferenceFromSequence(
                 reader, isEmptyProperty);
 
               if (tryUnitId.isError()) {
@@ -11929,7 +11874,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property sourceOfDefinition of an instance of class DataSpecificationIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11941,7 +11886,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "sourceOfDefinition"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11957,7 +11902,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property symbol of an instance of class DataSpecificationIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -11969,7 +11914,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "symbol"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -11984,7 +11929,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "dataType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -11992,7 +11937,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property dataType of an instance of class DataSpecificationIec61360, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textDataType;
@@ -12005,7 +11950,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "dataType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<DataTypeIec61360> optionalDataType =
@@ -12022,13 +11967,13 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "dataType"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
             case "definition":
             {
-              final _Result<List<ILangStringDefinitionTypeIec61360>> tryDefinition = parseList(
+              final Reporting.Result<List<ILangStringDefinitionTypeIec61360>> tryDefinition = parseList(
                 reader,
                 isEmptyProperty,
                 ILangStringDefinitionTypeIec61360.class,
@@ -12056,7 +12001,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property valueFormat of an instance of class DataSpecificationIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -12068,14 +12013,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "valueFormat"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "valueList":
             {
-              _Result<ValueList> tryValueList = tryValueListFromSequence(
+              Reporting.Result<ValueList> tryValueList = tryValueListFromSequence(
                 reader, isEmptyProperty);
 
               if (tryValueList.isError()) {
@@ -12100,7 +12045,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class DataSpecificationIec61360, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -12112,14 +12057,14 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
             }
             case "levelType":
             {
-              _Result<LevelType> tryLevelType = tryLevelTypeFromSequence(
+              Reporting.Result<LevelType> tryLevelType = tryLevelTypeFromSequence(
                 reader, isEmptyProperty);
 
               if (tryLevelType.isError()) {
@@ -12138,13 +12083,13 @@ public class Xmlization {
                 "We expected properties of the class DataSpecificationIec61360, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "DataSpecificationIec61360",
             reader,
             tryElementName);
@@ -12157,10 +12102,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property preferredName has not been given " +
           "in the XML representation of an instance of class DataSpecificationIec61360");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new DataSpecificationIec61360(
+      return Reporting.Result.success(new DataSpecificationIec61360(
         thePreferredName,
         theShortName,
         theUnit,
@@ -12178,7 +12123,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class DataSpecificationIec61360 from an XML element.
      */
-    private static _Result<? extends DataSpecificationIec61360> tryDataSpecificationIec61360FromElement(
+    private static Reporting.Result<? extends DataSpecificationIec61360> tryDataSpecificationIec61360FromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -12188,7 +12133,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class DataSpecificationIec61360 " +
               "with element name dataSpecificationIec61360, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryDataSpecificationIec61360FromSequence(reader, isEmptyElement);
@@ -12231,7 +12176,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IHasSemantics> result =
+      Reporting.Result<? extends IHasSemantics> result =
         _DeserializeImplementation.tryIHasSemanticsFromElement(
           reader);
 
@@ -12254,7 +12199,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Extension> result =
+      Reporting.Result<? extends Extension> result =
         _DeserializeImplementation.tryExtensionFromElement(
           reader);
 
@@ -12277,7 +12222,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IHasExtensions> result =
+      Reporting.Result<? extends IHasExtensions> result =
         _DeserializeImplementation.tryIHasExtensionsFromElement(
           reader);
 
@@ -12300,7 +12245,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IReferable> result =
+      Reporting.Result<? extends IReferable> result =
         _DeserializeImplementation.tryIReferableFromElement(
           reader);
 
@@ -12323,7 +12268,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IIdentifiable> result =
+      Reporting.Result<? extends IIdentifiable> result =
         _DeserializeImplementation.tryIIdentifiableFromElement(
           reader);
 
@@ -12346,7 +12291,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IHasKind> result =
+      Reporting.Result<? extends IHasKind> result =
         _DeserializeImplementation.tryIHasKindFromElement(
           reader);
 
@@ -12369,7 +12314,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IHasDataSpecification> result =
+      Reporting.Result<? extends IHasDataSpecification> result =
         _DeserializeImplementation.tryIHasDataSpecificationFromElement(
           reader);
 
@@ -12392,7 +12337,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends AdministrativeInformation> result =
+      Reporting.Result<? extends AdministrativeInformation> result =
         _DeserializeImplementation.tryAdministrativeInformationFromElement(
           reader);
 
@@ -12415,7 +12360,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IQualifiable> result =
+      Reporting.Result<? extends IQualifiable> result =
         _DeserializeImplementation.tryIQualifiableFromElement(
           reader);
 
@@ -12438,7 +12383,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Qualifier> result =
+      Reporting.Result<? extends Qualifier> result =
         _DeserializeImplementation.tryQualifierFromElement(
           reader);
 
@@ -12461,7 +12406,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends AssetAdministrationShell> result =
+      Reporting.Result<? extends AssetAdministrationShell> result =
         _DeserializeImplementation.tryAssetAdministrationShellFromElement(
           reader);
 
@@ -12484,7 +12429,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends AssetInformation> result =
+      Reporting.Result<? extends AssetInformation> result =
         _DeserializeImplementation.tryAssetInformationFromElement(
           reader);
 
@@ -12507,7 +12452,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Resource> result =
+      Reporting.Result<? extends Resource> result =
         _DeserializeImplementation.tryResourceFromElement(
           reader);
 
@@ -12530,7 +12475,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends SpecificAssetId> result =
+      Reporting.Result<? extends SpecificAssetId> result =
         _DeserializeImplementation.trySpecificAssetIdFromElement(
           reader);
 
@@ -12553,7 +12498,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Submodel> result =
+      Reporting.Result<? extends Submodel> result =
         _DeserializeImplementation.trySubmodelFromElement(
           reader);
 
@@ -12576,7 +12521,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends ISubmodelElement> result =
+      Reporting.Result<? extends ISubmodelElement> result =
         _DeserializeImplementation.tryISubmodelElementFromElement(
           reader);
 
@@ -12599,7 +12544,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IRelationshipElement> result =
+      Reporting.Result<? extends IRelationshipElement> result =
         _DeserializeImplementation.tryIRelationshipElementFromElement(
           reader);
 
@@ -12622,7 +12567,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends RelationshipElement> result =
+      Reporting.Result<? extends RelationshipElement> result =
         _DeserializeImplementation.tryRelationshipElementFromElement(
           reader);
 
@@ -12645,7 +12590,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends SubmodelElementList> result =
+      Reporting.Result<? extends SubmodelElementList> result =
         _DeserializeImplementation.trySubmodelElementListFromElement(
           reader);
 
@@ -12668,7 +12613,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends SubmodelElementCollection> result =
+      Reporting.Result<? extends SubmodelElementCollection> result =
         _DeserializeImplementation.trySubmodelElementCollectionFromElement(
           reader);
 
@@ -12691,7 +12636,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IDataElement> result =
+      Reporting.Result<? extends IDataElement> result =
         _DeserializeImplementation.tryIDataElementFromElement(
           reader);
 
@@ -12714,7 +12659,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Property> result =
+      Reporting.Result<? extends Property> result =
         _DeserializeImplementation.tryPropertyFromElement(
           reader);
 
@@ -12737,7 +12682,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends MultiLanguageProperty> result =
+      Reporting.Result<? extends MultiLanguageProperty> result =
         _DeserializeImplementation.tryMultiLanguagePropertyFromElement(
           reader);
 
@@ -12760,7 +12705,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Range> result =
+      Reporting.Result<? extends Range> result =
         _DeserializeImplementation.tryRangeFromElement(
           reader);
 
@@ -12783,7 +12728,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends ReferenceElement> result =
+      Reporting.Result<? extends ReferenceElement> result =
         _DeserializeImplementation.tryReferenceElementFromElement(
           reader);
 
@@ -12806,7 +12751,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Blob> result =
+      Reporting.Result<? extends Blob> result =
         _DeserializeImplementation.tryBlobFromElement(
           reader);
 
@@ -12829,7 +12774,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends File> result =
+      Reporting.Result<? extends File> result =
         _DeserializeImplementation.tryFileFromElement(
           reader);
 
@@ -12852,7 +12797,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends AnnotatedRelationshipElement> result =
+      Reporting.Result<? extends AnnotatedRelationshipElement> result =
         _DeserializeImplementation.tryAnnotatedRelationshipElementFromElement(
           reader);
 
@@ -12875,7 +12820,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Entity> result =
+      Reporting.Result<? extends Entity> result =
         _DeserializeImplementation.tryEntityFromElement(
           reader);
 
@@ -12898,7 +12843,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends EventPayload> result =
+      Reporting.Result<? extends EventPayload> result =
         _DeserializeImplementation.tryEventPayloadFromElement(
           reader);
 
@@ -12921,7 +12866,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IEventElement> result =
+      Reporting.Result<? extends IEventElement> result =
         _DeserializeImplementation.tryIEventElementFromElement(
           reader);
 
@@ -12944,7 +12889,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends BasicEventElement> result =
+      Reporting.Result<? extends BasicEventElement> result =
         _DeserializeImplementation.tryBasicEventElementFromElement(
           reader);
 
@@ -12967,7 +12912,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Operation> result =
+      Reporting.Result<? extends Operation> result =
         _DeserializeImplementation.tryOperationFromElement(
           reader);
 
@@ -12990,7 +12935,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends OperationVariable> result =
+      Reporting.Result<? extends OperationVariable> result =
         _DeserializeImplementation.tryOperationVariableFromElement(
           reader);
 
@@ -13013,7 +12958,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Capability> result =
+      Reporting.Result<? extends Capability> result =
         _DeserializeImplementation.tryCapabilityFromElement(
           reader);
 
@@ -13036,7 +12981,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends ConceptDescription> result =
+      Reporting.Result<? extends ConceptDescription> result =
         _DeserializeImplementation.tryConceptDescriptionFromElement(
           reader);
 
@@ -13059,7 +13004,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Reference> result =
+      Reporting.Result<? extends Reference> result =
         _DeserializeImplementation.tryReferenceFromElement(
           reader);
 
@@ -13082,7 +13027,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Key> result =
+      Reporting.Result<? extends Key> result =
         _DeserializeImplementation.tryKeyFromElement(
           reader);
 
@@ -13105,7 +13050,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IAbstractLangString> result =
+      Reporting.Result<? extends IAbstractLangString> result =
         _DeserializeImplementation.tryIAbstractLangStringFromElement(
           reader);
 
@@ -13128,7 +13073,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends LangStringNameType> result =
+      Reporting.Result<? extends LangStringNameType> result =
         _DeserializeImplementation.tryLangStringNameTypeFromElement(
           reader);
 
@@ -13151,7 +13096,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends LangStringTextType> result =
+      Reporting.Result<? extends LangStringTextType> result =
         _DeserializeImplementation.tryLangStringTextTypeFromElement(
           reader);
 
@@ -13174,7 +13119,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Environment> result =
+      Reporting.Result<? extends Environment> result =
         _DeserializeImplementation.tryEnvironmentFromElement(
           reader);
 
@@ -13197,7 +13142,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IDataSpecificationContent> result =
+      Reporting.Result<? extends IDataSpecificationContent> result =
         _DeserializeImplementation.tryIDataSpecificationContentFromElement(
           reader);
 
@@ -13220,7 +13165,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends EmbeddedDataSpecification> result =
+      Reporting.Result<? extends EmbeddedDataSpecification> result =
         _DeserializeImplementation.tryEmbeddedDataSpecificationFromElement(
           reader);
 
@@ -13243,7 +13188,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends LevelType> result =
+      Reporting.Result<? extends LevelType> result =
         _DeserializeImplementation.tryLevelTypeFromElement(
           reader);
 
@@ -13266,7 +13211,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends ValueReferencePair> result =
+      Reporting.Result<? extends ValueReferencePair> result =
         _DeserializeImplementation.tryValueReferencePairFromElement(
           reader);
 
@@ -13289,7 +13234,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends ValueList> result =
+      Reporting.Result<? extends ValueList> result =
         _DeserializeImplementation.tryValueListFromElement(
           reader);
 
@@ -13312,7 +13257,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends LangStringPreferredNameTypeIec61360> result =
+      Reporting.Result<? extends LangStringPreferredNameTypeIec61360> result =
         _DeserializeImplementation.tryLangStringPreferredNameTypeIec61360FromElement(
           reader);
 
@@ -13335,7 +13280,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends LangStringShortNameTypeIec61360> result =
+      Reporting.Result<? extends LangStringShortNameTypeIec61360> result =
         _DeserializeImplementation.tryLangStringShortNameTypeIec61360FromElement(
           reader);
 
@@ -13358,7 +13303,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends LangStringDefinitionTypeIec61360> result =
+      Reporting.Result<? extends LangStringDefinitionTypeIec61360> result =
         _DeserializeImplementation.tryLangStringDefinitionTypeIec61360FromElement(
           reader);
 
@@ -13381,7 +13326,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends DataSpecificationIec61360> result =
+      Reporting.Result<? extends DataSpecificationIec61360> result =
         _DeserializeImplementation.tryDataSpecificationIec61360FromElement(
           reader);
 
@@ -13402,118 +13347,257 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
-    private void extensionToSequence(
-      IExtension that,
-      XMLStreamWriter writer) {
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
       try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "name");
+        writer.writeStartElement(name);
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
-        writer.writeCharacters(
-          that.getName().toString());
+        serializeContent.serialize(that, writer);
         writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getValueType().isPresent()) {
-          writer.writeStartElement(
-            "valueType");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          Optional<String> textValueType = Stringification.toString(
-            that.getValueType().get());
-
-          if (!textValueType.isPresent()) {
-            throw new IllegalArgumentException(
-              "Invalid literal for the enumeration DataTypeDefXsd: " +
-              that.getValueType().get().toString());
-          }
-
-          writer.writeCharacters(textValueType.get());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-            "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getValue().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getRefersTo().isPresent()) {
-          writer.writeStartElement(
-          "refersTo");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getRefersTo().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
       } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
+    /**
+     * Write a literal of {@link ModellingKind} as XML content.
+     *
+     * <p>This is shared by every ModellingKind-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeModellingKindContent(ModellingKind that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link QualifierKind} as XML content.
+     *
+     * <p>This is shared by every QualifierKind-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeQualifierKindContent(QualifierKind that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link AssetKind} as XML content.
+     *
+     * <p>This is shared by every AssetKind-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeAssetKindContent(AssetKind that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link AasSubmodelElements} as XML content.
+     *
+     * <p>This is shared by every AasSubmodelElements-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeAasSubmodelElementsContent(AasSubmodelElements that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link EntityType} as XML content.
+     *
+     * <p>This is shared by every EntityType-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeEntityTypeContent(EntityType that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link Direction} as XML content.
+     *
+     * <p>This is shared by every Direction-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeDirectionContent(Direction that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link StateOfEvent} as XML content.
+     *
+     * <p>This is shared by every StateOfEvent-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeStateOfEventContent(StateOfEvent that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link ReferenceTypes} as XML content.
+     *
+     * <p>This is shared by every ReferenceTypes-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeReferenceTypesContent(ReferenceTypes that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link KeyTypes} as XML content.
+     *
+     * <p>This is shared by every KeyTypes-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeKeyTypesContent(KeyTypes that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link DataTypeDefXsd} as XML content.
+     *
+     * <p>This is shared by every DataTypeDefXsd-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeDataTypeDefXsdContent(DataTypeDefXsd that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    /**
+     * Write a literal of {@link DataTypeIec61360} as XML content.
+     *
+     * <p>This is shared by every DataTypeIec61360-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeDataTypeIec61360Content(DataTypeIec61360 that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    private void extensionToSequence(
+      IExtension that,
+      XMLStreamWriter writer) {
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
+      }
+
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
+      }
+
+      serializeElement(
+        "name",
+        that.getName(),
+        writer,
+        this::writeStringifiedContent);
+
+      if (that.getValueType().isPresent()) {
+        serializeElement(
+          "valueType",
+          that.getValueType().get(),
+          writer,
+          this::writeDataTypeDefXsdContent);
+      }
+
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          this::writeStringifiedContent);
+      }
+
+      if (that.getRefersTo().isPresent()) {
+        serializeElement(
+          "refersTo",
+          that.getRefersTo().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -13540,94 +13624,44 @@ public class Xmlization {
     private void administrativeInformationToSequence(
       IAdministrativeInformation that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getVersion().isPresent()) {
-          writer.writeStartElement(
-            "version");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getVersion().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getVersion().isPresent()) {
+        serializeElement(
+          "version",
+          that.getVersion().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getRevision().isPresent()) {
-          writer.writeStartElement(
-            "revision");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getRevision().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getRevision().isPresent()) {
+        serializeElement(
+          "revision",
+          that.getRevision().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getCreator().isPresent()) {
-          writer.writeStartElement(
-            "creator");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getCreator().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCreator().isPresent()) {
+        serializeElement(
+          "creator",
+          that.getCreator().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getTemplateId().isPresent()) {
-          writer.writeStartElement(
-            "templateId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getTemplateId().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getTemplateId().isPresent()) {
+        serializeElement(
+          "templateId",
+          that.getTemplateId().get(),
+          writer,
+          this::writeStringifiedContent);
       }
     }
 
@@ -13654,141 +13688,56 @@ public class Xmlization {
     private void qualifierToSequence(
       IQualifier that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getKind().isPresent()) {
-          writer.writeStartElement(
-            "kind");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          Optional<String> textKind = Stringification.toString(
-            that.getKind().get());
-
-          if (!textKind.isPresent()) {
-            throw new IllegalArgumentException(
-              "Invalid literal for the enumeration QualifierKind: " +
-              that.getKind().get().toString());
-          }
-
-          writer.writeCharacters(textKind.get());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getKind().isPresent()) {
+        serializeElement(
+          "kind",
+          that.getKind().get(),
+          writer,
+          this::writeQualifierKindContent);
       }
 
-      try {
-        writer.writeStartElement(
-          "type");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getType().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      serializeElement(
+        "type",
+        that.getType(),
+        writer,
+        this::writeStringifiedContent);
+
+      serializeElement(
+        "valueType",
+        that.getValueType(),
+        writer,
+        this::writeDataTypeDefXsdContent);
+
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        writer.writeStartElement(
-          "valueType");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        Optional<String> textValueType = Stringification.toString(
-          that.getValueType());
-
-        if (!textValueType.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration DataTypeDefXsd: " +
-            that.getValueType().toString());
-        }
-
-        writer.writeCharacters(textValueType.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-            "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getValue().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getValueId().isPresent()) {
-          writer.writeStartElement(
-            "valueId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getValueId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValueId().isPresent()) {
+        serializeElement(
+          "valueId",
+          that.getValueId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
     }
 
@@ -13815,194 +13764,88 @@ public class Xmlization {
     private void assetAdministrationShellToSequence(
       IAssetAdministrationShell that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getAdministration().isPresent()) {
-          writer.writeStartElement(
-            "administration");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.administrativeInformationToSequence(
-            that.getAdministration().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getAdministration().isPresent()) {
+        serializeElement(
+          "administration",
+          that.getAdministration().get(),
+          writer,
+          (value, w) -> this.administrativeInformationToSequence(value, w));
       }
 
-      try {
-        writer.writeStartElement(
-          "id");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getId().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      serializeElement(
+        "id",
+        that.getId(),
+        writer,
+        this::writeStringifiedContent);
+
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDerivedFrom().isPresent()) {
+        serializeElement(
+          "derivedFrom",
+          that.getDerivedFrom().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getDerivedFrom().isPresent()) {
-          writer.writeStartElement(
-            "derivedFrom");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
+      serializeElement(
+        "assetInformation",
+        that.getAssetInformation(),
+        writer,
+        (value, w) -> this.assetInformationToSequence(value, w));
 
-          this.referenceToSequence(
-            that.getDerivedFrom().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "assetInformation");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.assetInformationToSequence(
-          that.getAssetInformation(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getSubmodels().isPresent()) {
-          writer.writeStartElement(
-          "submodels");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSubmodels().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSubmodels().isPresent()) {
+        serializeElement(
+          "submodels",
+          that.getSubmodels().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -14029,100 +13872,42 @@ public class Xmlization {
     private void assetInformationToSequence(
       IAssetInformation that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "assetKind");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "assetKind",
+        that.getAssetKind(),
+        writer,
+        this::writeAssetKindContent);
 
-        Optional<String> textAssetKind = Stringification.toString(
-          that.getAssetKind());
-
-        if (!textAssetKind.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration AssetKind: " +
-            that.getAssetKind().toString());
-        }
-
-        writer.writeCharacters(textAssetKind.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getGlobalAssetId().isPresent()) {
+        serializeElement(
+          "globalAssetId",
+          that.getGlobalAssetId().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getGlobalAssetId().isPresent()) {
-          writer.writeStartElement(
-            "globalAssetId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getGlobalAssetId().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSpecificAssetIds().isPresent()) {
+        serializeElement(
+          "specificAssetIds",
+          that.getSpecificAssetIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSpecificAssetIds().isPresent()) {
-          writer.writeStartElement(
-          "specificAssetIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ISpecificAssetId item : that.getSpecificAssetIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getAssetType().isPresent()) {
+        serializeElement(
+          "assetType",
+          that.getAssetType().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getAssetType().isPresent()) {
-          writer.writeStartElement(
-            "assetType");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getAssetType().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getDefaultThumbnail().isPresent()) {
-          writer.writeStartElement(
-            "defaultThumbnail");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.resourceToSequence(
-            that.getDefaultThumbnail().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDefaultThumbnail().isPresent()) {
+        serializeElement(
+          "defaultThumbnail",
+          that.getDefaultThumbnail().get(),
+          writer,
+          (value, w) -> this.resourceToSequence(value, w));
       }
     }
 
@@ -14149,36 +13934,18 @@ public class Xmlization {
     private void resourceToSequence(
       IResource that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "path");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getPath().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "path",
+        that.getPath(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        if (that.getContentType().isPresent()) {
-          writer.writeStartElement(
-            "contentType");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getContentType().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getContentType().isPresent()) {
+        serializeElement(
+          "contentType",
+          that.getContentType().get(),
+          writer,
+          this::writeStringifiedContent);
       }
     }
 
@@ -14205,87 +13972,40 @@ public class Xmlization {
     private void specificAssetIdToSequence(
       ISpecificAssetId that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        writer.writeStartElement(
-          "name");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getName().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "name",
+        that.getName(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "value");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getValue().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "value",
+        that.getValue(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        if (that.getExternalSubjectId().isPresent()) {
-          writer.writeStartElement(
-            "externalSubjectId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getExternalSubjectId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExternalSubjectId().isPresent()) {
+        serializeElement(
+          "externalSubjectId",
+          that.getExternalSubjectId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
     }
 
@@ -14312,237 +14032,106 @@ public class Xmlization {
     private void submodelToSequence(
       ISubmodel that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getAdministration().isPresent()) {
-          writer.writeStartElement(
-            "administration");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.administrativeInformationToSequence(
-            that.getAdministration().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getAdministration().isPresent()) {
+        serializeElement(
+          "administration",
+          that.getAdministration().get(),
+          writer,
+          (value, w) -> this.administrativeInformationToSequence(value, w));
       }
 
-      try {
-        writer.writeStartElement(
-          "id");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getId().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      serializeElement(
+        "id",
+        that.getId(),
+        writer,
+        this::writeStringifiedContent);
+
+      if (that.getKind().isPresent()) {
+        serializeElement(
+          "kind",
+          that.getKind().get(),
+          writer,
+          this::writeModellingKindContent);
       }
 
-      try {
-        if (that.getKind().isPresent()) {
-          writer.writeStartElement(
-            "kind");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          Optional<String> textKind = Stringification.toString(
-            that.getKind().get());
-
-          if (!textKind.isPresent()) {
-            throw new IllegalArgumentException(
-              "Invalid literal for the enumeration ModellingKind: " +
-              that.getKind().get().toString());
-          }
-
-          writer.writeCharacters(textKind.get());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getSubmodelElements().isPresent()) {
-          writer.writeStartElement(
-          "submodelElements");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ISubmodelElement item : that.getSubmodelElements().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSubmodelElements().isPresent()) {
+        serializeElement(
+          "submodelElements",
+          that.getSubmodelElements().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -14569,196 +14158,89 @@ public class Xmlization {
     private void relationshipElementToSequence(
       IRelationshipElement that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        writer.writeStartElement(
-          "first");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "first",
+        that.getFirst(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
 
-        this.referenceToSequence(
-          that.getFirst(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "second");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.referenceToSequence(
-          that.getSecond(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "second",
+        that.getSecond(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
     }
 
     @Override
@@ -14784,265 +14266,114 @@ public class Xmlization {
     private void submodelElementListToSequence(
       ISubmodelElementList that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getOrderRelevant().isPresent()) {
-          writer.writeStartElement(
-            "orderRelevant");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getOrderRelevant().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getOrderRelevant().isPresent()) {
+        serializeElement(
+          "orderRelevant",
+          that.getOrderRelevant().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getSemanticIdListElement().isPresent()) {
-          writer.writeStartElement(
-            "semanticIdListElement");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticIdListElement().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticIdListElement().isPresent()) {
+        serializeElement(
+          "semanticIdListElement",
+          that.getSemanticIdListElement().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        writer.writeStartElement(
-          "typeValueListElement");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "typeValueListElement",
+        that.getTypeValueListElement(),
+        writer,
+        this::writeAasSubmodelElementsContent);
 
-        Optional<String> textTypeValueListElement = Stringification.toString(
-          that.getTypeValueListElement());
-
-        if (!textTypeValueListElement.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration AasSubmodelElements: " +
-            that.getTypeValueListElement().toString());
-        }
-
-        writer.writeCharacters(textTypeValueListElement.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValueTypeListElement().isPresent()) {
+        serializeElement(
+          "valueTypeListElement",
+          that.getValueTypeListElement().get(),
+          writer,
+          this::writeDataTypeDefXsdContent);
       }
 
-      try {
-        if (that.getValueTypeListElement().isPresent()) {
-          writer.writeStartElement(
-            "valueTypeListElement");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          Optional<String> textValueTypeListElement = Stringification.toString(
-            that.getValueTypeListElement().get());
-
-          if (!textValueTypeListElement.isPresent()) {
-            throw new IllegalArgumentException(
-              "Invalid literal for the enumeration DataTypeDefXsd: " +
-              that.getValueTypeListElement().get().toString());
-          }
-
-          writer.writeCharacters(textValueTypeListElement.get());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-          "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ISubmodelElement item : that.getValue().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -15069,178 +14400,84 @@ public class Xmlization {
     private void submodelElementCollectionToSequence(
       ISubmodelElementCollection that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-          "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ISubmodelElement item : that.getValue().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -15267,222 +14504,98 @@ public class Xmlization {
     private void propertyToSequence(
       IProperty that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        writer.writeStartElement(
-          "valueType");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "valueType",
+        that.getValueType(),
+        writer,
+        this::writeDataTypeDefXsdContent);
 
-        Optional<String> textValueType = Stringification.toString(
-          that.getValueType());
-
-        if (!textValueType.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration DataTypeDefXsd: " +
-            that.getValueType().toString());
-        }
-
-        writer.writeCharacters(textValueType.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-            "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getValue().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getValueId().isPresent()) {
-          writer.writeStartElement(
-            "valueId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getValueId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValueId().isPresent()) {
+        serializeElement(
+          "valueId",
+          that.getValueId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
     }
 
@@ -15509,197 +14622,92 @@ public class Xmlization {
     private void multiLanguagePropertyToSequence(
       IMultiLanguageProperty that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-          "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getValue().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getValueId().isPresent()) {
-          writer.writeStartElement(
-            "valueId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getValueId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValueId().isPresent()) {
+        serializeElement(
+          "valueId",
+          that.getValueId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
     }
 
@@ -15726,221 +14734,98 @@ public class Xmlization {
     private void rangeToSequence(
       IRange that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        writer.writeStartElement(
-          "valueType");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "valueType",
+        that.getValueType(),
+        writer,
+        this::writeDataTypeDefXsdContent);
 
-        Optional<String> textValueType = Stringification.toString(
-          that.getValueType());
-
-        if (!textValueType.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration DataTypeDefXsd: " +
-            that.getValueType().toString());
-        }
-
-        writer.writeCharacters(textValueType.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getMin().isPresent()) {
+        serializeElement(
+          "min",
+          that.getMin().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getMin().isPresent()) {
-          writer.writeStartElement(
-            "min");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getMin().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getMax().isPresent()) {
-          writer.writeStartElement(
-            "max");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getMax().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getMax().isPresent()) {
+        serializeElement(
+          "max",
+          that.getMax().get(),
+          writer,
+          this::writeStringifiedContent);
       }
     }
 
@@ -15967,180 +14852,84 @@ public class Xmlization {
     private void referenceElementToSequence(
       IReferenceElement that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-            "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getValue().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
     }
 
@@ -16167,192 +14956,91 @@ public class Xmlization {
     private void blobToSequence(
       IBlob that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement("value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          String theB64Value = Base64.getEncoder().encodeToString(
-            that.getValue().get());
-          writer.writeCharacters(theB64Value);
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          this::writeByteArrayContent);
       }
 
-      try {
-        writer.writeStartElement(
-          "contentType");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getContentType().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "contentType",
+        that.getContentType(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -16378,194 +15066,91 @@ public class Xmlization {
     private void fileToSequence(
       IFile that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-            "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getValue().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        writer.writeStartElement(
-          "contentType");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getContentType().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "contentType",
+        that.getContentType(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -16591,212 +15176,96 @@ public class Xmlization {
     private void annotatedRelationshipElementToSequence(
       IAnnotatedRelationshipElement that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        writer.writeStartElement(
-          "first");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "first",
+        that.getFirst(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
 
-        this.referenceToSequence(
-          that.getFirst(),
-          writer);
+      serializeElement(
+        "second",
+        that.getSecond(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
 
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "second");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.referenceToSequence(
-          that.getSecond(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getAnnotations().isPresent()) {
-          writer.writeStartElement(
-          "annotations");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IDataElement item : that.getAnnotations().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getAnnotations().isPresent()) {
+        serializeElement(
+          "annotations",
+          that.getAnnotations().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -16823,237 +15292,106 @@ public class Xmlization {
     private void entityToSequence(
       IEntity that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getStatements().isPresent()) {
-          writer.writeStartElement(
-          "statements");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ISubmodelElement item : that.getStatements().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getStatements().isPresent()) {
+        serializeElement(
+          "statements",
+          that.getStatements().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        writer.writeStartElement(
-          "entityType");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "entityType",
+        that.getEntityType(),
+        writer,
+        this::writeEntityTypeContent);
 
-        Optional<String> textEntityType = Stringification.toString(
-          that.getEntityType());
-
-        if (!textEntityType.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration EntityType: " +
-            that.getEntityType().toString());
-        }
-
-        writer.writeCharacters(textEntityType.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getGlobalAssetId().isPresent()) {
+        serializeElement(
+          "globalAssetId",
+          that.getGlobalAssetId().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getGlobalAssetId().isPresent()) {
-          writer.writeStartElement(
-            "globalAssetId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getGlobalAssetId().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getSpecificAssetIds().isPresent()) {
-          writer.writeStartElement(
-          "specificAssetIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ISpecificAssetId item : that.getSpecificAssetIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSpecificAssetIds().isPresent()) {
+        serializeElement(
+          "specificAssetIds",
+          that.getSpecificAssetIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -17080,143 +15418,62 @@ public class Xmlization {
     private void eventPayloadToSequence(
       IEventPayload that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "source");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "source",
+        that.getSource(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
 
-        this.referenceToSequence(
-          that.getSource(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSourceSemanticId().isPresent()) {
+        serializeElement(
+          "sourceSemanticId",
+          that.getSourceSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSourceSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "sourceSemanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
+      serializeElement(
+        "observableReference",
+        that.getObservableReference(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
 
-          this.referenceToSequence(
-            that.getSourceSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getObservableSemanticId().isPresent()) {
+        serializeElement(
+          "observableSemanticId",
+          that.getObservableSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        writer.writeStartElement(
-          "observableReference");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.referenceToSequence(
-          that.getObservableReference(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getTopic().isPresent()) {
+        serializeElement(
+          "topic",
+          that.getTopic().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getObservableSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "observableSemanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getObservableSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSubjectId().isPresent()) {
+        serializeElement(
+          "subjectId",
+          that.getSubjectId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getTopic().isPresent()) {
-          writer.writeStartElement(
-            "topic");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
+      serializeElement(
+        "timeStamp",
+        that.getTimeStamp(),
+        writer,
+        this::writeStringifiedContent);
 
-          writer.writeCharacters(
-            that.getTopic().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getSubjectId().isPresent()) {
-          writer.writeStartElement(
-            "subjectId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSubjectId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "timeStamp");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getTimeStamp().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getPayload().isPresent()) {
-          writer.writeStartElement("payload");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          String theB64Payload = Base64.getEncoder().encodeToString(
-            that.getPayload().get());
-          writer.writeCharacters(theB64Payload);
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getPayload().isPresent()) {
+        serializeElement(
+          "payload",
+          that.getPayload().get(),
+          writer,
+          this::writeByteArrayContent);
       }
     }
 
@@ -17243,317 +15500,134 @@ public class Xmlization {
     private void basicEventElementToSequence(
       IBasicEventElement that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        writer.writeStartElement(
-          "observed");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "observed",
+        that.getObserved(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
 
-        this.referenceToSequence(
-          that.getObserved(),
-          writer);
+      serializeElement(
+        "direction",
+        that.getDirection(),
+        writer,
+        this::writeDirectionContent);
 
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      serializeElement(
+        "state",
+        that.getState(),
+        writer,
+        this::writeStateOfEventContent);
+
+      if (that.getMessageTopic().isPresent()) {
+        serializeElement(
+          "messageTopic",
+          that.getMessageTopic().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        writer.writeStartElement(
-          "direction");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        Optional<String> textDirection = Stringification.toString(
-          that.getDirection());
-
-        if (!textDirection.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration Direction: " +
-            that.getDirection().toString());
-        }
-
-        writer.writeCharacters(textDirection.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getMessageBroker().isPresent()) {
+        serializeElement(
+          "messageBroker",
+          that.getMessageBroker().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        writer.writeStartElement(
-          "state");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        Optional<String> textState = Stringification.toString(
-          that.getState());
-
-        if (!textState.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration StateOfEvent: " +
-            that.getState().toString());
-        }
-
-        writer.writeCharacters(textState.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getLastUpdate().isPresent()) {
+        serializeElement(
+          "lastUpdate",
+          that.getLastUpdate().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getMessageTopic().isPresent()) {
-          writer.writeStartElement(
-            "messageTopic");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getMessageTopic().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getMinInterval().isPresent()) {
+        serializeElement(
+          "minInterval",
+          that.getMinInterval().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getMessageBroker().isPresent()) {
-          writer.writeStartElement(
-            "messageBroker");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getMessageBroker().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getLastUpdate().isPresent()) {
-          writer.writeStartElement(
-            "lastUpdate");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getLastUpdate().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getMinInterval().isPresent()) {
-          writer.writeStartElement(
-            "minInterval");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getMinInterval().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getMaxInterval().isPresent()) {
-          writer.writeStartElement(
-            "maxInterval");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getMaxInterval().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getMaxInterval().isPresent()) {
+        serializeElement(
+          "maxInterval",
+          that.getMaxInterval().get(),
+          writer,
+          this::writeStringifiedContent);
       }
     }
 
@@ -17580,212 +15654,100 @@ public class Xmlization {
     private void operationToSequence(
       IOperation that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getInputVariables().isPresent()) {
-          writer.writeStartElement(
-          "inputVariables");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IOperationVariable item : that.getInputVariables().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getInputVariables().isPresent()) {
+        serializeElement(
+          "inputVariables",
+          that.getInputVariables().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getOutputVariables().isPresent()) {
-          writer.writeStartElement(
-          "outputVariables");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IOperationVariable item : that.getOutputVariables().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getOutputVariables().isPresent()) {
+        serializeElement(
+          "outputVariables",
+          that.getOutputVariables().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getInoutputVariables().isPresent()) {
-          writer.writeStartElement(
-          "inoutputVariables");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IOperationVariable item : that.getInoutputVariables().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getInoutputVariables().isPresent()) {
+        serializeElement(
+          "inoutputVariables",
+          that.getInoutputVariables().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -17812,22 +15774,11 @@ public class Xmlization {
     private void operationVariableToSequence(
       IOperationVariable that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "value");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.visit(
-          that.getValue(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "value",
+        that.getValue(),
+        writer,
+        this::visit);
     }
 
     @Override
@@ -17853,161 +15804,76 @@ public class Xmlization {
     private void capabilityToSequence(
       ICapability that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "semanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSemanticId().isPresent()) {
+        serializeElement(
+          "semanticId",
+          that.getSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getSupplementalSemanticIds().isPresent()) {
-          writer.writeStartElement(
-          "supplementalSemanticIds");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getSupplementalSemanticIds().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSupplementalSemanticIds().isPresent()) {
+        serializeElement(
+          "supplementalSemanticIds",
+          that.getSupplementalSemanticIds().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getQualifiers().isPresent()) {
-          writer.writeStartElement(
-          "qualifiers");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IQualifier item : that.getQualifiers().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getQualifiers().isPresent()) {
+        serializeElement(
+          "qualifiers",
+          that.getQualifiers().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -18034,158 +15900,74 @@ public class Xmlization {
     private void conceptDescriptionToSequence(
       IConceptDescription that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getExtensions().isPresent()) {
-          writer.writeStartElement(
-          "extensions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IExtension item : that.getExtensions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getExtensions().isPresent()) {
+        serializeElement(
+          "extensions",
+          that.getExtensions().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getCategory().isPresent()) {
-          writer.writeStartElement(
-            "category");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getCategory().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getCategory().isPresent()) {
+        serializeElement(
+          "category",
+          that.getCategory().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getIdShort().isPresent()) {
-          writer.writeStartElement(
-            "idShort");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getIdShort().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIdShort().isPresent()) {
+        serializeElement(
+          "idShort",
+          that.getIdShort().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getDisplayName().isPresent()) {
-          writer.writeStartElement(
-          "displayName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringNameType item : that.getDisplayName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDisplayName().isPresent()) {
+        serializeElement(
+          "displayName",
+          that.getDisplayName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDescription().isPresent()) {
-          writer.writeStartElement(
-          "description");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringTextType item : that.getDescription().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDescription().isPresent()) {
+        serializeElement(
+          "description",
+          that.getDescription().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getAdministration().isPresent()) {
-          writer.writeStartElement(
-            "administration");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.administrativeInformationToSequence(
-            that.getAdministration().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getAdministration().isPresent()) {
+        serializeElement(
+          "administration",
+          that.getAdministration().get(),
+          writer,
+          (value, w) -> this.administrativeInformationToSequence(value, w));
       }
 
-      try {
-        writer.writeStartElement(
-          "id");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getId().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      serializeElement(
+        "id",
+        that.getId(),
+        writer,
+        this::writeStringifiedContent);
+
+      if (that.getEmbeddedDataSpecifications().isPresent()) {
+        serializeElement(
+          "embeddedDataSpecifications",
+          that.getEmbeddedDataSpecifications().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getEmbeddedDataSpecifications().isPresent()) {
-          writer.writeStartElement(
-          "embeddedDataSpecifications");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IEmbeddedDataSpecification item : that.getEmbeddedDataSpecifications().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getIsCaseOf().isPresent()) {
-          writer.writeStartElement(
-          "isCaseOf");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IReference item : that.getIsCaseOf().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getIsCaseOf().isPresent()) {
+        serializeElement(
+          "isCaseOf",
+          that.getIsCaseOf().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -18212,65 +15994,25 @@ public class Xmlization {
     private void referenceToSequence(
       IReference that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "type");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "type",
+        that.getType(),
+        writer,
+        this::writeReferenceTypesContent);
 
-        Optional<String> textType = Stringification.toString(
-          that.getType());
-
-        if (!textType.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration ReferenceTypes: " +
-            that.getType().toString());
-        }
-
-        writer.writeCharacters(textType.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getReferredSemanticId().isPresent()) {
+        serializeElement(
+          "referredSemanticId",
+          that.getReferredSemanticId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getReferredSemanticId().isPresent()) {
-          writer.writeStartElement(
-            "referredSemanticId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getReferredSemanticId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "keys");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        for (IKey item : that.getKeys()) {
-          this.visit(item, writer);
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "keys",
+        that.getKeys(),
+        writer,
+        serializeItems(this::visit));
     }
 
     @Override
@@ -18296,43 +16038,17 @@ public class Xmlization {
     private void keyToSequence(
       IKey that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "type");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "type",
+        that.getType(),
+        writer,
+        this::writeKeyTypesContent);
 
-        Optional<String> textType = Stringification.toString(
-          that.getType());
-
-        if (!textType.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration KeyTypes: " +
-            that.getType().toString());
-        }
-
-        writer.writeCharacters(textType.get());
-
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "value");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getValue().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "value",
+        that.getValue(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -18358,33 +16074,17 @@ public class Xmlization {
     private void langStringNameTypeToSequence(
       ILangStringNameType that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "language");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getLanguage().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "language",
+        that.getLanguage(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "text");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getText().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "text",
+        that.getText(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -18410,33 +16110,17 @@ public class Xmlization {
     private void langStringTextTypeToSequence(
       ILangStringTextType that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "language");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getLanguage().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "language",
+        that.getLanguage(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "text");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getText().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "text",
+        that.getText(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -18462,55 +16146,28 @@ public class Xmlization {
     private void environmentToSequence(
       IEnvironment that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getAssetAdministrationShells().isPresent()) {
-          writer.writeStartElement(
-          "assetAdministrationShells");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IAssetAdministrationShell item : that.getAssetAdministrationShells().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getAssetAdministrationShells().isPresent()) {
+        serializeElement(
+          "assetAdministrationShells",
+          that.getAssetAdministrationShells().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getSubmodels().isPresent()) {
-          writer.writeStartElement(
-          "submodels");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ISubmodel item : that.getSubmodels().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSubmodels().isPresent()) {
+        serializeElement(
+          "submodels",
+          that.getSubmodels().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getConceptDescriptions().isPresent()) {
-          writer.writeStartElement(
-          "conceptDescriptions");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (IConceptDescription item : that.getConceptDescriptions().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getConceptDescriptions().isPresent()) {
+        serializeElement(
+          "conceptDescriptions",
+          that.getConceptDescriptions().get(),
+          writer,
+          serializeItems(this::visit));
       }
     }
 
@@ -18537,39 +16194,17 @@ public class Xmlization {
     private void embeddedDataSpecificationToSequence(
       IEmbeddedDataSpecification that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "dataSpecification");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "dataSpecification",
+        that.getDataSpecification(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
 
-        this.referenceToSequence(
-          that.getDataSpecification(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "dataSpecificationContent");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.visit(
-          that.getDataSpecificationContent(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "dataSpecificationContent",
+        that.getDataSpecificationContent(),
+        writer,
+        this::visit);
     }
 
     @Override
@@ -18595,61 +16230,29 @@ public class Xmlization {
     private void levelTypeToSequence(
       ILevelType that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "min");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getMin().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "min",
+        that.getMin(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "nom");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getNom().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "nom",
+        that.getNom(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "typ");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getTyp().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "typ",
+        that.getTyp(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "max");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getMax().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "max",
+        that.getMax(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -18675,36 +16278,17 @@ public class Xmlization {
     private void valueReferencePairToSequence(
       IValueReferencePair that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "value");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getValue().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "value",
+        that.getValue(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "valueId");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.referenceToSequence(
-          that.getValueId(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "valueId",
+        that.getValueId(),
+        writer,
+        (value, w) -> this.referenceToSequence(value, w));
     }
 
     @Override
@@ -18730,22 +16314,11 @@ public class Xmlization {
     private void valueListToSequence(
       IValueList that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "valueReferencePairs");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        for (IValueReferencePair item : that.getValueReferencePairs()) {
-          this.visit(item, writer);
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "valueReferencePairs",
+        that.getValueReferencePairs(),
+        writer,
+        serializeItems(this::visit));
     }
 
     @Override
@@ -18771,33 +16344,17 @@ public class Xmlization {
     private void langStringPreferredNameTypeIec61360ToSequence(
       ILangStringPreferredNameTypeIec61360 that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "language");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getLanguage().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "language",
+        that.getLanguage(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "text");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getText().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "text",
+        that.getText(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -18823,33 +16380,17 @@ public class Xmlization {
     private void langStringShortNameTypeIec61360ToSequence(
       ILangStringShortNameTypeIec61360 that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "language");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getLanguage().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "language",
+        that.getLanguage(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "text");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getText().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "text",
+        that.getText(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -18875,33 +16416,17 @@ public class Xmlization {
     private void langStringDefinitionTypeIec61360ToSequence(
       ILangStringDefinitionTypeIec61360 that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "language");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getLanguage().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "language",
+        that.getLanguage(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "text");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getText().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "text",
+        that.getText(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -18927,228 +16452,98 @@ public class Xmlization {
     private void dataSpecificationIec61360ToSequence(
       IDataSpecificationIec61360 that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "preferredName");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "preferredName",
+        that.getPreferredName(),
+        writer,
+        serializeItems(this::visit));
 
-        for (ILangStringPreferredNameTypeIec61360 item : that.getPreferredName()) {
-          this.visit(item, writer);
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getShortName().isPresent()) {
+        serializeElement(
+          "shortName",
+          that.getShortName().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getShortName().isPresent()) {
-          writer.writeStartElement(
-          "shortName");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringShortNameTypeIec61360 item : that.getShortName().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getUnit().isPresent()) {
+        serializeElement(
+          "unit",
+          that.getUnit().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getUnit().isPresent()) {
-          writer.writeStartElement(
-            "unit");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getUnit().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getUnitId().isPresent()) {
+        serializeElement(
+          "unitId",
+          that.getUnitId().get(),
+          writer,
+          (value, w) -> this.referenceToSequence(value, w));
       }
 
-      try {
-        if (that.getUnitId().isPresent()) {
-          writer.writeStartElement(
-            "unitId");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.referenceToSequence(
-            that.getUnitId().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSourceOfDefinition().isPresent()) {
+        serializeElement(
+          "sourceOfDefinition",
+          that.getSourceOfDefinition().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getSourceOfDefinition().isPresent()) {
-          writer.writeStartElement(
-            "sourceOfDefinition");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getSourceOfDefinition().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getSymbol().isPresent()) {
+        serializeElement(
+          "symbol",
+          that.getSymbol().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getSymbol().isPresent()) {
-          writer.writeStartElement(
-            "symbol");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getSymbol().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDataType().isPresent()) {
+        serializeElement(
+          "dataType",
+          that.getDataType().get(),
+          writer,
+          this::writeDataTypeIec61360Content);
       }
 
-      try {
-        if (that.getDataType().isPresent()) {
-          writer.writeStartElement(
-            "dataType");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          Optional<String> textDataType = Stringification.toString(
-            that.getDataType().get());
-
-          if (!textDataType.isPresent()) {
-            throw new IllegalArgumentException(
-              "Invalid literal for the enumeration DataTypeIec61360: " +
-              that.getDataType().get().toString());
-          }
-
-          writer.writeCharacters(textDataType.get());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getDefinition().isPresent()) {
+        serializeElement(
+          "definition",
+          that.getDefinition().get(),
+          writer,
+          serializeItems(this::visit));
       }
 
-      try {
-        if (that.getDefinition().isPresent()) {
-          writer.writeStartElement(
-          "definition");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-          for (ILangStringDefinitionTypeIec61360 item : that.getDefinition().get()) {
-            this.visit(item, writer);
-          }
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValueFormat().isPresent()) {
+        serializeElement(
+          "valueFormat",
+          that.getValueFormat().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getValueFormat().isPresent()) {
-          writer.writeStartElement(
-            "valueFormat");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getValueFormat().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValueList().isPresent()) {
+        serializeElement(
+          "valueList",
+          that.getValueList().get(),
+          writer,
+          (value, w) -> this.valueListToSequence(value, w));
       }
 
-      try {
-        if (that.getValueList().isPresent()) {
-          writer.writeStartElement(
-            "valueList");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.valueListToSequence(
-            that.getValueList().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getValue().isPresent()) {
+        serializeElement(
+          "value",
+          that.getValue().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getValue().isPresent()) {
-          writer.writeStartElement(
-            "value");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getValue().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        if (that.getLevelType().isPresent()) {
-          writer.writeStartElement(
-            "levelType");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          this.levelTypeToSequence(
-            that.getLevelType().get(),
-            writer);
-
-          writer.writeEndElement();
-        }
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getLevelType().isPresent()) {
+        serializeElement(
+          "levelType",
+          that.getLevelType().get(),
+          writer,
+          (value, w) -> this.levelTypeToSequence(value, w));
       }
     }
 

--- a/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -115,17 +150,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<SomeEnum> trySomeEnumFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<SomeEnum> trySomeEnumFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(SomeEnum.class);
         }
         final Optional<SomeEnum> someEnum = Stringification.someEnumFromString(textResult.getResult());
         if (!someEnum.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of SomeEnum");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(someEnum.get());
+        return Reporting.Result.success(someEnum.get());
       }
 
       /**
@@ -134,11 +169,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         SomeEnum theSomeEnum = null;
@@ -152,7 +187,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends SomeEnum> theSomeEnumResult = trySomeEnumFrom(currentNode.getValue());
+              final Reporting.Result<? extends SomeEnum> theSomeEnumResult = trySomeEnumFrom(currentNode.getValue());
               if (theSomeEnumResult.isError()) {
                 theSomeEnumResult.getError()
                   .prependSegment(new Reporting.NameSegment("someEnum"));
@@ -164,7 +199,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -172,10 +207,10 @@ public class Jsonization {
         if (theSomeEnum == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someEnum\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeEnum));
       }
     }
@@ -203,63 +238,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -280,7 +258,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static SomeEnum deserializeSomeEnum(JsonNode node) {
-        final _Result<? extends SomeEnum> result =
+        final Reporting.Result<? extends SomeEnum> result =
           _DeserializeImplementation.trySomeEnumFrom(
             node);
 
@@ -297,7 +275,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -323,6 +301,34 @@ public class Jsonization {
             "The number can not be losslessly represented in JSON: " + that);
         }
         return JsonNodeFactory.instance.numberNode(that);
+      }
+
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
       }
 
       @Override
@@ -365,12 +371,7 @@ public class Jsonization {
        * Serialize a literal of SomeEnum into a JSON string.
        */
       public static JsonNode someEnumToJsonValue(SomeEnum that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid SomeEnum: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
     }
 }

--- a/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/stringification/Stringification.java
+++ b/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/stringification/Stringification.java
@@ -38,6 +38,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(someEnumToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(SomeEnum that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of SomeEnum: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, SomeEnum> someEnumFromString;
   static {
     final Map<String, SomeEnum> temp = new HashMap<>();

--- a/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/constants/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,15 +659,15 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link SomeEnum}.
      */
-    private static _Result<SomeEnum> tryVElementAsSomeEnum(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<SomeEnum> tryVElementAsSomeEnum(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(SomeEnum.class);
       }
@@ -734,10 +679,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of SomeEnum: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
@@ -747,7 +692,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       SomeEnum theSomeEnum = null;
@@ -759,7 +704,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -774,10 +719,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -796,7 +741,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someEnum"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -804,7 +749,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property someEnum of an instance of class Something, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textSomeEnum;
@@ -817,7 +762,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "someEnum"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<SomeEnum> optionalSomeEnum =
@@ -834,7 +779,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "someEnum"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -843,13 +788,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -862,17 +807,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someEnum has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeEnum));
     }
 
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -882,7 +827,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -925,7 +870,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -946,32 +891,98 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
-    private void somethingToSequence(
-      ISomething that,
-      XMLStreamWriter writer) {
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
       try {
-        writer.writeStartElement(
-          "someEnum");
+        writer.writeStartElement(name);
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
-
-        Optional<String> textSomeEnum = Stringification.toString(
-          that.getSomeEnum());
-
-        if (!textSomeEnum.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration SomeEnum: " +
-            that.getSomeEnum().toString());
-        }
-
-        writer.writeCharacters(textSomeEnum.get());
-
+        serializeContent.serialize(that, writer);
         writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
       }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
+    /**
+     * Write a literal of {@link SomeEnum} as XML content.
+     *
+     * <p>This is shared by every SomeEnum-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeSomeEnumContent(SomeEnum that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    private void somethingToSequence(
+      ISomething that,
+      XMLStreamWriter writer) {
+      serializeElement(
+        "someEnum",
+        that.getSomeEnum(),
+        writer,
+        this::writeSomeEnumContent);
     }
 
     @Override

--- a/dev/test_data/main/java/expected/constrained_primitives/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/constrained_primitives/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,11 +151,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         Boolean theSomeBool = null;
@@ -138,7 +173,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Boolean> theSomeBoolResult = tryBooleanFrom(currentNode.getValue());
+              final Reporting.Result<? extends Boolean> theSomeBoolResult = tryBooleanFrom(currentNode.getValue());
               if (theSomeBoolResult.isError()) {
                 theSomeBoolResult.getError()
                   .prependSegment(new Reporting.NameSegment("someBool"));
@@ -152,7 +187,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Long> theSomeIntResult = tryLongFrom(currentNode.getValue());
+              final Reporting.Result<? extends Long> theSomeIntResult = tryLongFrom(currentNode.getValue());
               if (theSomeIntResult.isError()) {
                 theSomeIntResult.getError()
                   .prependSegment(new Reporting.NameSegment("someInt"));
@@ -166,7 +201,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Double> theSomeFloatResult = tryDoubleFrom(currentNode.getValue());
+              final Reporting.Result<? extends Double> theSomeFloatResult = tryDoubleFrom(currentNode.getValue());
               if (theSomeFloatResult.isError()) {
                 theSomeFloatResult.getError()
                   .prependSegment(new Reporting.NameSegment("someFloat"));
@@ -180,7 +215,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theSomeStringResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theSomeStringResult = tryStringFrom(currentNode.getValue());
               if (theSomeStringResult.isError()) {
                 theSomeStringResult.getError()
                   .prependSegment(new Reporting.NameSegment("someString"));
@@ -194,7 +229,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends byte[]> theSomeBytesResult = tryBytesFrom(currentNode.getValue());
+              final Reporting.Result<? extends byte[]> theSomeBytesResult = tryBytesFrom(currentNode.getValue());
               if (theSomeBytesResult.isError()) {
                 theSomeBytesResult.getError()
                   .prependSegment(new Reporting.NameSegment("someBytes"));
@@ -206,7 +241,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -214,34 +249,34 @@ public class Jsonization {
         if (theSomeBool == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someBool\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeInt == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someInt\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeFloat == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someFloat\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeString == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someString\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeBytes == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someBytes\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeBool,
           theSomeInt,
           theSomeFloat,
@@ -273,63 +308,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -350,7 +328,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -378,6 +356,34 @@ public class Jsonization {
         return JsonNodeFactory.instance.numberNode(that);
       }
 
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
+      }
+
       @Override
       public JsonNode transformSomething(
         ISomething that
@@ -396,9 +402,8 @@ public class Jsonization {
         result.set("someString", JsonNodeFactory.instance.textNode(
           that.getSomeString()));
 
-        result.set("someBytes", JsonNodeFactory.instance.textNode(
-            Base64.getEncoder()
-              .encodeToString(that.getSomeBytes())));
+        result.set("someBytes", _Transformer.bytesToJsonNode(
+          that.getSomeBytes()));
 
         return result;
       }

--- a/dev/test_data/main/java/expected/constrained_primitives/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/constrained_primitives/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/constrained_primitives/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/constrained_primitives/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,7 +659,7 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -724,7 +669,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       Boolean theSomeBool = null;
@@ -740,7 +685,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -755,10 +700,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -777,7 +722,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someBool"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -785,7 +730,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someBool of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -797,7 +742,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someBool"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -812,7 +757,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someInt"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -820,7 +765,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someInt of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -832,7 +777,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someInt"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -847,7 +792,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someFloat"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -855,7 +800,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someFloat of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -867,7 +812,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someFloat"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -883,7 +828,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someString of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -895,7 +840,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someString"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -910,7 +855,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someBytes"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -918,7 +863,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someBytes of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -930,7 +875,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someBytes"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -940,13 +885,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -959,38 +904,38 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someBool has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeInt == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someInt has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeFloat == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someFloat has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeString == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someString has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeBytes == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someBytes has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeBool,
         theSomeInt,
         theSomeFloat,
@@ -1001,7 +946,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1011,7 +956,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -1054,7 +999,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -1075,79 +1020,110 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
+      try {
+        writer.writeStartElement(name);
+        if (topLevel) {
+          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+          topLevel = false;
+        }
+        serializeContent.serialize(that, writer);
+        writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
     private void somethingToSequence(
       ISomething that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "someBool");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeBool().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someBool",
+        that.getSomeBool(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someInt");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeInt().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someInt",
+        that.getSomeInt(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someFloat");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeFloat().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someFloat",
+        that.getSomeFloat(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someString");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeString().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someString",
+        that.getSomeString(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someBytes");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        String theB64Somebytes = Base64.getEncoder().encodeToString(
-          that.getSomeBytes());
-        writer.writeCharacters(theB64Somebytes);
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someBytes",
+        that.getSomeBytes(),
+        writer,
+        this::writeByteArrayContent);
     }
 
     @Override

--- a/dev/test_data/main/java/expected/custom_serialization_names/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/custom_serialization_names/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,11 +151,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<QueryCondition> tryQueryConditionFrom(JsonNode node) {
+      private static Reporting.Result<QueryCondition> tryQueryConditionFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theEq = null;
@@ -135,7 +170,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theEqResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theEqResult = tryStringFrom(currentNode.getValue());
               if (theEqResult.isError()) {
                 theEqResult.getError()
                   .prependSegment(new Reporting.NameSegment("$eq"));
@@ -149,7 +184,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theNotEqResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theNotEqResult = tryStringFrom(currentNode.getValue());
               if (theNotEqResult.isError()) {
                 theNotEqResult.getError()
                   .prependSegment(new Reporting.NameSegment("$ne"));
@@ -161,14 +196,14 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
 
 
 
-        return _Result.success(new QueryCondition(
+        return Reporting.Result.success(new QueryCondition(
           theEq,
           theNotEq));
       }
@@ -197,63 +232,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -274,7 +252,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static QueryCondition deserializeQueryCondition(JsonNode node) {
-        final _Result<? extends QueryCondition> result =
+        final Reporting.Result<? extends QueryCondition> result =
           _DeserializeImplementation.tryQueryConditionFrom(
             node);
 
@@ -300,6 +278,34 @@ public class Jsonization {
             "The number can not be losslessly represented in JSON: " + that);
         }
         return JsonNodeFactory.instance.numberNode(that);
+      }
+
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
       }
 
       @Override

--- a/dev/test_data/main/java/expected/custom_serialization_names/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/custom_serialization_names/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/custom_serialization_names/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/custom_serialization_names/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,7 +659,7 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -724,7 +669,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<QueryCondition> tryQueryConditionFromSequence(
+    private static Reporting.Result<QueryCondition> tryQueryConditionFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theEq = null;
@@ -737,7 +682,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class QueryCondition, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -752,10 +697,10 @@ public class Xmlization {
               "a property of an instance of class QueryCondition, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(QueryCondition.class);
           }
@@ -775,7 +720,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property eq of an instance of class QueryCondition, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -787,7 +732,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "eq"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -803,7 +748,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property notEq of an instance of class QueryCondition, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -815,7 +760,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "notEq"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -825,13 +770,13 @@ public class Xmlization {
                 "We expected properties of the class QueryCondition, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "QueryCondition",
             reader,
             tryElementName);
@@ -840,7 +785,7 @@ public class Xmlization {
         }
       }
 
-      return _Result.success(new QueryCondition(
+      return Reporting.Result.success(new QueryCondition(
         theEq,
         theNotEq));
     }
@@ -848,7 +793,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class QueryCondition from an XML element.
      */
-    private static _Result<? extends QueryCondition> tryQueryConditionFromElement(
+    private static Reporting.Result<? extends QueryCondition> tryQueryConditionFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -858,7 +803,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class QueryCondition " +
               "with element name queryCondition, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryQueryConditionFromSequence(reader, isEmptyElement);
@@ -901,7 +846,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends QueryCondition> result =
+      Reporting.Result<? extends QueryCondition> result =
         _DeserializeImplementation.tryQueryConditionFromElement(
           reader);
 
@@ -922,43 +867,95 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
+      try {
+        writer.writeStartElement(name);
+        if (topLevel) {
+          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+          topLevel = false;
+        }
+        serializeContent.serialize(that, writer);
+        writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
     private void queryConditionToSequence(
       IQueryCondition that,
       XMLStreamWriter writer) {
-      try {
-        if (that.getEq().isPresent()) {
-          writer.writeStartElement(
-            "eq");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getEq().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getEq().isPresent()) {
+        serializeElement(
+          "eq",
+          that.getEq().get(),
+          writer,
+          this::writeStringifiedContent);
       }
 
-      try {
-        if (that.getNotEq().isPresent()) {
-          writer.writeStartElement(
-            "not-eq");
-          if (topLevel) {
-            writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-            topLevel = false;
-          }
-
-          writer.writeCharacters(
-            that.getNotEq().get().toString());
-
-          writer.writeEndElement();
-        }
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      if (that.getNotEq().isPresent()) {
+        serializeElement(
+          "not-eq",
+          that.getNotEq().get(),
+          writer,
+          this::writeStringifiedContent);
       }
     }
 

--- a/dev/test_data/main/java/expected/deep_class_hierarchy/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/deep_class_hierarchy/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,20 +151,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends INode> tryINodeFrom(JsonNode node) {
+      public static Reporting.Result<? extends INode> tryINodeFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(INode.class);
         }
@@ -145,7 +180,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for INode: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -156,20 +191,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IBranch> tryIBranchFrom(JsonNode node) {
+      public static Reporting.Result<? extends IBranch> tryIBranchFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IBranch.class);
         }
@@ -185,7 +220,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IBranch: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -196,11 +231,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Branch> tryBranchFrom(JsonNode node) {
+      private static Reporting.Result<Branch> tryBranchFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theIdentifier = null;
@@ -217,7 +252,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdentifierResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdentifierResult = tryStringFrom(currentNode.getValue());
               if (theIdentifierResult.isError()) {
                 theIdentifierResult.getError()
                   .prependSegment(new Reporting.NameSegment("identifier"));
@@ -231,7 +266,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theDescriptionResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theDescriptionResult = tryStringFrom(currentNode.getValue());
               if (theDescriptionResult.isError()) {
                 theDescriptionResult.getError()
                   .prependSegment(new Reporting.NameSegment("description"));
@@ -244,9 +279,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -260,14 +295,14 @@ public class Jsonization {
                   "Expected the model type 'Branch', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -275,22 +310,22 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theIdentifier == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"identifier\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theDescription == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"description\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Branch(
+        return Reporting.Result.success(new Branch(
           theIdentifier,
           theDescription));
       }
@@ -301,20 +336,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends ILeaf> tryILeafFrom(JsonNode node) {
+      public static Reporting.Result<? extends ILeaf> tryILeafFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(ILeaf.class);
         }
@@ -328,7 +363,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for ILeaf: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -339,11 +374,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Leaf> tryLeafFrom(JsonNode node) {
+      private static Reporting.Result<Leaf> tryLeafFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theIdentifier = null;
@@ -361,7 +396,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdentifierResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdentifierResult = tryStringFrom(currentNode.getValue());
               if (theIdentifierResult.isError()) {
                 theIdentifierResult.getError()
                   .prependSegment(new Reporting.NameSegment("identifier"));
@@ -375,7 +410,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theDescriptionResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theDescriptionResult = tryStringFrom(currentNode.getValue());
               if (theDescriptionResult.isError()) {
                 theDescriptionResult.getError()
                   .prependSegment(new Reporting.NameSegment("description"));
@@ -389,7 +424,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Long> theValueResult = tryLongFrom(currentNode.getValue());
+              final Reporting.Result<? extends Long> theValueResult = tryLongFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -402,9 +437,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -418,14 +453,14 @@ public class Jsonization {
                   "Expected the model type 'Leaf', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -433,28 +468,28 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theIdentifier == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"identifier\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theDescription == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"description\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValue == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"value\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Leaf(
+        return Reporting.Result.success(new Leaf(
           theIdentifier,
           theDescription,
           theValue));
@@ -466,11 +501,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Blossom> tryBlossomFrom(JsonNode node) {
+      private static Reporting.Result<Blossom> tryBlossomFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theIdentifier = null;
@@ -489,7 +524,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theIdentifierResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theIdentifierResult = tryStringFrom(currentNode.getValue());
               if (theIdentifierResult.isError()) {
                 theIdentifierResult.getError()
                   .prependSegment(new Reporting.NameSegment("identifier"));
@@ -503,7 +538,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theDescriptionResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theDescriptionResult = tryStringFrom(currentNode.getValue());
               if (theDescriptionResult.isError()) {
                 theDescriptionResult.getError()
                   .prependSegment(new Reporting.NameSegment("description"));
@@ -517,7 +552,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Long> theValueResult = tryLongFrom(currentNode.getValue());
+              final Reporting.Result<? extends Long> theValueResult = tryLongFrom(currentNode.getValue());
               if (theValueResult.isError()) {
                 theValueResult.getError()
                   .prependSegment(new Reporting.NameSegment("value"));
@@ -531,7 +566,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theDetailsResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theDetailsResult = tryStringFrom(currentNode.getValue());
               if (theDetailsResult.isError()) {
                 theDetailsResult.getError()
                   .prependSegment(new Reporting.NameSegment("details"));
@@ -544,9 +579,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -560,14 +595,14 @@ public class Jsonization {
                   "Expected the model type 'Blossom', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -575,34 +610,34 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theIdentifier == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"identifier\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theDescription == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"description\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theValue == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"value\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theDetails == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"details\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Blossom(
+        return Reporting.Result.success(new Blossom(
           theIdentifier,
           theDescription,
           theValue,
@@ -615,11 +650,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         INode theSomeChoice = null;
@@ -634,7 +669,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends INode> theSomeChoiceResult = tryINodeFrom(currentNode.getValue());
+              final Reporting.Result<? extends INode> theSomeChoiceResult = tryINodeFrom(currentNode.getValue());
               if (theSomeChoiceResult.isError()) {
                 theSomeChoiceResult.getError()
                   .prependSegment(new Reporting.NameSegment("someChoice"));
@@ -648,7 +683,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends IBranch> theSomethingWithoutChoiceResult = tryIBranchFrom(currentNode.getValue());
+              final Reporting.Result<? extends IBranch> theSomethingWithoutChoiceResult = tryIBranchFrom(currentNode.getValue());
               if (theSomethingWithoutChoiceResult.isError()) {
                 theSomethingWithoutChoiceResult.getError()
                   .prependSegment(new Reporting.NameSegment("somethingWithoutChoice"));
@@ -660,7 +695,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -668,16 +703,16 @@ public class Jsonization {
         if (theSomeChoice == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someChoice\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomethingWithoutChoice == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"somethingWithoutChoice\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeChoice,
           theSomethingWithoutChoice));
       }
@@ -688,11 +723,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Container> tryContainerFrom(JsonNode node) {
+      private static Reporting.Result<Container> tryContainerFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         INode theNode = null;
@@ -707,7 +742,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends INode> theNodeResult = tryINodeFrom(currentNode.getValue());
+              final Reporting.Result<? extends INode> theNodeResult = tryINodeFrom(currentNode.getValue());
               if (theNodeResult.isError()) {
                 theNodeResult.getError()
                   .prependSegment(new Reporting.NameSegment("node"));
@@ -721,7 +756,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends ISomething> theSomethingResult = trySomethingFrom(currentNode.getValue());
+              final Reporting.Result<? extends ISomething> theSomethingResult = trySomethingFrom(currentNode.getValue());
               if (theSomethingResult.isError()) {
                 theSomethingResult.getError()
                   .prependSegment(new Reporting.NameSegment("something"));
@@ -733,7 +768,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -741,16 +776,16 @@ public class Jsonization {
         if (theNode == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"node\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomething == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"something\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Container(
+        return Reporting.Result.success(new Container(
           theNode,
           theSomething));
       }
@@ -779,63 +814,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -856,7 +834,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static INode deserializeINode(JsonNode node) {
-        final _Result<? extends INode> result =
+        final Reporting.Result<? extends INode> result =
           _DeserializeImplementation.tryINodeFrom(
             node);
 
@@ -873,7 +851,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IBranch deserializeIBranch(JsonNode node) {
-        final _Result<? extends IBranch> result =
+        final Reporting.Result<? extends IBranch> result =
           _DeserializeImplementation.tryIBranchFrom(
             node);
 
@@ -890,7 +868,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Branch deserializeBranch(JsonNode node) {
-        final _Result<? extends Branch> result =
+        final Reporting.Result<? extends Branch> result =
           _DeserializeImplementation.tryBranchFrom(
             node);
 
@@ -907,7 +885,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static ILeaf deserializeILeaf(JsonNode node) {
-        final _Result<? extends ILeaf> result =
+        final Reporting.Result<? extends ILeaf> result =
           _DeserializeImplementation.tryILeafFrom(
             node);
 
@@ -924,7 +902,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Leaf deserializeLeaf(JsonNode node) {
-        final _Result<? extends Leaf> result =
+        final Reporting.Result<? extends Leaf> result =
           _DeserializeImplementation.tryLeafFrom(
             node);
 
@@ -941,7 +919,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Blossom deserializeBlossom(JsonNode node) {
-        final _Result<? extends Blossom> result =
+        final Reporting.Result<? extends Blossom> result =
           _DeserializeImplementation.tryBlossomFrom(
             node);
 
@@ -958,7 +936,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -975,7 +953,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Container deserializeContainer(JsonNode node) {
-        final _Result<? extends Container> result =
+        final Reporting.Result<? extends Container> result =
           _DeserializeImplementation.tryContainerFrom(
             node);
 
@@ -1001,6 +979,34 @@ public class Jsonization {
             "The number can not be losslessly represented in JSON: " + that);
         }
         return JsonNodeFactory.instance.numberNode(that);
+      }
+
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
       }
 
       @Override

--- a/dev/test_data/main/java/expected/deep_class_hierarchy/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/deep_class_hierarchy/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/deep_class_hierarchy/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/deep_class_hierarchy/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,13 +659,13 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Deserialize an instance of INode from an XML element.
      */
-    private static _Result<? extends INode> tryINodeFromElement(
+    private static Reporting.Result<? extends INode> tryINodeFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -736,7 +681,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -748,7 +693,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Branch> tryBranchFromSequence(
+    private static Reporting.Result<Branch> tryBranchFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theIdentifier = null;
@@ -761,7 +706,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Branch, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -776,10 +721,10 @@ public class Xmlization {
               "a property of an instance of class Branch, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Branch.class);
           }
@@ -799,7 +744,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property identifier of an instance of class Branch, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -811,7 +756,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "identifier"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -827,7 +772,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property description of an instance of class Branch, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -839,7 +784,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -849,13 +794,13 @@ public class Xmlization {
                 "We expected properties of the class Branch, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Branch",
             reader,
             tryElementName);
@@ -868,17 +813,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property identifier has not been given " +
           "in the XML representation of an instance of class Branch");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theDescription == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property description has not been given " +
           "in the XML representation of an instance of class Branch");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Branch(
+      return Reporting.Result.success(new Branch(
         theIdentifier,
         theDescription));
     }
@@ -886,7 +831,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of IBranch from an XML element.
      */
-    private static _Result<? extends IBranch> tryIBranchFromElement(
+    private static Reporting.Result<? extends IBranch> tryIBranchFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -902,7 +847,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -910,7 +855,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Branch from an XML element.
      */
-    private static _Result<? extends Branch> tryBranchFromElement(
+    private static Reporting.Result<? extends Branch> tryBranchFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -920,7 +865,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Branch " +
               "with element name branch, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryBranchFromSequence(reader, isEmptyElement);
@@ -934,7 +879,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Leaf> tryLeafFromSequence(
+    private static Reporting.Result<Leaf> tryLeafFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theIdentifier = null;
@@ -948,7 +893,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Leaf, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -963,10 +908,10 @@ public class Xmlization {
               "a property of an instance of class Leaf, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Leaf.class);
           }
@@ -986,7 +931,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property identifier of an instance of class Leaf, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -998,7 +943,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "identifier"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1014,7 +959,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property description of an instance of class Leaf, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1026,7 +971,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1041,7 +986,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "value"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -1049,7 +994,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class Leaf, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1061,7 +1006,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1071,13 +1016,13 @@ public class Xmlization {
                 "We expected properties of the class Leaf, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Leaf",
             reader,
             tryElementName);
@@ -1090,24 +1035,24 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property identifier has not been given " +
           "in the XML representation of an instance of class Leaf");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theDescription == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property description has not been given " +
           "in the XML representation of an instance of class Leaf");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theValue == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property value has not been given " +
           "in the XML representation of an instance of class Leaf");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Leaf(
+      return Reporting.Result.success(new Leaf(
         theIdentifier,
         theDescription,
         theValue));
@@ -1116,7 +1061,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of ILeaf from an XML element.
      */
-    private static _Result<? extends ILeaf> tryILeafFromElement(
+    private static Reporting.Result<? extends ILeaf> tryILeafFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1130,7 +1075,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -1138,7 +1083,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Leaf from an XML element.
      */
-    private static _Result<? extends Leaf> tryLeafFromElement(
+    private static Reporting.Result<? extends Leaf> tryLeafFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1148,7 +1093,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Leaf " +
               "with element name leaf, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryLeafFromSequence(reader, isEmptyElement);
@@ -1162,7 +1107,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Blossom> tryBlossomFromSequence(
+    private static Reporting.Result<Blossom> tryBlossomFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theIdentifier = null;
@@ -1177,7 +1122,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Blossom, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1192,10 +1137,10 @@ public class Xmlization {
               "a property of an instance of class Blossom, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Blossom.class);
           }
@@ -1215,7 +1160,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property identifier of an instance of class Blossom, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1227,7 +1172,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "identifier"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1243,7 +1188,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property description of an instance of class Blossom, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1255,7 +1200,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "description"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1270,7 +1215,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "value"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -1278,7 +1223,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property value of an instance of class Blossom, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1290,7 +1235,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "value"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1306,7 +1251,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property details of an instance of class Blossom, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1318,7 +1263,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "details"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1328,13 +1273,13 @@ public class Xmlization {
                 "We expected properties of the class Blossom, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Blossom",
             reader,
             tryElementName);
@@ -1347,31 +1292,31 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property identifier has not been given " +
           "in the XML representation of an instance of class Blossom");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theDescription == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property description has not been given " +
           "in the XML representation of an instance of class Blossom");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theValue == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property value has not been given " +
           "in the XML representation of an instance of class Blossom");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theDetails == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property details has not been given " +
           "in the XML representation of an instance of class Blossom");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Blossom(
+      return Reporting.Result.success(new Blossom(
         theIdentifier,
         theDescription,
         theValue,
@@ -1381,7 +1326,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Blossom from an XML element.
      */
-    private static _Result<? extends Blossom> tryBlossomFromElement(
+    private static Reporting.Result<? extends Blossom> tryBlossomFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1391,7 +1336,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Blossom " +
               "with element name blossom, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryBlossomFromSequence(reader, isEmptyElement);
@@ -1405,7 +1350,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       INode theSomeChoice = null;
@@ -1418,7 +1363,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1433,10 +1378,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -1452,7 +1397,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property someChoice of an instance of class Something, " +
                   "but encountered a self-closing element.");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // We need to skip the whitespace here in order to be able to look ahead
@@ -1464,7 +1409,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property someChoice of an instance of class Something, " +
                   "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // Try to look ahead the discriminator name;
@@ -1473,12 +1418,12 @@ public class Xmlization {
               // checks.
               String discriminatorElementName = null;
               if (currentEvent(reader).isStartElement()) {
-                _Result<String> tryDiscriminatorElementName = tryElementName(reader);
+                Reporting.Result<String> tryDiscriminatorElementName = tryElementName(reader);
                 assert(!tryDiscriminatorElementName.isError());
                 discriminatorElementName = tryDiscriminatorElementName.getResult();
               }
 
-              _Result<? extends INode> trySomeChoice = tryINodeFromElement(reader);
+              Reporting.Result<? extends INode> trySomeChoice = tryINodeFromElement(reader);
 
               if (trySomeChoice.isError()) {
                 if (discriminatorElementName != null) {
@@ -1505,7 +1450,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property somethingWithoutChoice of an instance of class Something, " +
                   "but encountered a self-closing element.");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // We need to skip the whitespace here in order to be able to look ahead
@@ -1517,7 +1462,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property somethingWithoutChoice of an instance of class Something, " +
                   "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // Try to look ahead the discriminator name;
@@ -1526,12 +1471,12 @@ public class Xmlization {
               // checks.
               String discriminatorElementName = null;
               if (currentEvent(reader).isStartElement()) {
-                _Result<String> tryDiscriminatorElementName = tryElementName(reader);
+                Reporting.Result<String> tryDiscriminatorElementName = tryElementName(reader);
                 assert(!tryDiscriminatorElementName.isError());
                 discriminatorElementName = tryDiscriminatorElementName.getResult();
               }
 
-              _Result<? extends IBranch> trySomethingWithoutChoice = tryIBranchFromElement(reader);
+              Reporting.Result<? extends IBranch> trySomethingWithoutChoice = tryIBranchFromElement(reader);
 
               if (trySomethingWithoutChoice.isError()) {
                 if (discriminatorElementName != null) {
@@ -1556,13 +1501,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -1575,17 +1520,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someChoice has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomethingWithoutChoice == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property somethingWithoutChoice has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeChoice,
         theSomethingWithoutChoice));
     }
@@ -1593,7 +1538,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1603,7 +1548,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -1617,7 +1562,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Container> tryContainerFromSequence(
+    private static Reporting.Result<Container> tryContainerFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       INode theNode = null;
@@ -1630,7 +1575,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Container, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1645,10 +1590,10 @@ public class Xmlization {
               "a property of an instance of class Container, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Container.class);
           }
@@ -1664,7 +1609,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property node of an instance of class Container, " +
                   "but encountered a self-closing element.");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // We need to skip the whitespace here in order to be able to look ahead
@@ -1676,7 +1621,7 @@ public class Xmlization {
                   "Expected an XML element within the element " + tryElementName.getResult() + " representing " +
                   "the property node of an instance of class Container, " +
                   "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               // Try to look ahead the discriminator name;
@@ -1685,12 +1630,12 @@ public class Xmlization {
               // checks.
               String discriminatorElementName = null;
               if (currentEvent(reader).isStartElement()) {
-                _Result<String> tryDiscriminatorElementName = tryElementName(reader);
+                Reporting.Result<String> tryDiscriminatorElementName = tryElementName(reader);
                 assert(!tryDiscriminatorElementName.isError());
                 discriminatorElementName = tryDiscriminatorElementName.getResult();
               }
 
-              _Result<? extends INode> tryNode = tryINodeFromElement(reader);
+              Reporting.Result<? extends INode> tryNode = tryINodeFromElement(reader);
 
               if (tryNode.isError()) {
                 if (discriminatorElementName != null) {
@@ -1712,7 +1657,7 @@ public class Xmlization {
             }
             case "something":
             {
-              _Result<Something> trySomething = trySomethingFromSequence(
+              Reporting.Result<Something> trySomething = trySomethingFromSequence(
                 reader, isEmptyProperty);
 
               if (trySomething.isError()) {
@@ -1731,13 +1676,13 @@ public class Xmlization {
                 "We expected properties of the class Container, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Container",
             reader,
             tryElementName);
@@ -1750,17 +1695,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property node has not been given " +
           "in the XML representation of an instance of class Container");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomething == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property something has not been given " +
           "in the XML representation of an instance of class Container");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Container(
+      return Reporting.Result.success(new Container(
         theNode,
         theSomething));
     }
@@ -1768,7 +1713,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Container from an XML element.
      */
-    private static _Result<? extends Container> tryContainerFromElement(
+    private static Reporting.Result<? extends Container> tryContainerFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1778,7 +1723,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Container " +
               "with element name container, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryContainerFromSequence(reader, isEmptyElement);
@@ -1821,7 +1766,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends INode> result =
+      Reporting.Result<? extends INode> result =
         _DeserializeImplementation.tryINodeFromElement(
           reader);
 
@@ -1844,7 +1789,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IBranch> result =
+      Reporting.Result<? extends IBranch> result =
         _DeserializeImplementation.tryIBranchFromElement(
           reader);
 
@@ -1867,7 +1812,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Branch> result =
+      Reporting.Result<? extends Branch> result =
         _DeserializeImplementation.tryBranchFromElement(
           reader);
 
@@ -1890,7 +1835,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends ILeaf> result =
+      Reporting.Result<? extends ILeaf> result =
         _DeserializeImplementation.tryILeafFromElement(
           reader);
 
@@ -1913,7 +1858,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Leaf> result =
+      Reporting.Result<? extends Leaf> result =
         _DeserializeImplementation.tryLeafFromElement(
           reader);
 
@@ -1936,7 +1881,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Blossom> result =
+      Reporting.Result<? extends Blossom> result =
         _DeserializeImplementation.tryBlossomFromElement(
           reader);
 
@@ -1959,7 +1904,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -1982,7 +1927,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Container> result =
+      Reporting.Result<? extends Container> result =
         _DeserializeImplementation.tryContainerFromElement(
           reader);
 
@@ -2003,36 +1948,92 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
+      try {
+        writer.writeStartElement(name);
+        if (topLevel) {
+          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+          topLevel = false;
+        }
+        serializeContent.serialize(that, writer);
+        writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
     private void branchToSequence(
       IBranch that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "identifier");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getIdentifier().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "identifier",
+        that.getIdentifier(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "description");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getDescription().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "description",
+        that.getDescription(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -2058,47 +2059,23 @@ public class Xmlization {
     private void leafToSequence(
       ILeaf that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "identifier");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getIdentifier().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "identifier",
+        that.getIdentifier(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "description");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getDescription().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "description",
+        that.getDescription(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "value");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getValue().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "value",
+        that.getValue(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -2124,61 +2101,29 @@ public class Xmlization {
     private void blossomToSequence(
       IBlossom that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "identifier");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getIdentifier().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "identifier",
+        that.getIdentifier(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "description");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getDescription().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "description",
+        that.getDescription(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "value");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getValue().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "value",
+        that.getValue(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "details");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getDetails().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "details",
+        that.getDetails(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -2204,39 +2149,17 @@ public class Xmlization {
     private void somethingToSequence(
       ISomething that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "someChoice");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "someChoice",
+        that.getSomeChoice(),
+        writer,
+        this::visit);
 
-        this.visit(
-          that.getSomeChoice(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "somethingWithoutChoice");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.visit(
-          that.getSomethingWithoutChoice(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "somethingWithoutChoice",
+        that.getSomethingWithoutChoice(),
+        writer,
+        this::visit);
     }
 
     @Override
@@ -2262,39 +2185,17 @@ public class Xmlization {
     private void containerToSequence(
       IContainer that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "node");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "node",
+        that.getNode(),
+        writer,
+        this::visit);
 
-        this.visit(
-          that.getNode(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "something");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        this.somethingToSequence(
-          that.getSomething(),
-          writer);
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "something",
+        that.getSomething(),
+        writer,
+        (value, w) -> this.somethingToSequence(value, w));
     }
 
     @Override

--- a/dev/test_data/main/java/expected/empty_class/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/empty_class/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,11 +151,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
 
@@ -132,14 +167,14 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
 
 
 
-        return _Result.success(new Something());
+        return Reporting.Result.success(new Something());
       }
     }
 
@@ -166,63 +201,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -243,7 +221,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -269,6 +247,34 @@ public class Jsonization {
             "The number can not be losslessly represented in JSON: " + that);
         }
         return JsonNodeFactory.instance.numberNode(that);
+      }
+
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
       }
 
       @Override

--- a/dev/test_data/main/java/expected/empty_class/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/empty_class/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/empty_class/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/empty_class/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,7 +659,7 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -724,16 +669,16 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
-      return _Result.success(new Something());
+      return Reporting.Result.success(new Something());
     }
 
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -743,7 +688,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -786,7 +731,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -806,6 +751,78 @@ public class Xmlization {
     extends AbstractVisitorWithContext<XMLStreamWriter> {
 
     private boolean topLevel = true;
+
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
+      try {
+        writer.writeStartElement(name);
+        if (topLevel) {
+          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+          topLevel = false;
+        }
+        serializeContent.serialize(that, writer);
+        writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
 
     private void somethingToSequence(
       ISomething that,

--- a/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -115,17 +150,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<Result> tryResultFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<Result> tryResultFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(Result.class);
         }
         final Optional<Result> result = Stringification.resultFromString(textResult.getResult());
         if (!result.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of Result");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(result.get());
+        return Reporting.Result.success(result.get());
       }
 
       /**
@@ -134,11 +169,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         Result theSomeResult = null;
@@ -152,7 +187,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Result> theSomeResultResult = tryResultFrom(currentNode.getValue());
+              final Reporting.Result<? extends Result> theSomeResultResult = tryResultFrom(currentNode.getValue());
               if (theSomeResultResult.isError()) {
                 theSomeResultResult.getError()
                   .prependSegment(new Reporting.NameSegment("someResult"));
@@ -164,7 +199,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -172,10 +207,10 @@ public class Jsonization {
         if (theSomeResult == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someResult\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeResult));
       }
     }
@@ -203,63 +238,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -280,7 +258,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Result deserializeResult(JsonNode node) {
-        final _Result<? extends Result> result =
+        final Reporting.Result<? extends Result> result =
           _DeserializeImplementation.tryResultFrom(
             node);
 
@@ -297,7 +275,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -323,6 +301,34 @@ public class Jsonization {
             "The number can not be losslessly represented in JSON: " + that);
         }
         return JsonNodeFactory.instance.numberNode(that);
+      }
+
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
       }
 
       @Override
@@ -365,12 +371,7 @@ public class Jsonization {
        * Serialize a literal of Result into a JSON string.
        */
       public static JsonNode resultToJsonValue(Result that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid Result: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
     }
 }

--- a/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/stringification/Stringification.java
+++ b/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/stringification/Stringification.java
@@ -37,6 +37,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(resultToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(Result that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of Result: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, Result> resultFromString;
   static {
     final Map<String, Result> temp = new HashMap<>();

--- a/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/enum/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,15 +659,15 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link Result}.
      */
-    private static _Result<Result> tryVElementAsResult(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<Result> tryVElementAsResult(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(Result.class);
       }
@@ -734,10 +679,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of Result: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
@@ -747,7 +692,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       Result theSomeResult = null;
@@ -759,7 +704,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -774,10 +719,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -796,7 +741,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someResult"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               if (currentEvent(reader).isEndDocument()) {
@@ -804,7 +749,7 @@ public class Xmlization {
                     "Expected an XML content representing "
                         + "the property someResult of an instance of class Something, "
                         + "but reached the end-of-file");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               String textSomeResult;
@@ -817,7 +762,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "someResult"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
 
               final Optional<Result> optionalSomeResult =
@@ -834,7 +779,7 @@ public class Xmlization {
                 error.prependSegment(
                     new Reporting.NameSegment(
                         "someResult"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               break;
             }
@@ -843,13 +788,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -862,17 +807,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someResult has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeResult));
     }
 
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -882,7 +827,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -925,7 +870,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -946,32 +891,98 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
-    private void somethingToSequence(
-      ISomething that,
-      XMLStreamWriter writer) {
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
       try {
-        writer.writeStartElement(
-          "someResult");
+        writer.writeStartElement(name);
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
-
-        Optional<String> textSomeResult = Stringification.toString(
-          that.getSomeResult());
-
-        if (!textSomeResult.isPresent()) {
-          throw new IllegalArgumentException(
-            "Invalid literal for the enumeration Result: " +
-            that.getSomeResult().toString());
-        }
-
-        writer.writeCharacters(textSomeResult.get());
-
+        serializeContent.serialize(that, writer);
         writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
       }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
+    /**
+     * Write a literal of {@link Result} as XML content.
+     *
+     * <p>This is shared by every Result-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeResultContent(Result that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    private void somethingToSequence(
+      ISomething that,
+      XMLStreamWriter writer) {
+      serializeElement(
+        "someResult",
+        that.getSomeResult(),
+        writer,
+        this::writeResultContent);
     }
 
     @Override

--- a/dev/test_data/main/java/expected/list_of_classes/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/list_of_classes/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,20 +151,20 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      public static _Result<? extends IAbstractItem> tryIAbstractItemFrom(JsonNode node) {
+      public static Reporting.Result<? extends IAbstractItem> tryIAbstractItemFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         final JsonNode modelTypeNode = node.get("modelType");
         if (modelTypeNode == null) {
           final Reporting.Error error = new Reporting.Error(
               "Expected a model type, but none is present");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        final _Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
+        final Reporting.Result<String> modelTypeResult = tryStringFrom(modelTypeNode);
         if (modelTypeResult.isError()) {
           return modelTypeResult.castTo(IAbstractItem.class);
         }
@@ -143,7 +178,7 @@ public class Jsonization {
         }  default: {
             final Reporting.Error error = new Reporting.Error(
               "Unexpected model type for IAbstractItem: " + modelTypeResult.getResult());
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
         }
       }
@@ -154,11 +189,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<SomeItem> trySomeItemFrom(JsonNode node) {
+      private static Reporting.Result<SomeItem> trySomeItemFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theName = null;
@@ -174,7 +209,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
               if (theNameResult.isError()) {
                 theNameResult.getError()
                   .prependSegment(new Reporting.NameSegment("name"));
@@ -187,9 +222,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -203,14 +238,14 @@ public class Jsonization {
                   "Expected the model type 'SomeItem', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -218,16 +253,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theName == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"name\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new SomeItem(
+        return Reporting.Result.success(new SomeItem(
           theName));
       }
 
@@ -237,11 +272,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<AnotherItem> tryAnotherItemFrom(JsonNode node) {
+      private static Reporting.Result<AnotherItem> tryAnotherItemFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         Long theSerialNumber = null;
@@ -257,7 +292,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Long> theSerialNumberResult = tryLongFrom(currentNode.getValue());
+              final Reporting.Result<? extends Long> theSerialNumberResult = tryLongFrom(currentNode.getValue());
               if (theSerialNumberResult.isError()) {
                 theSerialNumberResult.getError()
                   .prependSegment(new Reporting.NameSegment("serialNumber"));
@@ -270,9 +305,9 @@ public class Jsonization {
               if (currentNode.getValue() == null) {
                 final Reporting.Error error = new Reporting.Error(
                   "Expected a model type, but got null");
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              final _Result<? extends String> modelTypeResult =
+              final Reporting.Result<? extends String> modelTypeResult =
                 _DeserializeImplementation.tryStringFrom(currentNode.getValue());
               if (modelTypeResult.isError()) {
                 modelTypeResult.getError()
@@ -286,14 +321,14 @@ public class Jsonization {
                   "Expected the model type 'AnotherItem', " +
                   "but got '" + modelType + "'");
                   error.prependSegment(new Reporting.NameSegment("modelType"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
               }
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -301,16 +336,16 @@ public class Jsonization {
         if (modelType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"modelType\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSerialNumber == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"serialNumber\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new AnotherItem(
+        return Reporting.Result.success(new AnotherItem(
           theSerialNumber));
       }
 
@@ -320,11 +355,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Simple> trySimpleFrom(JsonNode node) {
+      private static Reporting.Result<Simple> trySimpleFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theName = null;
@@ -338,7 +373,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theNameResult = tryStringFrom(currentNode.getValue());
               if (theNameResult.isError()) {
                 theNameResult.getError()
                   .prependSegment(new Reporting.NameSegment("name"));
@@ -350,7 +385,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -358,10 +393,10 @@ public class Jsonization {
         if (theName == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"name\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Simple(
+        return Reporting.Result.success(new Simple(
           theName));
       }
 
@@ -371,11 +406,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<IAbstractItem> theSomeItems = null;
@@ -397,42 +432,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someItems"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeItems = new ArrayList<>(
-                arraySomeItems.size());
-              int indexSomeItems = 0;
-              for (JsonNode item : arraySomeItems) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeItems));
-                  error.prependSegment(
+              final Reporting.Result<List<IAbstractItem>> theSomeItemsResult = parseArray(
+                arraySomeItems,
+                _DeserializeImplementation::tryIAbstractItemFrom);
+              if (theSomeItemsResult.isError()) {
+                theSomeItemsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someItems"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends IAbstractItem> parsedItemResult =
-                  tryIAbstractItemFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeItems));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someItems"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeItems.add(
-                  parsedItemResult.getResult());
-                indexSomeItems++;
+                return theSomeItemsResult.castTo(Something.class);
               }
+              theSomeItems = theSomeItemsResult.getResult();
               break;
             }
             case "someSimples": {
@@ -447,48 +459,25 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someSimples"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeSimples = new ArrayList<>(
-                arraySomeSimples.size());
-              int indexSomeSimples = 0;
-              for (JsonNode item : arraySomeSimples) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeSimples));
-                  error.prependSegment(
+              final Reporting.Result<List<ISimple>> theSomeSimplesResult = parseArray(
+                arraySomeSimples,
+                _DeserializeImplementation::trySimpleFrom);
+              if (theSomeSimplesResult.isError()) {
+                theSomeSimplesResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someSimples"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends ISimple> parsedItemResult =
-                  trySimpleFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeSimples));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someSimples"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeSimples.add(
-                  parsedItemResult.getResult());
-                indexSomeSimples++;
+                return theSomeSimplesResult.castTo(Something.class);
               }
+              theSomeSimples = theSomeSimplesResult.getResult();
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -496,16 +485,16 @@ public class Jsonization {
         if (theSomeItems == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someItems\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeSimples == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someSimples\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeItems,
           theSomeSimples));
       }
@@ -534,63 +523,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -611,7 +543,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static IAbstractItem deserializeIAbstractItem(JsonNode node) {
-        final _Result<? extends IAbstractItem> result =
+        final Reporting.Result<? extends IAbstractItem> result =
           _DeserializeImplementation.tryIAbstractItemFrom(
             node);
 
@@ -628,7 +560,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static SomeItem deserializeSomeItem(JsonNode node) {
-        final _Result<? extends SomeItem> result =
+        final Reporting.Result<? extends SomeItem> result =
           _DeserializeImplementation.trySomeItemFrom(
             node);
 
@@ -645,7 +577,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static AnotherItem deserializeAnotherItem(JsonNode node) {
-        final _Result<? extends AnotherItem> result =
+        final Reporting.Result<? extends AnotherItem> result =
           _DeserializeImplementation.tryAnotherItemFrom(
             node);
 
@@ -662,7 +594,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Simple deserializeSimple(JsonNode node) {
-        final _Result<? extends Simple> result =
+        final Reporting.Result<? extends Simple> result =
           _DeserializeImplementation.trySimpleFrom(
             node);
 
@@ -679,7 +611,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -705,6 +637,34 @@ public class Jsonization {
             "The number can not be losslessly represented in JSON: " + that);
         }
         return JsonNodeFactory.instance.numberNode(that);
+      }
+
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
       }
 
       @Override
@@ -753,20 +713,18 @@ public class Jsonization {
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        final ArrayNode arraySomeItems = JsonNodeFactory.instance.arrayNode();
-        for (IAbstractItem item : that.getSomeItems()) {
-          arraySomeItems.add(
+        final ArrayNode arraySomeItems = serializeArray(
+          that.getSomeItems(),
+          (IAbstractItem item) ->
             transform(
               item));
-        }
         result.set("someItems", arraySomeItems);
 
-        final ArrayNode arraySomeSimples = JsonNodeFactory.instance.arrayNode();
-        for (ISimple item : that.getSomeSimples()) {
-          arraySomeSimples.add(
+        final ArrayNode arraySomeSimples = serializeArray(
+          that.getSomeSimples(),
+          (ISimple item) ->
             transform(
               item));
-        }
         result.set("someSimples", arraySomeSimples);
 
         return result;

--- a/dev/test_data/main/java/expected/list_of_classes/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/list_of_classes/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/list_of_classes/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/list_of_classes/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,13 +659,13 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Deserialize an instance of IAbstractItem from an XML element.
      */
-    private static _Result<? extends IAbstractItem> tryIAbstractItemFromElement(
+    private static Reporting.Result<? extends IAbstractItem> tryIAbstractItemFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -734,7 +679,7 @@ public class Xmlization {
             default:
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected element with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
         });
     }
@@ -746,7 +691,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<SomeItem> trySomeItemFromSequence(
+    private static Reporting.Result<SomeItem> trySomeItemFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theName = null;
@@ -758,7 +703,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class SomeItem, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -773,10 +718,10 @@ public class Xmlization {
               "a property of an instance of class SomeItem, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(SomeItem.class);
           }
@@ -796,7 +741,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property name of an instance of class SomeItem, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -808,7 +753,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "name"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -818,13 +763,13 @@ public class Xmlization {
                 "We expected properties of the class SomeItem, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "SomeItem",
             reader,
             tryElementName);
@@ -837,17 +782,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property name has not been given " +
           "in the XML representation of an instance of class SomeItem");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new SomeItem(
+      return Reporting.Result.success(new SomeItem(
         theName));
     }
 
     /**
      * Deserialize an instance of class SomeItem from an XML element.
      */
-    private static _Result<? extends SomeItem> trySomeItemFromElement(
+    private static Reporting.Result<? extends SomeItem> trySomeItemFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -857,7 +802,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class SomeItem " +
               "with element name someItem, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomeItemFromSequence(reader, isEmptyElement);
@@ -871,7 +816,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<AnotherItem> tryAnotherItemFromSequence(
+    private static Reporting.Result<AnotherItem> tryAnotherItemFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       Long theSerialNumber = null;
@@ -883,7 +828,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class AnotherItem, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -898,10 +843,10 @@ public class Xmlization {
               "a property of an instance of class AnotherItem, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(AnotherItem.class);
           }
@@ -920,7 +865,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "serialNumber"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -928,7 +873,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property serialNumber of an instance of class AnotherItem, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -940,7 +885,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "serialNumber"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -950,13 +895,13 @@ public class Xmlization {
                 "We expected properties of the class AnotherItem, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "AnotherItem",
             reader,
             tryElementName);
@@ -969,17 +914,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property serialNumber has not been given " +
           "in the XML representation of an instance of class AnotherItem");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new AnotherItem(
+      return Reporting.Result.success(new AnotherItem(
         theSerialNumber));
     }
 
     /**
      * Deserialize an instance of class AnotherItem from an XML element.
      */
-    private static _Result<? extends AnotherItem> tryAnotherItemFromElement(
+    private static Reporting.Result<? extends AnotherItem> tryAnotherItemFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -989,7 +934,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class AnotherItem " +
               "with element name anotherItem, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return tryAnotherItemFromSequence(reader, isEmptyElement);
@@ -1003,7 +948,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Simple> trySimpleFromSequence(
+    private static Reporting.Result<Simple> trySimpleFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theName = null;
@@ -1015,7 +960,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Simple, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1030,10 +975,10 @@ public class Xmlization {
               "a property of an instance of class Simple, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Simple.class);
           }
@@ -1053,7 +998,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property name of an instance of class Simple, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -1065,7 +1010,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "name"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -1075,13 +1020,13 @@ public class Xmlization {
                 "We expected properties of the class Simple, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Simple",
             reader,
             tryElementName);
@@ -1094,17 +1039,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property name has not been given " +
           "in the XML representation of an instance of class Simple");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Simple(
+      return Reporting.Result.success(new Simple(
         theName));
     }
 
     /**
      * Deserialize an instance of class Simple from an XML element.
      */
-    private static _Result<? extends Simple> trySimpleFromElement(
+    private static Reporting.Result<? extends Simple> trySimpleFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1114,7 +1059,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Simple " +
               "with element name simple, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySimpleFromSequence(reader, isEmptyElement);
@@ -1128,7 +1073,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<IAbstractItem> theSomeItems = null;
@@ -1141,7 +1086,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -1156,10 +1101,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -1170,7 +1115,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "someItems":
             {
-              final _Result<List<IAbstractItem>> trySomeItems = parseList(
+              final Reporting.Result<List<IAbstractItem>> trySomeItems = parseList(
                 reader,
                 isEmptyProperty,
                 IAbstractItem.class,
@@ -1189,7 +1134,7 @@ public class Xmlization {
             }
             case "someSimples":
             {
-              final _Result<List<ISimple>> trySomeSimples = parseList(
+              final Reporting.Result<List<ISimple>> trySomeSimples = parseList(
                 reader,
                 isEmptyProperty,
                 ISimple.class,
@@ -1211,13 +1156,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -1230,17 +1175,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someItems has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeSimples == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someSimples has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeItems,
         theSomeSimples));
     }
@@ -1248,7 +1193,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1258,7 +1203,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -1301,7 +1246,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends IAbstractItem> result =
+      Reporting.Result<? extends IAbstractItem> result =
         _DeserializeImplementation.tryIAbstractItemFromElement(
           reader);
 
@@ -1324,7 +1269,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends SomeItem> result =
+      Reporting.Result<? extends SomeItem> result =
         _DeserializeImplementation.trySomeItemFromElement(
           reader);
 
@@ -1347,7 +1292,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends AnotherItem> result =
+      Reporting.Result<? extends AnotherItem> result =
         _DeserializeImplementation.tryAnotherItemFromElement(
           reader);
 
@@ -1370,7 +1315,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Simple> result =
+      Reporting.Result<? extends Simple> result =
         _DeserializeImplementation.trySimpleFromElement(
           reader);
 
@@ -1393,7 +1338,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -1414,22 +1359,86 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
-    private void someItemToSequence(
-      ISomeItem that,
-      XMLStreamWriter writer) {
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
       try {
-        writer.writeStartElement(
-          "name");
+        writer.writeStartElement(name);
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
-        writer.writeCharacters(
-          that.getName().toString());
+        serializeContent.serialize(that, writer);
         writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
       }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
+    private void someItemToSequence(
+      ISomeItem that,
+      XMLStreamWriter writer) {
+      serializeElement(
+        "name",
+        that.getName(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -1455,19 +1464,11 @@ public class Xmlization {
     private void anotherItemToSequence(
       IAnotherItem that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "serialNumber");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSerialNumber().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "serialNumber",
+        that.getSerialNumber(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -1493,19 +1494,11 @@ public class Xmlization {
     private void simpleToSequence(
       ISimple that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "name");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getName().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "name",
+        that.getName(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override
@@ -1531,39 +1524,17 @@ public class Xmlization {
     private void somethingToSequence(
       ISomething that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "someItems");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "someItems",
+        that.getSomeItems(),
+        writer,
+        serializeItems(this::visit));
 
-        for (IAbstractItem item : that.getSomeItems()) {
-          this.visit(item, writer);
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "someSimples");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        for (ISimple item : that.getSomeSimples()) {
-          this.visit(item, writer);
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someSimples",
+        that.getSomeSimples(),
+        writer,
+        serializeItems(this::visit));
     }
 
     @Override

--- a/dev/test_data/main/java/expected/list_of_constrained_primitives/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/list_of_constrained_primitives/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,11 +151,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<String> theSomeNames = null;
@@ -141,48 +176,25 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someNames"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeNames = new ArrayList<>(
-                arraySomeNames.size());
-              int indexSomeNames = 0;
-              for (JsonNode item : arraySomeNames) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeNames));
-                  error.prependSegment(
+              final Reporting.Result<List<String>> theSomeNamesResult = parseArray(
+                arraySomeNames,
+                _DeserializeImplementation::tryStringFrom);
+              if (theSomeNamesResult.isError()) {
+                theSomeNamesResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someNames"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends String> parsedItemResult =
-                  tryStringFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeNames));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someNames"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeNames.add(
-                  parsedItemResult.getResult());
-                indexSomeNames++;
+                return theSomeNamesResult.castTo(Something.class);
               }
+              theSomeNames = theSomeNamesResult.getResult();
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -190,10 +202,10 @@ public class Jsonization {
         if (theSomeNames == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someNames\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeNames));
       }
     }
@@ -221,63 +233,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -298,7 +253,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -326,18 +281,45 @@ public class Jsonization {
         return JsonNodeFactory.instance.numberNode(that);
       }
 
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
+      }
+
       @Override
       public JsonNode transformSomething(
         ISomething that
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        final ArrayNode arraySomeNames = JsonNodeFactory.instance.arrayNode();
-        for (String item : that.getSomeNames()) {
-          arraySomeNames.add(
+        final ArrayNode arraySomeNames = serializeArray(
+          that.getSomeNames(),
+          (String item) ->
             JsonNodeFactory.instance.textNode(
               item));
-        }
         result.set("someNames", arraySomeNames);
 
         return result;

--- a/dev/test_data/main/java/expected/list_of_constrained_primitives/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/list_of_constrained_primitives/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/list_of_constrained_primitives/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/list_of_constrained_primitives/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,7 +659,7 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -724,7 +669,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<String> theSomeNames = null;
@@ -736,7 +681,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -751,10 +696,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -765,7 +710,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "someNames":
             {
-              final _Result<List<String>> trySomeNames = parseList(
+              final Reporting.Result<List<String>> trySomeNames = parseList(
                 reader,
                 isEmptyProperty,
                 String.class,
@@ -787,13 +732,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -806,17 +751,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someNames has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeNames));
     }
 
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -826,7 +771,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -869,7 +814,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -890,27 +835,87 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
-    private void somethingToSequence(
-      ISomething that,
-      XMLStreamWriter writer) {
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
       try {
-        writer.writeStartElement(
-          "someNames");
+        writer.writeStartElement(name);
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
-
-        for (String item : that.getSomeNames()) {
-          writer.writeStartElement("v");
-          writer.writeCharacters(item.toString());
-          writer.writeEndElement();
-        }
-
+        serializeContent.serialize(that, writer);
         writer.writeEndElement();
       } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+        throw new SerializeException("", exception.getMessage());
       }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
+    private void somethingToSequence(
+      ISomething that,
+      XMLStreamWriter writer) {
+      serializeElement(
+        "someNames",
+        that.getSomeNames(),
+        writer,
+        serializeItems((item, w) -> serializeElement(
+          "v", item, w, this::writeStringifiedContent)));
     }
 
     @Override

--- a/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -115,17 +150,17 @@ public class Jsonization {
        *
        * @param node JSON node to be parsed
        */
-      private static _Result<Result> tryResultFrom(JsonNode node) {
-        final _Result<String> textResult = tryStringFrom(node);
+      private static Reporting.Result<Result> tryResultFrom(JsonNode node) {
+        final Reporting.Result<String> textResult = tryStringFrom(node);
         if (textResult.isError()) {
           return textResult.castTo(Result.class);
         }
         final Optional<Result> result = Stringification.resultFromString(textResult.getResult());
         if (!result.isPresent()) {
           final Reporting.Error error = new Reporting.Error("Not a valid JSON representation of Result");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(result.get());
+        return Reporting.Result.success(result.get());
       }
 
       /**
@@ -134,11 +169,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<Result> theSomeResults = null;
@@ -159,48 +194,25 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someResults"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeResults = new ArrayList<>(
-                arraySomeResults.size());
-              int indexSomeResults = 0;
-              for (JsonNode item : arraySomeResults) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeResults));
-                  error.prependSegment(
+              final Reporting.Result<List<Result>> theSomeResultsResult = parseArray(
+                arraySomeResults,
+                _DeserializeImplementation::tryResultFrom);
+              if (theSomeResultsResult.isError()) {
+                theSomeResultsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someResults"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends Result> parsedItemResult =
-                  tryResultFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeResults));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someResults"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeResults.add(
-                  parsedItemResult.getResult());
-                indexSomeResults++;
+                return theSomeResultsResult.castTo(Something.class);
               }
+              theSomeResults = theSomeResultsResult.getResult();
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -208,10 +220,10 @@ public class Jsonization {
         if (theSomeResults == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someResults\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeResults));
       }
     }
@@ -239,63 +251,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -316,7 +271,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Result deserializeResult(JsonNode node) {
-        final _Result<? extends Result> result =
+        final Reporting.Result<? extends Result> result =
           _DeserializeImplementation.tryResultFrom(
             node);
 
@@ -333,7 +288,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -361,18 +316,45 @@ public class Jsonization {
         return JsonNodeFactory.instance.numberNode(that);
       }
 
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
+      }
+
       @Override
       public JsonNode transformSomething(
         ISomething that
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        final ArrayNode arraySomeResults = JsonNodeFactory.instance.arrayNode();
-        for (Result item : that.getSomeResults()) {
-          arraySomeResults.add(
+        final ArrayNode arraySomeResults = serializeArray(
+          that.getSomeResults(),
+          (Result item) ->
             Serialize.resultToJsonValue(
               item));
-        }
         result.set("someResults", arraySomeResults);
 
         return result;
@@ -406,12 +388,7 @@ public class Jsonization {
        * Serialize a literal of Result into a JSON string.
        */
       public static JsonNode resultToJsonValue(Result that) {
-        Optional<String> text = Stringification.toString(that);
-        if (!text.isPresent()) {
-          throw new IllegalArgumentException("Invalid Result: " + that);
-        }
-
-        return JsonNodeFactory.instance.textNode(text.get());
+        return JsonNodeFactory.instance.textNode(Stringification.mustToString(that));
       }
     }
 }

--- a/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/stringification/Stringification.java
+++ b/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/stringification/Stringification.java
@@ -37,6 +37,20 @@ public class Stringification {
     return Optional.ofNullable(that).map(resultToString::get);
   }
 
+  /**
+   * Retrieve the string representation of {@code that}.
+   *
+   * @throws IllegalArgumentException if {@code that} is not a valid literal
+   */
+  public static String mustToString(Result that)
+  {
+    final Optional<String> text = toString(that);
+    if (!text.isPresent()) {
+      throw new IllegalArgumentException("Invalid literal of Result: " + that);
+    }
+    return text.get();
+  }
+
   private static final Map<String, Result> resultFromString;
   static {
     final Map<String, Result> temp = new HashMap<>();

--- a/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/list_of_enums/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,15 +659,15 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element and parse its content as a literal
      * of {@link Result}.
      */
-    private static _Result<Result> tryVElementAsResult(XMLEventReader reader) {
-      final _Result<String> tryText = tryVElementAsString(reader);
+    private static Reporting.Result<Result> tryVElementAsResult(XMLEventReader reader) {
+      final Reporting.Result<String> tryText = tryVElementAsString(reader);
       if (tryText.isError()) {
         return tryText.castTo(Result.class);
       }
@@ -734,10 +679,10 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The text could not be parsed as a literal of Result: " +
           tryText.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(result.get());
+      return Reporting.Result.success(result.get());
     }
 
     /**
@@ -747,7 +692,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<Result> theSomeResults = null;
@@ -759,7 +704,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -774,10 +719,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -788,7 +733,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "someResults":
             {
-              final _Result<List<Result>> trySomeResults = parseList(
+              final Reporting.Result<List<Result>> trySomeResults = parseList(
                 reader,
                 isEmptyProperty,
                 Result.class,
@@ -810,13 +755,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -829,17 +774,17 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someResults has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeResults));
     }
 
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -849,7 +794,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -892,7 +837,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -913,32 +858,99 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
-    private void somethingToSequence(
-      ISomething that,
-      XMLStreamWriter writer) {
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
       try {
-        writer.writeStartElement(
-          "someResults");
+        writer.writeStartElement(name);
         if (topLevel) {
           writer.writeNamespace("xmlns", AAS_NAME_SPACE);
           topLevel = false;
         }
-
-        for (Result item : that.getSomeResults()) {
-          writer.writeStartElement("v");
-          final Optional<String> itemText = Stringification.toString(item);
-          if (!itemText.isPresent()) {
-            throw new IllegalArgumentException(
-              "Invalid literal for the enumeration Result: " + item.toString());
-          }
-          writer.writeCharacters(itemText.get());
-          writer.writeEndElement();
-        }
-
+        serializeContent.serialize(that, writer);
         writer.writeEndElement();
       } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
+        throw new SerializeException("", exception.getMessage());
       }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
+    /**
+     * Write a literal of {@link Result} as XML content.
+     *
+     * <p>This is shared by every Result-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeResultContent(Result that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(Stringification.mustToString(that));
+    }
+
+    private void somethingToSequence(
+      ISomething that,
+      XMLStreamWriter writer) {
+      serializeElement(
+        "someResults",
+        that.getSomeResults(),
+        writer,
+        serializeItems((item, w) -> serializeElement(
+          "v", item, w, this::writeResultContent)));
     }
 
     @Override

--- a/dev/test_data/main/java/expected/list_of_primitives/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/list_of_primitives/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,11 +151,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         List<Boolean> theSomeBools = null;
@@ -145,42 +180,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someBools"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeBools = new ArrayList<>(
-                arraySomeBools.size());
-              int indexSomeBools = 0;
-              for (JsonNode item : arraySomeBools) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeBools));
-                  error.prependSegment(
+              final Reporting.Result<List<Boolean>> theSomeBoolsResult = parseArray(
+                arraySomeBools,
+                _DeserializeImplementation::tryBooleanFrom);
+              if (theSomeBoolsResult.isError()) {
+                theSomeBoolsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someBools"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends Boolean> parsedItemResult =
-                  tryBooleanFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeBools));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someBools"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeBools.add(
-                  parsedItemResult.getResult());
-                indexSomeBools++;
+                return theSomeBoolsResult.castTo(Something.class);
               }
+              theSomeBools = theSomeBoolsResult.getResult();
               break;
             }
             case "someInts": {
@@ -195,42 +207,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someInts"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeInts = new ArrayList<>(
-                arraySomeInts.size());
-              int indexSomeInts = 0;
-              for (JsonNode item : arraySomeInts) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeInts));
-                  error.prependSegment(
+              final Reporting.Result<List<Long>> theSomeIntsResult = parseArray(
+                arraySomeInts,
+                _DeserializeImplementation::tryLongFrom);
+              if (theSomeIntsResult.isError()) {
+                theSomeIntsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someInts"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends Long> parsedItemResult =
-                  tryLongFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeInts));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someInts"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeInts.add(
-                  parsedItemResult.getResult());
-                indexSomeInts++;
+                return theSomeIntsResult.castTo(Something.class);
               }
+              theSomeInts = theSomeIntsResult.getResult();
               break;
             }
             case "someFloats": {
@@ -245,42 +234,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someFloats"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeFloats = new ArrayList<>(
-                arraySomeFloats.size());
-              int indexSomeFloats = 0;
-              for (JsonNode item : arraySomeFloats) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeFloats));
-                  error.prependSegment(
+              final Reporting.Result<List<Double>> theSomeFloatsResult = parseArray(
+                arraySomeFloats,
+                _DeserializeImplementation::tryDoubleFrom);
+              if (theSomeFloatsResult.isError()) {
+                theSomeFloatsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someFloats"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends Double> parsedItemResult =
-                  tryDoubleFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeFloats));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someFloats"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeFloats.add(
-                  parsedItemResult.getResult());
-                indexSomeFloats++;
+                return theSomeFloatsResult.castTo(Something.class);
               }
+              theSomeFloats = theSomeFloatsResult.getResult();
               break;
             }
             case "someStrings": {
@@ -295,42 +261,19 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someStrings"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeStrings = new ArrayList<>(
-                arraySomeStrings.size());
-              int indexSomeStrings = 0;
-              for (JsonNode item : arraySomeStrings) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeStrings));
-                  error.prependSegment(
+              final Reporting.Result<List<String>> theSomeStringsResult = parseArray(
+                arraySomeStrings,
+                _DeserializeImplementation::tryStringFrom);
+              if (theSomeStringsResult.isError()) {
+                theSomeStringsResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someStrings"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends String> parsedItemResult =
-                  tryStringFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeStrings));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someStrings"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeStrings.add(
-                  parsedItemResult.getResult());
-                indexSomeStrings++;
+                return theSomeStringsResult.castTo(Something.class);
               }
+              theSomeStrings = theSomeStringsResult.getResult();
               break;
             }
             case "someBytes": {
@@ -345,48 +288,25 @@ public class Jsonization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someBytes"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
-              theSomeBytes = new ArrayList<>(
-                arraySomeBytes.size());
-              int indexSomeBytes = 0;
-              for (JsonNode item : arraySomeBytes) {
-                if (item == null) {
-                  final Reporting.Error error = new Reporting.Error(
-                    "Expected a non-null item, but got a null");
-                  error.prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeBytes));
-                  error.prependSegment(
+              final Reporting.Result<List<byte[]>> theSomeBytesResult = parseArray(
+                arraySomeBytes,
+                _DeserializeImplementation::tryBytesFrom);
+              if (theSomeBytesResult.isError()) {
+                theSomeBytesResult.getError()
+                  .prependSegment(
                     new Reporting.NameSegment(
                       "someBytes"));
-                  return _Result.failure(error);
-                }
-                final _Result<? extends byte[]> parsedItemResult =
-                  tryBytesFrom(item);
-                if (parsedItemResult.isError()) {
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.IndexSegment(
-                      indexSomeBytes));
-                  parsedItemResult
-                    .getError()
-                    .prependSegment(
-                    new Reporting.NameSegment(
-                      "someBytes"));
-                  return parsedItemResult.castTo(Something.class);
-                }
-                theSomeBytes.add(
-                  parsedItemResult.getResult());
-                indexSomeBytes++;
+                return theSomeBytesResult.castTo(Something.class);
               }
+              theSomeBytes = theSomeBytesResult.getResult();
               break;
             }
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -394,34 +314,34 @@ public class Jsonization {
         if (theSomeBools == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someBools\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeInts == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someInts\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeFloats == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someFloats\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeStrings == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someStrings\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeBytes == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someBytes\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeBools,
           theSomeInts,
           theSomeFloats,
@@ -453,63 +373,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -530,7 +393,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -558,51 +421,73 @@ public class Jsonization {
         return JsonNodeFactory.instance.numberNode(that);
       }
 
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
+      }
+
       @Override
       public JsonNode transformSomething(
         ISomething that
       ) {
         final ObjectNode result = JsonNodeFactory.instance.objectNode();
 
-        final ArrayNode arraySomeBools = JsonNodeFactory.instance.arrayNode();
-        for (Boolean item : that.getSomeBools()) {
-          arraySomeBools.add(
+        final ArrayNode arraySomeBools = serializeArray(
+          that.getSomeBools(),
+          (Boolean item) ->
             JsonNodeFactory.instance.booleanNode(
               item));
-        }
         result.set("someBools", arraySomeBools);
 
-        final ArrayNode arraySomeInts = JsonNodeFactory.instance.arrayNode();
-        for (Long item : that.getSomeInts()) {
-          arraySomeInts.add(
+        final ArrayNode arraySomeInts = serializeArray(
+          that.getSomeInts(),
+          (Long item) ->
             _Transformer.toJsonNode(
               item));
-        }
         result.set("someInts", arraySomeInts);
 
-        final ArrayNode arraySomeFloats = JsonNodeFactory.instance.arrayNode();
-        for (Double item : that.getSomeFloats()) {
-          arraySomeFloats.add(
+        final ArrayNode arraySomeFloats = serializeArray(
+          that.getSomeFloats(),
+          (Double item) ->
             JsonNodeFactory.instance.numberNode(
               item));
-        }
         result.set("someFloats", arraySomeFloats);
 
-        final ArrayNode arraySomeStrings = JsonNodeFactory.instance.arrayNode();
-        for (String item : that.getSomeStrings()) {
-          arraySomeStrings.add(
+        final ArrayNode arraySomeStrings = serializeArray(
+          that.getSomeStrings(),
+          (String item) ->
             JsonNodeFactory.instance.textNode(
               item));
-        }
         result.set("someStrings", arraySomeStrings);
 
-        final ArrayNode arraySomeBytes = JsonNodeFactory.instance.arrayNode();
-        for (byte[] item : that.getSomeBytes()) {
-          arraySomeBytes.add(
-            JsonNodeFactory.instance.textNode(
-                Base64.getEncoder()
-                  .encodeToString(item)));
-        }
+        final ArrayNode arraySomeBytes = serializeArray(
+          that.getSomeBytes(),
+          (byte[] item) ->
+            _Transformer.bytesToJsonNode(
+              item));
         result.set("someBytes", arraySomeBytes);
 
         return result;

--- a/dev/test_data/main/java/expected/list_of_primitives/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/list_of_primitives/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/list_of_primitives/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/list_of_primitives/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,7 +659,7 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -724,7 +669,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       List<Boolean> theSomeBools = null;
@@ -740,7 +685,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -755,10 +700,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -769,7 +714,7 @@ public class Xmlization {
           switch (tryElementName.getResult()) {
             case "someBools":
             {
-              final _Result<List<Boolean>> trySomeBools = parseList(
+              final Reporting.Result<List<Boolean>> trySomeBools = parseList(
                 reader,
                 isEmptyProperty,
                 Boolean.class,
@@ -788,7 +733,7 @@ public class Xmlization {
             }
             case "someInts":
             {
-              final _Result<List<Long>> trySomeInts = parseList(
+              final Reporting.Result<List<Long>> trySomeInts = parseList(
                 reader,
                 isEmptyProperty,
                 Long.class,
@@ -807,7 +752,7 @@ public class Xmlization {
             }
             case "someFloats":
             {
-              final _Result<List<Double>> trySomeFloats = parseList(
+              final Reporting.Result<List<Double>> trySomeFloats = parseList(
                 reader,
                 isEmptyProperty,
                 Double.class,
@@ -826,7 +771,7 @@ public class Xmlization {
             }
             case "someStrings":
             {
-              final _Result<List<String>> trySomeStrings = parseList(
+              final Reporting.Result<List<String>> trySomeStrings = parseList(
                 reader,
                 isEmptyProperty,
                 String.class,
@@ -845,7 +790,7 @@ public class Xmlization {
             }
             case "someBytes":
             {
-              final _Result<List<byte[]>> trySomeBytes = parseList(
+              final Reporting.Result<List<byte[]>> trySomeBytes = parseList(
                 reader,
                 isEmptyProperty,
                 byte[].class,
@@ -867,13 +812,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -886,38 +831,38 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someBools has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeInts == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someInts has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeFloats == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someFloats has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeStrings == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someStrings has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeBytes == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someBytes has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeBools,
         theSomeInts,
         theSomeFloats,
@@ -928,7 +873,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -938,7 +883,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -981,7 +926,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -1002,104 +947,115 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
+      try {
+        writer.writeStartElement(name);
+        if (topLevel) {
+          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+          topLevel = false;
+        }
+        serializeContent.serialize(that, writer);
+        writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
     private void somethingToSequence(
       ISomething that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "someBools");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "someBools",
+        that.getSomeBools(),
+        writer,
+        serializeItems((item, w) -> serializeElement(
+          "v", item, w, this::writeStringifiedContent)));
 
-        for (Boolean item : that.getSomeBools()) {
-          writer.writeStartElement("v");
-          writer.writeCharacters(item.toString());
-          writer.writeEndElement();
-        }
+      serializeElement(
+        "someInts",
+        that.getSomeInts(),
+        writer,
+        serializeItems((item, w) -> serializeElement(
+          "v", item, w, this::writeStringifiedContent)));
 
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someFloats",
+        that.getSomeFloats(),
+        writer,
+        serializeItems((item, w) -> serializeElement(
+          "v", item, w, this::writeStringifiedContent)));
 
-      try {
-        writer.writeStartElement(
-          "someInts");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
+      serializeElement(
+        "someStrings",
+        that.getSomeStrings(),
+        writer,
+        serializeItems((item, w) -> serializeElement(
+          "v", item, w, this::writeStringifiedContent)));
 
-        for (Long item : that.getSomeInts()) {
-          writer.writeStartElement("v");
-          writer.writeCharacters(item.toString());
-          writer.writeEndElement();
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "someFloats");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        for (Double item : that.getSomeFloats()) {
-          writer.writeStartElement("v");
-          writer.writeCharacters(item.toString());
-          writer.writeEndElement();
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "someStrings");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        for (String item : that.getSomeStrings()) {
-          writer.writeStartElement("v");
-          writer.writeCharacters(item.toString());
-          writer.writeEndElement();
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
-
-      try {
-        writer.writeStartElement(
-          "someBytes");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-
-        for (byte[] item : that.getSomeBytes()) {
-          writer.writeStartElement("v");
-          writer.writeCharacters(
-            Base64.getEncoder().encodeToString(item));
-          writer.writeEndElement();
-        }
-
-        writer.writeEndElement();
-      } catch (XMLStreamException exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someBytes",
+        that.getSomeBytes(),
+        writer,
+        serializeItems((item, w) -> serializeElement(
+          "v", item, w, this::writeByteArrayContent)));
     }
 
     @Override

--- a/dev/test_data/main/java/expected/primitive_types/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/primitive_types/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,11 +151,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         Boolean theSomeBool = null;
@@ -138,7 +173,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Boolean> theSomeBoolResult = tryBooleanFrom(currentNode.getValue());
+              final Reporting.Result<? extends Boolean> theSomeBoolResult = tryBooleanFrom(currentNode.getValue());
               if (theSomeBoolResult.isError()) {
                 theSomeBoolResult.getError()
                   .prependSegment(new Reporting.NameSegment("someBool"));
@@ -152,7 +187,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Long> theSomeIntResult = tryLongFrom(currentNode.getValue());
+              final Reporting.Result<? extends Long> theSomeIntResult = tryLongFrom(currentNode.getValue());
               if (theSomeIntResult.isError()) {
                 theSomeIntResult.getError()
                   .prependSegment(new Reporting.NameSegment("someInt"));
@@ -166,7 +201,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends Double> theSomeFloatResult = tryDoubleFrom(currentNode.getValue());
+              final Reporting.Result<? extends Double> theSomeFloatResult = tryDoubleFrom(currentNode.getValue());
               if (theSomeFloatResult.isError()) {
                 theSomeFloatResult.getError()
                   .prependSegment(new Reporting.NameSegment("someFloat"));
@@ -180,7 +215,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theSomeStringResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theSomeStringResult = tryStringFrom(currentNode.getValue());
               if (theSomeStringResult.isError()) {
                 theSomeStringResult.getError()
                   .prependSegment(new Reporting.NameSegment("someString"));
@@ -194,7 +229,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends byte[]> theSomeBytesResult = tryBytesFrom(currentNode.getValue());
+              final Reporting.Result<? extends byte[]> theSomeBytesResult = tryBytesFrom(currentNode.getValue());
               if (theSomeBytesResult.isError()) {
                 theSomeBytesResult.getError()
                   .prependSegment(new Reporting.NameSegment("someBytes"));
@@ -206,7 +241,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -214,34 +249,34 @@ public class Jsonization {
         if (theSomeBool == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someBool\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeInt == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someInt\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeFloat == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someFloat\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeString == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someString\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theSomeBytes == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"someBytes\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theSomeBool,
           theSomeInt,
           theSomeFloat,
@@ -273,63 +308,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -350,7 +328,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -378,6 +356,34 @@ public class Jsonization {
         return JsonNodeFactory.instance.numberNode(that);
       }
 
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
+      }
+
       @Override
       public JsonNode transformSomething(
         ISomething that
@@ -396,9 +402,8 @@ public class Jsonization {
         result.put("someString", JsonNodeFactory.instance.textNode(
           that.getSomeString()));
 
-        result.set("someBytes", JsonNodeFactory.instance.textNode(
-            Base64.getEncoder()
-              .encodeToString(that.getSomeBytes())));
+        result.set("someBytes", _Transformer.bytesToJsonNode(
+          that.getSomeBytes()));
 
         return result;
       }

--- a/dev/test_data/main/java/expected/primitive_types/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/primitive_types/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/primitive_types/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/primitive_types/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,7 +659,7 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -724,7 +669,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       Boolean theSomeBool = null;
@@ -740,7 +685,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -755,10 +700,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -777,7 +722,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someBool"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -785,7 +730,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someBool of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -797,7 +742,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someBool"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -812,7 +757,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someInt"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -820,7 +765,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someInt of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -832,7 +777,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someInt"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -847,7 +792,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someFloat"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -855,7 +800,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someFloat of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -867,7 +812,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someFloat"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -883,7 +828,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someString of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -895,7 +840,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someString"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -910,7 +855,7 @@ public class Xmlization {
                 error.prependSegment(
                   new Reporting.NameSegment(
                     "someBytes"));
-                return _Result.failure(error);
+                return Reporting.Result.failure(error);
               }
               else {
                 if (currentEvent(reader).isEndDocument()) {
@@ -918,7 +863,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property someBytes of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -930,7 +875,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "someBytes"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -940,13 +885,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -959,38 +904,38 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property someBool has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeInt == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someInt has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeFloat == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someFloat has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeString == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someString has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theSomeBytes == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property someBytes has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theSomeBool,
         theSomeInt,
         theSomeFloat,
@@ -1001,7 +946,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -1011,7 +956,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -1054,7 +999,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -1075,79 +1020,110 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
+      try {
+        writer.writeStartElement(name);
+        if (topLevel) {
+          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+          topLevel = false;
+        }
+        serializeContent.serialize(that, writer);
+        writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
     private void somethingToSequence(
       ISomething that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "someBool");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeBool().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someBool",
+        that.getSomeBool(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someInt");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeInt().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someInt",
+        that.getSomeInt(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someFloat");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeFloat().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someFloat",
+        that.getSomeFloat(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someString");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getSomeString().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someString",
+        that.getSomeString(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "someBytes");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        String theB64Somebytes = Base64.getEncoder().encodeToString(
-          that.getSomeBytes());
-        writer.writeCharacters(theB64Somebytes);
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "someBytes",
+        that.getSomeBytes(),
+        writer,
+        this::writeByteArrayContent);
     }
 
     @Override

--- a/dev/test_data/main/java/expected/problematic_keywords/expected_output/src/main/java/dummy/jsonization/Jsonization.java
+++ b/dev/test_data/main/java/expected/problematic_keywords/expected_output/src/main/java/dummy/jsonization/Jsonization.java
@@ -44,56 +44,56 @@ public class Jsonization {
       /** Convert {@code value} to a string.
        * @param node JSON node to be parsed
        */
-      private static _Result<String> tryStringFrom(JsonNode value) {
+      private static Reporting.Result<String> tryStringFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asText());
+        return Reporting.Result.success(value.asText());
       }
 
       /** Convert {@code value} to a boolean.
        * @param node JSON node to be parsed
        */
-      private static _Result<Boolean> tryBooleanFrom(JsonNode value) {
+      private static Reporting.Result<Boolean> tryBooleanFrom(JsonNode value) {
         if (!value.isBoolean()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Boolean, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asBoolean());
+        return Reporting.Result.success(value.asBoolean());
       }
 
       /** Convert {@code value} to a long 64-bit integer.
        * @param node JSON node to be parsed
        */
-      private static _Result<Long> tryLongFrom(JsonNode value) {
+      private static Reporting.Result<Long> tryLongFrom(JsonNode value) {
         if (!value.isIntegralNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Long, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asLong());
+        return Reporting.Result.success(value.asLong());
       }
 
       /** Convert {@code value} to a double-precision 64-bit float.
        * @param node JSON node to be parsed
        */
-      private static _Result<Double> tryDoubleFrom(JsonNode value) {
+      private static Reporting.Result<Double> tryDoubleFrom(JsonNode value) {
         if (!value.isFloatingPointNumber()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of Double, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
-        return _Result.success(value.asDouble());
+        return Reporting.Result.success(value.asDouble());
       }
 
-      private static _Result<byte[]> tryBytesFrom(JsonNode value) {
+      private static Reporting.Result<byte[]> tryBytesFrom(JsonNode value) {
         if (!value.isTextual()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonValue of String, but got " + value.getNodeType());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         final byte[] decodedData;
         Base64.Decoder decoder = Base64.getDecoder();
@@ -104,10 +104,45 @@ public class Jsonization {
           final Reporting.Error error = new Reporting.Error(
             "Expected Base-64 encoded bytes, but the conversion failed " +
               "because: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(decodedData);
+        return Reporting.Result.success(decodedData);
+      }
+
+      /**
+       * Parse every item of {@code array} with {@code parseItem}.
+       *
+       * @param array JSON array to be parsed
+       * @param parseItem to parse a single item of the array
+       */
+      private static <T> Reporting.Result<List<T>> parseArray(
+        JsonNode array,
+        Function<JsonNode, Reporting.Result<? extends T>> parseItem) {
+        final List<T> result = new ArrayList<>(array.size());
+        int index = 0;
+        for (JsonNode item : array) {
+          if (item == null) {
+            final Reporting.Error error = new Reporting.Error(
+              "Expected a non-null item, but got a null");
+            error.prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(error);
+          }
+
+          final Reporting.Result<? extends T> parsedItemResult = parseItem.apply(item);
+          if (parsedItemResult.isError()) {
+            parsedItemResult.getError()
+              .prependSegment(
+              new Reporting.IndexSegment(index));
+            return Reporting.Result.failure(parsedItemResult.getError());
+          }
+
+          result.add(parsedItemResult.getResult());
+          index++;
+        }
+
+        return Reporting.Result.success(result);
       }
 
       /**
@@ -116,11 +151,11 @@ public class Jsonization {
        * @param node JSON node to be parsed
        * @param elem Error, if any, during the deserialization
        */
-      private static _Result<Something> trySomethingFrom(JsonNode node) {
+      private static Reporting.Result<Something> trySomethingFrom(JsonNode node) {
         if (node == null || !node.isObject()) {
           final Reporting.Error error = new Reporting.Error(
             "Expected a JsonObject, but got " + (node == null ? "null" : node.getNodeType()));
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         String theInterface = null;
@@ -137,7 +172,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theInterfaceResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theInterfaceResult = tryStringFrom(currentNode.getValue());
               if (theInterfaceResult.isError()) {
                 theInterfaceResult.getError()
                   .prependSegment(new Reporting.NameSegment("interface"));
@@ -151,7 +186,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theTypeResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theTypeResult = tryStringFrom(currentNode.getValue());
               if (theTypeResult.isError()) {
                 theTypeResult.getError()
                   .prependSegment(new Reporting.NameSegment("type"));
@@ -165,7 +200,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theRangeResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theRangeResult = tryStringFrom(currentNode.getValue());
               if (theRangeResult.isError()) {
                 theRangeResult.getError()
                   .prependSegment(new Reporting.NameSegment("range"));
@@ -179,7 +214,7 @@ public class Jsonization {
                 continue;
               }
 
-              final _Result<? extends String> theVoidResult = tryStringFrom(currentNode.getValue());
+              final Reporting.Result<? extends String> theVoidResult = tryStringFrom(currentNode.getValue());
               if (theVoidResult.isError()) {
                 theVoidResult.getError()
                   .prependSegment(new Reporting.NameSegment("void"));
@@ -191,7 +226,7 @@ public class Jsonization {
             default: {
               final Reporting.Error error = new Reporting.Error(
                 "Unexpected property: " + currentNode.getKey());
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
             }
           }
         }
@@ -199,28 +234,28 @@ public class Jsonization {
         if (theInterface == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"interface\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theType == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"type\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theRange == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"range\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
         if (theVoid == null) {
           final Reporting.Error error = new Reporting.Error(
             "Required property \"void\" is missing");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
 
-        return _Result.success(new Something(
+        return Reporting.Result.success(new Something(
           theInterface,
           theType,
           theRange,
@@ -251,63 +286,6 @@ public class Jsonization {
         }
       }
 
-    private static class _Result<T> {
-      private final T result;
-      private final Reporting.Error error;
-      private final boolean success;
-
-      private _Result(T result, Reporting.Error error, boolean success) {
-        this.result = result;
-        this.error = error;
-        this.success = success;
-      }
-
-      public static <T> _Result<T> success(T result) {
-        if (result == null) throw new IllegalArgumentException("Result must not be null.");
-        return new _Result<>(result, null, true);
-      }
-
-      public static <T> _Result<T> failure(Reporting.Error error) {
-        if (error == null) throw new IllegalArgumentException("Error must not be null.");
-        return new _Result<>(null, error, false);
-      }
-
-      @SuppressWarnings("unchecked")
-      public <I> _Result<I> castTo(Class<I> type) {
-        if (isError() || type.isInstance(result)) return (_Result<I>) this;
-        throw new IllegalStateException("Result of type "
-          + result.getClass().getName()
-          + " is not an instance of "
-          + type.getName());
-      }
-
-      public T getResult() {
-        if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-        return result;
-      }
-
-      public boolean isSuccess() {
-        return success;
-      }
-
-      public boolean isError() {
-        return !success;
-      }
-
-      public Reporting.Error getError() {
-        if (isSuccess()) throw new IllegalStateException("Result is present.");
-        return error;
-      }
-
-      public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-        return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-      }
-
-      public T onError(Function<Reporting.Error, T> errorFunction) {
-        return map(Function.identity(), errorFunction);
-      }
-    }
-
     /**
      * Deserialize instances of meta-model classes from JSON nodes.
      *
@@ -328,7 +306,7 @@ public class Jsonization {
        * @param node JSON node to be parsed
        */
       public static Something deserializeSomething(JsonNode node) {
-        final _Result<? extends Something> result =
+        final Reporting.Result<? extends Something> result =
           _DeserializeImplementation.trySomethingFrom(
             node);
 
@@ -354,6 +332,34 @@ public class Jsonization {
             "The number can not be losslessly represented in JSON: " + that);
         }
         return JsonNodeFactory.instance.numberNode(that);
+      }
+
+      /**
+       * Convert {@code that} byte array to a JSON value.
+       *
+       * @param that value to be converted
+       */
+      private static JsonNode bytesToJsonNode(byte[] that) {
+        return JsonNodeFactory.instance.textNode(
+          Base64.getEncoder().encodeToString(that));
+      }
+
+      /**
+       * Serialize every item of {@code items} with {@code serializeItem} into
+       * a JSON array.
+       *
+       * @param items to be serialized
+       * @param serializeItem to serialize a single item of {@code items}
+       */
+      private static <T> ArrayNode serializeArray(
+        Iterable<T> items,
+        Function<T, JsonNode> serializeItem) {
+        final ArrayNode result = JsonNodeFactory.instance.arrayNode();
+        for (T item : items) {
+          result.add(
+            serializeItem.apply(item));
+        }
+        return result;
       }
 
       @Override

--- a/dev/test_data/main/java/expected/problematic_keywords/expected_output/src/main/java/dummy/reporting/Reporting.java
+++ b/dev/test_data/main/java/expected/problematic_keywords/expected_output/src/main/java/dummy/reporting/Reporting.java
@@ -12,6 +12,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.LinkedList;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -158,6 +159,70 @@ public class Reporting
 
         public Collection<Segment> getPathSegments() {
             return pathSegments;
+        }
+    }
+
+    /**
+     * Represent the outcome of a de/serialization or a verification step.
+     *
+     * <p>This is shared by JSON de/serialization, XML de/serialization and
+     * verification, all of which propagate an {@link Error} instead of relying
+     * on exceptions for the common (successful) case.
+     */
+    public static class Result<T> {
+        private final T result;
+        private final Error error;
+        private final boolean success;
+
+        private Result(T result, Error error, boolean success) {
+            this.result = result;
+            this.error = error;
+            this.success = success;
+        }
+
+        public static <T> Result<T> success(T result) {
+            if (result == null) throw new IllegalArgumentException("Result must not be null.");
+            return new Result<>(result, null, true);
+        }
+
+        public static <T> Result<T> failure(Error error) {
+            if (error == null) throw new IllegalArgumentException("Error must not be null.");
+            return new Result<>(null, error, false);
+        }
+
+        @SuppressWarnings("unchecked")
+        public <I> Result<I> castTo(Class<I> type) {
+            if (isError() || type.isInstance(result)) return (Result<I>) this;
+            throw new IllegalStateException("Result of type "
+                + result.getClass().getName()
+                + " is not an instance of "
+                + type.getName());
+        }
+
+        public T getResult() {
+            if (!isSuccess()) throw new IllegalStateException("Result is not present.");
+            return result;
+        }
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public boolean isError() {
+            return !success;
+        }
+
+        public Error getError() {
+            if (isSuccess()) throw new IllegalStateException("Result is present.");
+            return error;
+        }
+
+        public <R> R map(Function<T, R> successFunction, Function<Error, R> errorFunction) {
+            return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
+        }
+
+        public T onError(Function<Error, T> errorFunction) {
+            return map(Function.identity(), errorFunction);
         }
     }
 }

--- a/dev/test_data/main/java/expected/problematic_keywords/expected_output/src/main/java/dummy/xmlization/Xmlization.java
+++ b/dev/test_data/main/java/expected/problematic_keywords/expected_output/src/main/java/dummy/xmlization/Xmlization.java
@@ -79,61 +79,6 @@ public class Xmlization {
   public static final String AAS_NAME_SPACE =
     "https://dummy.com";
 
-  private static class _Result<T> {
-    private final T result;
-    private final Reporting.Error error;
-    private final boolean success;
-
-    private _Result(T result, Reporting.Error error, boolean success) {
-      this.result = result;
-      this.error = error;
-      this.success = success;
-    }
-
-    public static <T> _Result<T> success(T result) {
-      if(result == null) throw new IllegalArgumentException("Result must not be null.");
-      return new _Result<>(result, null, true);
-    }
-
-    public static <T> _Result<T> failure(Reporting.Error error) {
-      if(error == null) throw new IllegalArgumentException("Error must not be null.");
-      return new _Result<>(null, error, false);
-    }
-
-    @SuppressWarnings("unchecked")
-    public <I> _Result<I> castTo(Class<I> type){
-      if(isError() || type.isInstance(result)) return (_Result<I>) this;
-      throw new IllegalStateException("Result of type "
-        + result.getClass().getName()
-        + " is not an instance of "
-        + type.getName());
-    }
-
-    public T getResult() {
-      if (!isSuccess()) throw new IllegalStateException("Result is not present.");
-      return result;
-    }
-
-    public boolean isSuccess() {
-      return success;
-    }
-
-    public boolean isError(){return !success;}
-
-    public Reporting.Error getError() {
-      if (isSuccess()) throw new IllegalStateException("Result is present.");
-      return error;
-    }
-
-    public <R> R map(Function<T, R> successFunction, Function<Reporting.Error, R> errorFunction) {
-      return isSuccess() ? successFunction.apply(result) : errorFunction.apply(error);
-    }
-
-    public T onError(Function<Reporting.Error, T>  errorFunction){
-      return map(Function.identity(), errorFunction);
-    }
-  }
-
   /**
    * Implement the deserialization of meta-model classes from XML.
    *
@@ -201,17 +146,17 @@ public class Xmlization {
       return currentEvent(reader).isEndElement();
     }
 
-    private static _Result<XMLEvent> verifyClosingTagForClass(
+    private static Reporting.Result<XMLEvent> verifyClosingTagForClass(
       String className,
       XMLEventReader reader,
-      _Result<String> tryElementName) {
+      Reporting.Result<String> tryElementName) {
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent.isEndElement()) {
@@ -220,9 +165,9 @@ public class Xmlization {
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the node of type " + getEventTypeAsString(currentEvent)
                 + " with the value " + currentEvent);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      final _Result<String> tryEndElementName = tryElementName(reader);
+      final Reporting.Result<String> tryEndElementName = tryElementName(reader);
       if (tryEndElementName.isError()) {
         return tryEndElementName.castTo(XMLEvent.class);
       }
@@ -231,10 +176,10 @@ public class Xmlization {
             "Expected an XML end element to conclude a property of class " + className
                 + " with the element name " + tryElementName.getResult() + ", "
                 + "but got the end element with the name " + tryEndElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method verifyClosingTagForClass because of: " +
@@ -249,45 +194,45 @@ public class Xmlization {
      * the element is self-closing, and is expected to consume the properties of
      * the instance, but not the element's closing tag.
      */
-    private static <T> _Result<? extends T> parseInstanceFromElement(
+    private static <T> Reporting.Result<? extends T> parseInstanceFromElement(
       XMLEventReader reader,
       Class<T> type,
-      BiFunction<String, Boolean, _Result<? extends T>> parseAsSequence) {
+      BiFunction<String, Boolean, Reporting.Result<? extends T>> parseAsSequence) {
       skipWhitespaceAndComments(reader);
 
       final XMLEvent currentEvent = currentEvent(reader);
       if (currentEvent.getEventType() == XMLStreamConstants.END_DOCUMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but reached the end-of-file"));
       }
 
       if (currentEvent.getEventType() != XMLStreamConstants.START_ELEMENT) {
-        return _Result.failure(new Reporting.Error(
+        return Reporting.Result.failure(new Reporting.Error(
           "Expected an XML element representing an instance of " + type.getSimpleName() + ", " +
             "but got a node of type " + getEventTypeAsString(currentEvent) +
             " with value " + currentEvent));
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
-        return _Result.failure(tryElementName.getError());
+        return Reporting.Result.failure(tryElementName.getError());
       }
 
       final String elementName = tryElementName.getResult();
       final boolean isEmptyElement = isEmptyElement(reader);
 
-      final _Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
+      final Reporting.Result<? extends T> result = parseAsSequence.apply(elementName, isEmptyElement);
       if (result.isError()) {
         return result;
       }
 
-      final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+      final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
         type.getSimpleName(),
         reader,
         tryElementName);
       if (checkEndElement.isError()) {
-        return _Result.failure(checkEndElement.getError());
+        return Reporting.Result.failure(checkEndElement.getError());
       }
 
       return result;
@@ -326,7 +271,7 @@ public class Xmlization {
     /**
      * Check the namespace and extract the element's name.
      */
-    private static _Result<String> tryElementName(XMLEventReader reader) {
+    private static Reporting.Result<String> tryElementName(XMLEventReader reader) {
       final XMLEvent currentEvent = currentEvent(reader);
       final boolean precondition = currentEvent.isStartElement() || currentEvent.isEndElement();
       if (!precondition) {
@@ -341,9 +286,9 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
             "Expected an element within a namespace " +
             AAS_NAME_SPACE + ", " + "but got: " + namespace);
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
-      return _Result.success(currentEvent.isStartElement()
+      return Reporting.Result.success(currentEvent.isStartElement()
           ? currentEvent.asStartElement().getName().getLocalPart()
           : currentEvent.asEndElement().getName().getLocalPart());
     }
@@ -434,21 +379,21 @@ public class Xmlization {
      * Consume a {@code <v>} element from the reader and return whether
      * it was a self-closing (empty) element.
      */
-    private static _Result<Boolean> tryVStartElement(XMLEventReader reader) {
+    private static Reporting.Result<Boolean> tryVStartElement(XMLEventReader reader) {
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isStartElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> start element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(Boolean.class);
       }
@@ -456,33 +401,33 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a <v> element, but got an element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final boolean isEmpty = isEmptyElement(reader);
-      return _Result.success(isEmpty);
+      return Reporting.Result.success(isEmpty);
     }
 
     /**
      * Consume a {@code </v>} element from the reader.
      */
-    private static _Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
+    private static Reporting.Result<XMLEvent> tryVEndElement(XMLEventReader reader) {
       skipWhitespaceAndComments(reader);
 
       if (currentEvent(reader).isEndDocument()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end-of-file.");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (!currentEvent(reader).isEndElement()) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> end element, but got the node of type "
             + getEventTypeAsString(currentEvent(reader)));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<String> tryElementName = tryElementName(reader);
+      final Reporting.Result<String> tryElementName = tryElementName(reader);
       if (tryElementName.isError()) {
         return tryElementName.castTo(XMLEvent.class);
       }
@@ -490,11 +435,11 @@ public class Xmlization {
       if (!"v".equals(tryElementName.getResult())) {
         final Reporting.Error error = new Reporting.Error(
           "Expected a </v> element, but got an end element " + tryElementName.getResult());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       try {
-        return _Result.success(reader.nextEvent());
+        return Reporting.Result.success(reader.nextEvent());
       } catch (XMLStreamException xmlStreamException) {
         throw new Xmlization.DeserializeException("",
           "Failed in method tryVEndElement because of: " +
@@ -505,8 +450,8 @@ public class Xmlization {
     /**
      * Read the content of a {@code <v>} element and parse it as Boolean.
      */
-    private static _Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Boolean> tryVElementAsBoolean(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Boolean.class);
       }
@@ -515,7 +460,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Boolean, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Boolean result;
@@ -525,22 +470,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Boolean: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Boolean.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Long.
      */
-    private static _Result<Long> tryVElementAsLong(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Long> tryVElementAsLong(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Long.class);
       }
@@ -549,7 +494,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Long, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Long result;
@@ -559,22 +504,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Long: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Long.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as Double.
      */
-    private static _Result<Double> tryVElementAsDouble(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<Double> tryVElementAsDouble(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(Double.class);
       }
@@ -583,7 +528,7 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "Expected an XML content representing Double, " +
           "but got a self-closing <v /> element");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       final Double result;
@@ -593,22 +538,22 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The content of a <v> element could not be de-serialized " +
           "as Double: " + exception.getMessage());
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(Double.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read the content of a {@code <v>} element and parse it as a string.
      */
-    private static _Result<String> tryVElementAsString(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<String> tryVElementAsString(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(String.class);
       }
@@ -623,7 +568,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as String: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -631,19 +576,19 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(String.class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
      * Read a {@code <v>} element as base64-encoded bytes.
      */
-    private static _Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
-      final _Result<Boolean> tryVStart = tryVStartElement(reader);
+    private static Reporting.Result<byte[]> tryVElementAsBytes(XMLEventReader reader) {
+      final Reporting.Result<Boolean> tryVStart = tryVStartElement(reader);
       if (tryVStart.isError()) {
         return tryVStart.castTo(byte[].class);
       }
@@ -658,7 +603,7 @@ public class Xmlization {
           final Reporting.Error error = new Reporting.Error(
             "The content of a <v> element could not be de-serialized " +
             "as base64-encoded bytes: " + exception.getMessage());
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
       }
 
@@ -666,12 +611,12 @@ public class Xmlization {
       // A self-closing <v /> is represented as a pair of start and end events
       // in StAX, so we need to consume the end element even if the <v /> was
       // empty.
-      final _Result<XMLEvent> tryVEnd = tryVEndElement(reader);
+      final Reporting.Result<XMLEvent> tryVEnd = tryVEndElement(reader);
       if (tryVEnd.isError()) {
         return tryVEnd.castTo(byte[].class);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -680,14 +625,14 @@ public class Xmlization {
      * <p>Every start element is considered to mark the start of an item. Parsing
      * stops as soon as a non-start element is encountered.
      */
-    private static <T> _Result<List<T>> parseList(
+    private static <T> Reporting.Result<List<T>> parseList(
       XMLEventReader reader,
       boolean isEmptyProperty,
       Class<T> itemType,
-      Function<XMLEventReader, _Result<? extends T>> parseItem) {
+      Function<XMLEventReader, Reporting.Result<? extends T>> parseItem) {
       final List<T> result = new ArrayList<>();
       if (isEmptyProperty) {
-        return _Result.success(result);
+        return Reporting.Result.success(result);
       }
 
       skipWhitespaceAndComments(reader);
@@ -697,16 +642,16 @@ public class Xmlization {
           "Expected a start element opening an instance of " + itemType.getSimpleName() +
             ", but got an XML " + getEventTypeAsString(currentEvent(reader)));
         error.prependSegment(new Reporting.IndexSegment(index));
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       while (currentEvent(reader).isStartElement()) {
-        final _Result<? extends T> itemResult = parseItem.apply(reader);
+        final Reporting.Result<? extends T> itemResult = parseItem.apply(reader);
         if (itemResult.isError()) {
           itemResult.getError()
             .prependSegment(
               new Reporting.IndexSegment(index));
-          return _Result.failure(itemResult.getError());
+          return Reporting.Result.failure(itemResult.getError());
         }
 
         result.add(itemResult.getResult());
@@ -714,7 +659,7 @@ public class Xmlization {
         skipWhitespaceAndComments(reader);
       }
 
-      return _Result.success(result);
+      return Reporting.Result.success(result);
     }
 
     /**
@@ -724,7 +669,7 @@ public class Xmlization {
      * the instance from an empty sequence. That is, the parent element
      * was a self-closing element.
      */
-    private static _Result<Something> trySomethingFromSequence(
+    private static Reporting.Result<Something> trySomethingFromSequence(
       XMLEventReader reader,
       boolean isEmptySequence) {
       String theInterface = null;
@@ -739,7 +684,7 @@ public class Xmlization {
             "Expected an XML element representing " +
             "a property of an instance of class Something, " +
             "but reached the end-of-file");
-          return _Result.failure(error);
+          return Reporting.Result.failure(error);
         }
         while (true) {
           skipWhitespaceAndComments(reader);
@@ -754,10 +699,10 @@ public class Xmlization {
               "a property of an instance of class Something, " +
               "but got the node of type " + getEventTypeAsString(currentEvent(reader)) +
               " with the value " + currentEvent(reader));
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
-          final _Result<String> tryElementName = tryElementName(reader);
+          final Reporting.Result<String> tryElementName = tryElementName(reader);
           if (tryElementName.isError()) {
             return tryElementName.castTo(Something.class);
           }
@@ -777,7 +722,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property interfacE of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -789,7 +734,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "interfacE"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -805,7 +750,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property type of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -817,7 +762,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "type"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -833,7 +778,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property range of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -845,7 +790,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "range"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -861,7 +806,7 @@ public class Xmlization {
                     "Expected an XML content representing " +
                     "the property voiD of an instance of class Something, " +
                     "but reached the end-of-file");
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
 
                 try {
@@ -873,7 +818,7 @@ public class Xmlization {
                   error.prependSegment(
                     new Reporting.NameSegment(
                       "voiD"));
-                  return _Result.failure(error);
+                  return Reporting.Result.failure(error);
                 }
               }
               break;
@@ -883,13 +828,13 @@ public class Xmlization {
                 "We expected properties of the class Something, " +
                 "but got an unexpected element " +
                 "with the name " + elementName);
-              return _Result.failure(error);
+              return Reporting.Result.failure(error);
           }
 
           skipWhitespaceAndComments(reader);
 
 
-          final _Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
+          final Reporting.Result<XMLEvent> checkEndElement = verifyClosingTagForClass(
             "Something",
             reader,
             tryElementName);
@@ -902,31 +847,31 @@ public class Xmlization {
         final Reporting.Error error = new Reporting.Error(
           "The required property interfacE has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theType == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property type has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theRange == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property range has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
       if (theVoid == null) {
         final Reporting.Error error = new Reporting.Error(
           "The required property voiD has not been given " +
           "in the XML representation of an instance of class Something");
-        return _Result.failure(error);
+        return Reporting.Result.failure(error);
       }
 
-      return _Result.success(new Something(
+      return Reporting.Result.success(new Something(
         theInterface,
         theType,
         theRange,
@@ -936,7 +881,7 @@ public class Xmlization {
     /**
      * Deserialize an instance of class Something from an XML element.
      */
-    private static _Result<? extends Something> trySomethingFromElement(
+    private static Reporting.Result<? extends Something> trySomethingFromElement(
       XMLEventReader reader) {
       return parseInstanceFromElement(
         reader,
@@ -946,7 +891,7 @@ public class Xmlization {
             final Reporting.Error error = new Reporting.Error(
               "Expected an element representing an instance of class Something " +
               "with element name something, but got: " + elementName);
-            return _Result.failure(error);
+            return Reporting.Result.failure(error);
           }
 
           return trySomethingFromSequence(reader, isEmptyElement);
@@ -989,7 +934,7 @@ public class Xmlization {
       _DeserializeImplementation.skipStartDocument(reader);
       _DeserializeImplementation.skipWhitespaceAndComments(reader);
 
-      _Result<? extends Something> result =
+      Reporting.Result<? extends Something> result =
         _DeserializeImplementation.trySomethingFromElement(
           reader);
 
@@ -1010,64 +955,104 @@ public class Xmlization {
 
     private boolean topLevel = true;
 
+    @FunctionalInterface
+    private interface ElementContentSerializer<T> {
+      void serialize(T that, XMLStreamWriter writer) throws XMLStreamException;
+    }
+
+    /**
+     * Write {@code that} as an XML element named {@code name}, delegating
+     * the content in-between the start and the end tag to
+     * {@code serializeContent}.
+     *
+     * <p>This is shared by all the property kinds (primitive, enumeration,
+     * class, interface, list) as they all wrap their content in exactly the
+     * same way.
+     */
+    private <T> void serializeElement(
+      String name,
+      T that,
+      XMLStreamWriter writer,
+      ElementContentSerializer<T> serializeContent) {
+      try {
+        writer.writeStartElement(name);
+        if (topLevel) {
+          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
+          topLevel = false;
+        }
+        serializeContent.serialize(that, writer);
+        writer.writeEndElement();
+      } catch (XMLStreamException exception) {
+        throw new SerializeException("", exception.getMessage());
+      }
+    }
+
+    /**
+     * Adapt {@code writeItem} to serialize every item of an iterable.
+     *
+     * <p>This is shared by all the list-typed properties, which only need to
+     * supply how a single item is written.
+     */
+    private <T> ElementContentSerializer<Iterable<T>> serializeItems(
+      ElementContentSerializer<T> writeItem) {
+      return (items, w) -> {
+        for (T item : items) {
+          writeItem.serialize(item, w);
+        }
+      };
+    }
+
+    /**
+     * Write {@code that.toString()} as XML content.
+     *
+     * <p>This is shared by every {@code boolean}/{@code long}/{@code double}/
+     * {@code String}-typed property or list item, standing in for the property-
+     * or item-specific {@link ElementContentSerializer}.
+     */
+    private <T> void writeStringifiedContent(T that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(that.toString());
+    }
+
+    /**
+     * Write {@code that} as base64-encoded XML content.
+     *
+     * <p>This is shared by every {@code byte[]}-typed property or list item,
+     * standing in for the property- or item-specific
+     * {@link ElementContentSerializer}.
+     */
+    private void writeByteArrayContent(byte[] that, XMLStreamWriter writer)
+      throws XMLStreamException {
+      writer.writeCharacters(
+        Base64.getEncoder().encodeToString(that));
+    }
+
     private void somethingToSequence(
       ISomething that,
       XMLStreamWriter writer) {
-      try {
-        writer.writeStartElement(
-          "interface");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getInterface().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "interface",
+        that.getInterface(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "type");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getType().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "type",
+        that.getType(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "range");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getRange().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "range",
+        that.getRange(),
+        writer,
+        this::writeStringifiedContent);
 
-      try {
-        writer.writeStartElement(
-          "void");
-        if (topLevel) {
-          writer.writeNamespace("xmlns", AAS_NAME_SPACE);
-          topLevel = false;
-        }
-        writer.writeCharacters(
-          that.getVoid().toString());
-        writer.writeEndElement();
-      } catch (Exception exception) {
-        throw new SerializeException("",exception.getMessage());
-      }
+      serializeElement(
+        "void",
+        that.getVoid(),
+        writer,
+        this::writeStringifiedContent);
     }
 
     @Override


### PR DESCRIPTION
We add generic ``parseArray``/``serializeArray`` helpers for JSON list (de)serialization, replacing per-property inlined boilerplate with shared calls.

We factor out a generic ``serializeElement`` helper for XML serialization, mirroring C# (#676). It unifies the previously duplicated ``writeStartElement``/``topLevel``/``writeEndElement``/ try-catch wrapping across all five property kinds (primitive, enumeration, interface, concrete class, list), which also tightens two branches' overly broad ``catch (Exception)`` down to ``catch (XMLStreamException)``, matching what the other three branches already did. A further ``serializeItems`` helper does the list-item iteration generically as well, so every list-typed property collapses to a single call instead of its own inlined ``for`` loop.

Rather than let the per-item and per-property content-writing logic live on as duplicated lambda text at each call site, we follow the shape of the merged C++ simplification (``SerializeBool``/ ``SerializeInt64``/etc. plus a ``serialize_{enum}`` per enumeration): we generate named methods once -- ``writeStringifiedContent`` (shared across ``boolean``/``long``/``double``/``String``, since ``Object.toString()`` is universal in Java, unlike C++), ``writeByteArrayContent``, and one ``write{Enum}Content`` per enumeration and reference them via ``this::...`` from both the standalone property and the list-item path.

A per-enum method is still needed there, even though the string conversion itself is shared (see below), because Java resolves that overload statically per concrete enum type, so a single generic wrapper cannot call it.

We add ``Stringification.mustToString``, a per-enum helper that returns the string representation of a literal or throws, and reuse it for JSON's ``{enum}ToJsonValue`` and for XML's per-enum content writer, removing three separate copies of the same ``Optional``-or-throw check.

We promote the ``_Result<T>`` class -- previously defined independently, and near-identically, in both ``Jsonization.java`` and ``Xmlization.java`` -- to a single shared ``Reporting.Result<T>``, since ``Reporting`` is already imported by both.

Finally, on the JSON side, we factor the byte-array-to-``JsonNode`` conversion (``Base64``-encode, then wrap in a text node) into a ``bytesToJsonNode`` method on ``_Transformer``, mirroring the existing ``toJsonNode`` for ``Long``.