### PR TITLE
Simplify JSON, XML de/serialization in TypeScript

### DIFF
--- a/aas_core_codegen/typescript/lib/_generate_jsonization.py
+++ b/aas_core_codegen/typescript/lib/_generate_jsonization.py
@@ -67,6 +67,105 @@ function parseArray<T>(
     )
 
 
+def _generate_check_model_type() -> Stripped:
+    """Generate the generic helper to check a parsed ``modelType`` property."""
+    return Stripped(
+        f"""\
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+{I}modelType: string | null,
+{I}expected: string
+): DeserializationError | null {{
+{I}if (modelType === null) {{
+{II}return new DeserializationError(
+{III}"The required property 'modelType' is missing"
+{II});
+{I}}}
+{I}if (modelType != expected) {{
+{II}return new DeserializationError(
+{III}`Expected model type '${{expected}}', ` +
+{III}`but got: ${{modelType}}`
+{II});
+{I}}}
+
+{I}return null;
+}}"""
+    )
+
+
+def _generate_check_is_json_object() -> Stripped:
+    """Generate the generic helper to check that a JSON-able is a JSON object."""
+    return Stripped(
+        f"""\
+/**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {{
+{I}if (jsonable === null) {{
+{II}return new DeserializationError(
+{III}"Expected a JSON object, but got null"
+{II});
+{I}}}
+{I}if (Array.isArray(jsonable)) {{
+{II}return new DeserializationError(
+{III}"Expected a JSON object, but got a JSON array"
+{II});
+{I}}}
+{I}if (typeof jsonable !== "object") {{
+{II}return new DeserializationError(
+{III}`Expected a JSON object, but got: ${{typeof jsonable}}`
+{II});
+{I}}}
+
+{I}return null;
+}}"""
+    )
+
+
+def _generate_check_is_iterable() -> Stripped:
+    """Generate the generic helper to check that a JSON-able is an iterable."""
+    return Stripped(
+        f"""\
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {{
+{I}if (jsonable === null) {{
+{II}return new DeserializationError(
+{III}"Expected an iterable, but got null"
+{II});
+{I}}}
+{I}if (typeof jsonable !== "object") {{
+{II}return new DeserializationError(
+{III}`Expected an iterable, but got: ${{typeof jsonable}}`
+{II});
+{I}}}
+{I}if (typeof jsonable[Symbol.iterator] !== "function") {{
+{II}return new DeserializationError(
+{III}"Expected an iterable with iterator function, " +
+{IIII}`but got iterator of type: ${{typeof jsonable[Symbol.iterator]}}`
+{II});
+{I}}}
+
+{I}return null;
+}}"""
+    )
+
+
 def _generate_bool_from_jsonable() -> Stripped:
     """Generate the function to decode a ``bool`` from a JSON-able."""
     return Stripped(
@@ -375,23 +474,19 @@ export function {function_name}(
 {I}AasTypes.{interface_name},
 {I}DeserializationError
 > {{
-{I}if (jsonable === null) {{
-{II}return newDeserializationError<AasTypes.{interface_name}>(
-{III}"Expected a JSON object, but got null"
+{I}const objectError = checkIsJsonObject(jsonable);
+{I}if (objectError !== null) {{
+{II}return new AasCommon.Either<
+{III}AasTypes.{interface_name},
+{III}DeserializationError
+{II}>(
+{III}null,
+{III}objectError
 {II});
 {I}}}
-{I}if (Array.isArray(jsonable)) {{
-{II}return newDeserializationError<AasTypes.{interface_name}>(
-{III}"Expected a JSON object, but got a JSON array"
-{II});
-{I}}}
-{I}if (typeof jsonable !== "object") {{
-{II}return newDeserializationError<AasTypes.{interface_name}>(
-{III}`Expected a JSON object, but got: ${{typeof jsonable}}`
-{II});
-{I}}}
+{I}const jsonObject = <JsonObject>jsonable;
 
-{I}const modelType = jsonable["modelType"];
+{I}const modelType = jsonObject["modelType"];
 {I}if (modelType === undefined) {{
 {II}return newDeserializationError<AasTypes.{interface_name}>(
 {III}"The required property modelType is missing"
@@ -549,21 +644,9 @@ if (parsedOrError.error !== null) {{
 
             body = Stripped(
                 f"""\
-if (jsonable === null) {{
-{I}return new DeserializationError(
-{II}"Expected an iterable, but got null"
-{I});
-}}
-if (typeof jsonable !== "object") {{
-{I}return new DeserializationError(
-{II}`Expected an iterable, but got: ${{typeof jsonable}}`
-{I});
-}}
-if (typeof jsonable[Symbol.iterator] !== "function") {{
-{I}return new DeserializationError(
-{II}"Expected an iterable with iterator function, " +
-{III}`but got iterator of type: ${{typeof jsonable[Symbol.iterator]}}`
-{I});
+const iterableError = checkIsIterable(jsonable);
+if (iterableError !== null) {{
+{I}return iterableError;
 }}
 
 const iterable = <Iterable<JsonValue>>jsonable;
@@ -791,21 +874,17 @@ def _generate_concrete_class_from_jsonable(
     blocks = [
         Stripped(
             f"""\
-if (jsonable === null) {{
-{I}return newDeserializationError<AasTypes.{cls_name}>(
-{II}"Expected a JSON object, but got null"
+const objectError = checkIsJsonObject(jsonable);
+if (objectError !== null) {{
+{I}return new AasCommon.Either<
+{II}AasTypes.{cls_name},
+{II}DeserializationError
+{I}>(
+{II}null,
+{II}objectError
 {I});
 }}
-if (Array.isArray(jsonable)) {{
-{I}return newDeserializationError<AasTypes.{cls_name}>(
-{II}"Expected a JSON object, but got a JSON array"
-{I});
-}}
-if (typeof jsonable !== "object") {{
-{I}return newDeserializationError<AasTypes.{cls_name}>(
-{II}`Expected a JSON object, but got: ${{typeof jsonable}}`
-{I});
-}}"""
+const jsonObject = <JsonObject>jsonable;"""
         ),
         Stripped(f"const setter = new {setter_cls_name}();"),
     ]  # type: List[Stripped]
@@ -817,8 +896,8 @@ if (typeof jsonable !== "object") {{
     blocks.append(
         Stripped(
             f"""\
-for (const key in jsonable) {{
-{I}const jsonableValue = jsonable[key];
+for (const key in jsonObject) {{
+{I}const jsonableValue = jsonObject[key];
 {I}const setterMethod =
 {II}{map_name}.get(key);
 
@@ -833,7 +912,7 @@ for (const key in jsonable) {{
 {I}const error = setterMethod.call(setter, jsonableValue);
 {I}if (error !== null) {{
 {II}error.path.prepend(
-{III}new PropertySegment(<JsonObject>jsonable, key)
+{III}new PropertySegment(jsonObject, key)
 {II});
 {II}return new AasCommon.Either<
 {III}AasTypes.{cls_name},
@@ -884,18 +963,14 @@ if (setter.{prop_name} === null) {{
         blocks.append(
             Stripped(
                 f"""\
-if (setter.{prop_name} === null) {{
-{I}return newDeserializationError<
-{II}AasTypes.{cls_name}
+const modelTypeError = checkModelType(setter.{prop_name}, "{model_type}");
+if (modelTypeError !== null) {{
+{I}return new AasCommon.Either<
+{II}AasTypes.{cls_name},
+{II}DeserializationError
 {I}>(
-{II}"The required property 'modelType' is missing"
-{I});
-}} else if (setter.{prop_name} != "{model_type}") {{
-{I}return newDeserializationError<
-{II}AasTypes.{cls_name}
-{I}>(
-{II}"Expected model type '{model_type}', " +
-{II}`but got: ${{setter.{prop_name}}}`
+{II}null,
+{II}modelTypeError
 {I});
 }}"""
             )
@@ -1487,6 +1562,9 @@ function newDeserializationError<T>(
 {I});
 }}"""
         ),
+        _generate_check_is_json_object(),
+        _generate_check_model_type(),
+        _generate_check_is_iterable(),
         _generate_parse_array(),
         _generate_bool_from_jsonable(),
         _generate_int_from_jsonable(),

--- a/aas_core_codegen/typescript/lib/_generate_xmlization.py
+++ b/aas_core_codegen/typescript/lib/_generate_xmlization.py
@@ -465,7 +465,7 @@ if ({var_name} !== null) {{
 
 const propertyCloseError = consumeCloseTag(
 {I}cursor,
-{I}localNameOfTag(propertyStartTag.tag)
+{I}propertyLocalName
 );
 if (propertyCloseError !== null) {{
 {I}propertyError = propertyCloseError;
@@ -598,38 +598,23 @@ function {function_name}(
 ): AasCommon.Either<AasTypes.{cls_name}, DeserializationError> {{
 {I}{indent_but_first_line(declarations, I)}
 
+{I}const className = AasTypes.{cls_name}.name;
+
 {I}cursor.skipIgnorable();
 {I}// eslint-disable-next-line no-constant-condition
 {I}while (true) {{
-{II}const token = cursor.current();
-{II}if (token === null) {{
-{III}return newDeserializationError<AasTypes.{cls_name}>(
-{IIII}`Unexpected end of token stream while parsing {cls_name}`
-{III});
-{II}}}
-
-{II}if (token instanceof CloseTagToken) {{
+{II}const nextTagOrError = nextPropertyOpenTag(cursor, className);
+{II}if (nextTagOrError === null) {{
 {III}break;
 {II}}}
-
-{II}if (!(token instanceof OpenTagToken)) {{
-{III}return newDeserializationError<AasTypes.{cls_name}>(
-{IIII}"Expected an XML property start element or the closing element of " +
-{IIII}`{cls_name}, but got token kind: ${{token.kind}}`
-{III});
-{II}}}
-
-{II}const namespaceError = checkExpectedOpenTagNamespace(token);
-{II}if (namespaceError !== null) {{
+{II}if (nextTagOrError instanceof DeserializationError) {{
 {III}return new AasCommon.Either<AasTypes.{cls_name}, DeserializationError>(
 {IIII}null,
-{IIII}namespaceError
+{IIII}nextTagOrError
 {III});
 {II}}}
 
-{II}const propertyStartTag = token;
-{II}const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-{II}cursor.advance();
+{II}const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
 {II}let propertyError: DeserializationError | null = null;
 {II}switch (propertyLocalName) {{
@@ -787,38 +772,27 @@ def _generate_serialize_atomic_element(
     access_expr: Stripped,
 ) -> Stripped:
     """
-    Generate the statements to write an atomic value wrapped in an element.
+    Generate the statement to write an atomic value wrapped in an element.
 
     This is used both for a single atomic property and for an atomic item of
     a list or a tuple, where ``element_name_literal`` is either the property's
     own XML name or a fixed item element name (*e.g.*, ``"v"`` or ``"v1"``).
     """
     return Stripped(
-        f"""\
-parts.push(openTag({element_name_literal}));
-parts.push({serialize_function}({access_expr}));
-parts.push(closeTag({element_name_literal}));"""
+        f"writeVElement(parts, {element_name_literal}, "
+        f"{serialize_function}({access_expr}));"
     )
 
 
-def _generate_serialize_class_element(
-    serialized_var: Identifier,
-    access_expr: Stripped,
-) -> Stripped:
+def _generate_serialize_class_element(access_expr: Stripped) -> Stripped:
     """
-    Generate the statements to write a class instance using its own element tag.
+    Generate the statement to write a class instance using its own element tag.
 
     This is used whenever the runtime type of the value is not statically known
     to be a concrete class without descendants (*i.e.*, for polymorphic
     properties, and for every item of a list or a tuple of class instances).
     """
-    return Stripped(
-        f"""\
-const {serialized_var} = this.transform({access_expr});
-parts.push(openTag({serialized_var}.localName));
-parts.push({serialized_var}.innerXml);
-parts.push(closeTag({serialized_var}.localName));"""
-    )
+    return Stripped(f"writeClassElement(parts, this.transform({access_expr}));")
 
 
 def _generate_serialize_block_for_property(
@@ -840,13 +814,13 @@ def _generate_serialize_block_for_property(
             (intermediate.AbstractClass, intermediate.ConcreteClass),
         ):
             our_type = type_anno.our_type
-            serialized_var = typescript_naming.variable_name(
-                Identifier(f"serialized_{prop.name}")
-            )
             if (
                 isinstance(our_type, intermediate.ConcreteClass)
                 and len(our_type.concrete_descendants) == 0
             ):
+                serialized_var = typescript_naming.variable_name(
+                    Identifier(f"serialized_{prop.name}")
+                )
                 body = Stripped(
                     f"""\
 const {serialized_var} = this.transform({access_expr});
@@ -859,9 +833,7 @@ parts.push(closeTag({xml_name_literal}));"""
                     f"""\
 parts.push(openTag({xml_name_literal}));
 {indent_but_first_line(
-    _generate_serialize_class_element(
-        serialized_var=serialized_var, access_expr=access_expr
-    ),
+    _generate_serialize_class_element(access_expr=access_expr),
     I,
 )}
 parts.push(closeTag({xml_name_literal}));"""
@@ -912,18 +884,13 @@ parts.push(closeTag({xml_name_literal}));"""
             (intermediate.AbstractClass, intermediate.ConcreteClass),
         ):
             item_var = typescript_naming.variable_name(Identifier(f"item_{prop.name}"))
-            serialized_item_var = typescript_naming.variable_name(
-                Identifier(f"serialized_{prop.name}_item")
-            )
 
             body = Stripped(
                 f"""\
 parts.push(openTag({xml_name_literal}));
 for (const {item_var} of {access_expr}) {{
 {I}{indent_but_first_line(
-    _generate_serialize_class_element(
-        serialized_var=serialized_item_var, access_expr=Stripped(item_var)
-    ),
+    _generate_serialize_class_element(access_expr=Stripped(item_var)),
     I,
 )}
 }}
@@ -1443,6 +1410,47 @@ function checkExpectedOpenTagNamespace(
 {I}return null;
 }}
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+{I}cursor: XmlCursor,
+{I}className: string
+): OpenTagToken | DeserializationError | null {{
+{I}const token = cursor.current();
+{I}if (token === null) {{
+{II}return new DeserializationError(
+{III}`Unexpected end of token stream while parsing ${{className}}`
+{II});
+{I}}}
+
+{I}if (token instanceof CloseTagToken) {{
+{II}return null;
+{I}}}
+
+{I}if (!(token instanceof OpenTagToken)) {{
+{II}return new DeserializationError(
+{III}"Expected an XML property start element or the closing element of " +
+{III}`${{className}}, but got token kind: ${{token.kind}}`
+{II});
+{I}}}
+
+{I}const namespaceError = checkExpectedOpenTagNamespace(token);
+{I}if (namespaceError !== null) {{
+{II}return namespaceError;
+{I}}}
+
+{I}cursor.advance();
+{I}return token;
+}}
+
 function checkExpectedCloseTag(
 {I}closeTag: CloseTagToken,
 {I}expectedLocalName: string
@@ -1937,6 +1945,37 @@ function openTag(localName: string, withNamespace = false): string {{
 
 function closeTag(localName: string): string {{
 {I}return `</${{localName}}>`;
+}}
+
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+{I}parts: Array<string>,
+{I}localName: string,
+{I}content: string
+): void {{
+{I}parts.push(openTag(localName));
+{I}parts.push(content);
+{I}parts.push(closeTag(localName));
+}}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {{@link SerializedElement.localName}}.
+ */
+function writeClassElement(
+{I}parts: Array<string>,
+{I}serialized: SerializedElement
+): void {{
+{I}parts.push(openTag(serialized.localName));
+{I}parts.push(serialized.innerXml);
+{I}parts.push(closeTag(serialized.localName));
 }}
 
 function escapeXmlText(text: string): string {{

--- a/dev/live_tests/live_test_typescript.py
+++ b/dev/live_tests/live_test_typescript.py
@@ -281,7 +281,7 @@ def main() -> int:
     "@typescript-eslint/no-unused-vars": [
       "error",
       {
-        "varsIgnorePattern": "^(_|Aas.*|.*FromJsonable|.*FromXmlElement|parse.*|serialize.*)$",
+        "varsIgnorePattern": "^(_|Aas.*|.*FromJsonable|.*FromXmlElement|parse.*|serialize.*|check.*|write.*|next.*)$",
         // NOTE (mristin):
         // We do not flag unused function/method parameters. Some
         // meta-model-defined functions (*e.g.*, a ``@verification`` function

--- a/dev/test_data/main/typescript/expected/aas_core_meta.v3/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/aas_core_meta.v3/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -333,23 +414,19 @@ export function hasSemanticsFromJsonable(
   AasTypes.IHasSemantics,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IHasSemantics>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IHasSemantics,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IHasSemantics>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IHasSemantics>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IHasSemantics>(
       "The required property modelType is missing"
@@ -418,21 +495,9 @@ class SetterForExtension {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -518,21 +583,9 @@ class SetterForExtension {
   setRefersToFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -564,26 +617,22 @@ export function extensionFromJsonable(
   AasTypes.Extension,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Extension>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Extension,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Extension>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Extension>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForExtension();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_EXTENSION.get(key);
 
@@ -598,7 +647,7 @@ export function extensionFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Extension,
@@ -647,23 +696,19 @@ export function hasExtensionsFromJsonable(
   AasTypes.IHasExtensions,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IHasExtensions>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IHasExtensions,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IHasExtensions>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IHasExtensions>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IHasExtensions>(
       "The required property modelType is missing"
@@ -699,23 +744,19 @@ export function referableFromJsonable(
   AasTypes.IReferable,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IReferable>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IReferable,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IReferable>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IReferable>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IReferable>(
       "The required property modelType is missing"
@@ -751,23 +792,19 @@ export function identifiableFromJsonable(
   AasTypes.IIdentifiable,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IIdentifiable>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IIdentifiable,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IIdentifiable>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IIdentifiable>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IIdentifiable>(
       "The required property modelType is missing"
@@ -833,23 +870,19 @@ export function hasKindFromJsonable(
   AasTypes.IHasKind,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IHasKind>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IHasKind,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IHasKind>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IHasKind>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IHasKind>(
       "The required property modelType is missing"
@@ -885,23 +918,19 @@ export function hasDataSpecificationFromJsonable(
   AasTypes.IHasDataSpecification,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IHasDataSpecification>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IHasDataSpecification,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IHasDataSpecification>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IHasDataSpecification>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IHasDataSpecification>(
       "The required property modelType is missing"
@@ -948,21 +977,9 @@ class SetterForAdministrativeInformation {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -1074,26 +1091,22 @@ export function administrativeInformationFromJsonable(
   AasTypes.AdministrativeInformation,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.AdministrativeInformation>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AdministrativeInformation,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.AdministrativeInformation>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.AdministrativeInformation>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForAdministrativeInformation();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_ADMINISTRATIVE_INFORMATION.get(key);
 
@@ -1108,7 +1121,7 @@ export function administrativeInformationFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.AdministrativeInformation,
@@ -1148,23 +1161,19 @@ export function qualifiableFromJsonable(
   AasTypes.IQualifiable,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IQualifiable>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IQualifiable,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IQualifiable>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IQualifiable>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IQualifiable>(
       "The required property modelType is missing"
@@ -1265,21 +1274,9 @@ class SetterForQualifier {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -1411,26 +1408,22 @@ export function qualifierFromJsonable(
   AasTypes.Qualifier,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Qualifier>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Qualifier,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Qualifier>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Qualifier>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForQualifier();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_QUALIFIER.get(key);
 
@@ -1445,7 +1438,7 @@ export function qualifierFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Qualifier,
@@ -1529,21 +1522,9 @@ class SetterForAssetAdministrationShell {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -1609,21 +1590,9 @@ class SetterForAssetAdministrationShell {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -1649,21 +1618,9 @@ class SetterForAssetAdministrationShell {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -1729,21 +1686,9 @@ class SetterForAssetAdministrationShell {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -1809,21 +1754,9 @@ class SetterForAssetAdministrationShell {
   setSubmodelsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -1877,26 +1810,22 @@ export function assetAdministrationShellFromJsonable(
   AasTypes.AssetAdministrationShell,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.AssetAdministrationShell>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AssetAdministrationShell,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.AssetAdministrationShell>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.AssetAdministrationShell>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForAssetAdministrationShell();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_ASSET_ADMINISTRATION_SHELL.get(key);
 
@@ -1911,7 +1840,7 @@ export function assetAdministrationShellFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.AssetAdministrationShell,
@@ -1939,18 +1868,14 @@ export function assetAdministrationShellFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.AssetAdministrationShell
+  const modelTypeError = checkModelType(setter.modelType, "AssetAdministrationShell");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AssetAdministrationShell,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "AssetAdministrationShell") {
-    return newDeserializationError<
-      AasTypes.AssetAdministrationShell
-    >(
-      "Expected model type 'AssetAdministrationShell', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -2039,21 +1964,9 @@ class SetterForAssetInformation {
   setSpecificAssetIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2125,26 +2038,22 @@ export function assetInformationFromJsonable(
   AasTypes.AssetInformation,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.AssetInformation>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AssetInformation,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.AssetInformation>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.AssetInformation>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForAssetInformation();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_ASSET_INFORMATION.get(key);
 
@@ -2159,7 +2068,7 @@ export function assetInformationFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.AssetInformation,
@@ -2258,26 +2167,22 @@ export function resourceFromJsonable(
   AasTypes.Resource,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Resource>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Resource,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Resource>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Resource>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForResource();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_RESOURCE.get(key);
 
@@ -2292,7 +2197,7 @@ export function resourceFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Resource,
@@ -2398,21 +2303,9 @@ class SetterForSpecificAssetId {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2504,26 +2397,22 @@ export function specificAssetIdFromJsonable(
   AasTypes.SpecificAssetId,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.SpecificAssetId>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.SpecificAssetId,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.SpecificAssetId>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.SpecificAssetId>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSpecificAssetId();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SPECIFIC_ASSET_ID.get(key);
 
@@ -2538,7 +2427,7 @@ export function specificAssetIdFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.SpecificAssetId,
@@ -2624,21 +2513,9 @@ class SetterForSubmodel {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2704,21 +2581,9 @@ class SetterForSubmodel {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2744,21 +2609,9 @@ class SetterForSubmodel {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2864,21 +2717,9 @@ class SetterForSubmodel {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2904,21 +2745,9 @@ class SetterForSubmodel {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2944,21 +2773,9 @@ class SetterForSubmodel {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -2984,21 +2801,9 @@ class SetterForSubmodel {
   setSubmodelElementsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3052,26 +2857,22 @@ export function submodelFromJsonable(
   AasTypes.Submodel,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Submodel>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Submodel,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Submodel>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Submodel>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSubmodel();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SUBMODEL.get(key);
 
@@ -3086,7 +2887,7 @@ export function submodelFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Submodel,
@@ -3106,18 +2907,14 @@ export function submodelFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Submodel
+  const modelTypeError = checkModelType(setter.modelType, "Submodel");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Submodel,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Submodel") {
-    return newDeserializationError<
-      AasTypes.Submodel
-    >(
-      "Expected model type 'Submodel', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -3157,23 +2954,19 @@ export function submodelElementFromJsonable(
   AasTypes.ISubmodelElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.ISubmodelElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ISubmodelElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.ISubmodelElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.ISubmodelElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.ISubmodelElement>(
       "The required property modelType is missing"
@@ -3209,23 +3002,19 @@ export function relationshipElementFromJsonable(
   AasTypes.IRelationshipElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IRelationshipElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IRelationshipElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IRelationshipElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IRelationshipElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IRelationshipElement>(
       "The required property modelType is missing"
@@ -3287,21 +3076,9 @@ class SetterForRelationshipElement {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3367,21 +3144,9 @@ class SetterForRelationshipElement {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3407,21 +3172,9 @@ class SetterForRelationshipElement {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3467,21 +3220,9 @@ class SetterForRelationshipElement {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3507,21 +3248,9 @@ class SetterForRelationshipElement {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3547,21 +3276,9 @@ class SetterForRelationshipElement {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3662,26 +3379,22 @@ function relationshipElementFromJsonableWithoutDispatch(
   AasTypes.RelationshipElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.RelationshipElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.RelationshipElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.RelationshipElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.RelationshipElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForRelationshipElement();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_RELATIONSHIP_ELEMENT.get(key);
 
@@ -3696,7 +3409,7 @@ function relationshipElementFromJsonableWithoutDispatch(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.RelationshipElement,
@@ -3724,18 +3437,14 @@ function relationshipElementFromJsonableWithoutDispatch(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.RelationshipElement
+  const modelTypeError = checkModelType(setter.modelType, "RelationshipElement");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.RelationshipElement,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "RelationshipElement") {
-    return newDeserializationError<
-      AasTypes.RelationshipElement
-    >(
-      "Expected model type 'RelationshipElement', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -3835,21 +3544,9 @@ class SetterForSubmodelElementList {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3915,21 +3612,9 @@ class SetterForSubmodelElementList {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -3955,21 +3640,9 @@ class SetterForSubmodelElementList {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4015,21 +3688,9 @@ class SetterForSubmodelElementList {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4055,21 +3716,9 @@ class SetterForSubmodelElementList {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4095,21 +3744,9 @@ class SetterForSubmodelElementList {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4215,21 +3852,9 @@ class SetterForSubmodelElementList {
   setValueFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4283,26 +3908,22 @@ export function submodelElementListFromJsonable(
   AasTypes.SubmodelElementList,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.SubmodelElementList>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.SubmodelElementList,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.SubmodelElementList>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.SubmodelElementList>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSubmodelElementList();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SUBMODEL_ELEMENT_LIST.get(key);
 
@@ -4317,7 +3938,7 @@ export function submodelElementListFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.SubmodelElementList,
@@ -4337,18 +3958,14 @@ export function submodelElementListFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.SubmodelElementList
+  const modelTypeError = checkModelType(setter.modelType, "SubmodelElementList");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.SubmodelElementList,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "SubmodelElementList") {
-    return newDeserializationError<
-      AasTypes.SubmodelElementList
-    >(
-      "Expected model type 'SubmodelElementList', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -4413,21 +4030,9 @@ class SetterForSubmodelElementCollection {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4493,21 +4098,9 @@ class SetterForSubmodelElementCollection {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4533,21 +4126,9 @@ class SetterForSubmodelElementCollection {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4593,21 +4174,9 @@ class SetterForSubmodelElementCollection {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4633,21 +4202,9 @@ class SetterForSubmodelElementCollection {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4673,21 +4230,9 @@ class SetterForSubmodelElementCollection {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4713,21 +4258,9 @@ class SetterForSubmodelElementCollection {
   setValueFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -4781,26 +4314,22 @@ export function submodelElementCollectionFromJsonable(
   AasTypes.SubmodelElementCollection,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.SubmodelElementCollection>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.SubmodelElementCollection,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.SubmodelElementCollection>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.SubmodelElementCollection>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSubmodelElementCollection();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SUBMODEL_ELEMENT_COLLECTION.get(key);
 
@@ -4815,7 +4344,7 @@ export function submodelElementCollectionFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.SubmodelElementCollection,
@@ -4827,18 +4356,14 @@ export function submodelElementCollectionFromJsonable(
     }
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.SubmodelElementCollection
+  const modelTypeError = checkModelType(setter.modelType, "SubmodelElementCollection");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.SubmodelElementCollection,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "SubmodelElementCollection") {
-    return newDeserializationError<
-      AasTypes.SubmodelElementCollection
-    >(
-      "Expected model type 'SubmodelElementCollection', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -4875,23 +4400,19 @@ export function dataElementFromJsonable(
   AasTypes.IDataElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IDataElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IDataElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IDataElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IDataElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IDataElement>(
       "The required property modelType is missing"
@@ -4955,21 +4476,9 @@ class SetterForProperty {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5035,21 +4544,9 @@ class SetterForProperty {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5075,21 +4572,9 @@ class SetterForProperty {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5135,21 +4620,9 @@ class SetterForProperty {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5175,21 +4648,9 @@ class SetterForProperty {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5215,21 +4676,9 @@ class SetterForProperty {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5343,26 +4792,22 @@ export function propertyFromJsonable(
   AasTypes.Property,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Property>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Property,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Property>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Property>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForProperty();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_PROPERTY.get(key);
 
@@ -5377,7 +4822,7 @@ export function propertyFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Property,
@@ -5397,18 +4842,14 @@ export function propertyFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Property
+  const modelTypeError = checkModelType(setter.modelType, "Property");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Property,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Property") {
-    return newDeserializationError<
-      AasTypes.Property
-    >(
-      "Expected model type 'Property', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -5473,21 +4914,9 @@ class SetterForMultiLanguageProperty {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5553,21 +4982,9 @@ class SetterForMultiLanguageProperty {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5593,21 +5010,9 @@ class SetterForMultiLanguageProperty {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5653,21 +5058,9 @@ class SetterForMultiLanguageProperty {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5693,21 +5086,9 @@ class SetterForMultiLanguageProperty {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5733,21 +5114,9 @@ class SetterForMultiLanguageProperty {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5773,21 +5142,9 @@ class SetterForMultiLanguageProperty {
   setValueFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -5861,26 +5218,22 @@ export function multiLanguagePropertyFromJsonable(
   AasTypes.MultiLanguageProperty,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.MultiLanguageProperty>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.MultiLanguageProperty,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.MultiLanguageProperty>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.MultiLanguageProperty>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForMultiLanguageProperty();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_MULTI_LANGUAGE_PROPERTY.get(key);
 
@@ -5895,7 +5248,7 @@ export function multiLanguagePropertyFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.MultiLanguageProperty,
@@ -5907,18 +5260,14 @@ export function multiLanguagePropertyFromJsonable(
     }
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.MultiLanguageProperty
+  const modelTypeError = checkModelType(setter.modelType, "MultiLanguageProperty");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.MultiLanguageProperty,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "MultiLanguageProperty") {
-    return newDeserializationError<
-      AasTypes.MultiLanguageProperty
-    >(
-      "Expected model type 'MultiLanguageProperty', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -5984,21 +5333,9 @@ class SetterForRange {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6064,21 +5401,9 @@ class SetterForRange {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6104,21 +5429,9 @@ class SetterForRange {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6164,21 +5477,9 @@ class SetterForRange {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6204,21 +5505,9 @@ class SetterForRange {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6244,21 +5533,9 @@ class SetterForRange {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6372,26 +5649,22 @@ export function rangeFromJsonable(
   AasTypes.Range,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Range>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Range,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Range>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Range>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForRange();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_RANGE.get(key);
 
@@ -6406,7 +5679,7 @@ export function rangeFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Range,
@@ -6426,18 +5699,14 @@ export function rangeFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Range
+  const modelTypeError = checkModelType(setter.modelType, "Range");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Range,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Range") {
-    return newDeserializationError<
-      AasTypes.Range
-    >(
-      "Expected model type 'Range', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -6500,21 +5769,9 @@ class SetterForReferenceElement {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6580,21 +5837,9 @@ class SetterForReferenceElement {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6620,21 +5865,9 @@ class SetterForReferenceElement {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6680,21 +5913,9 @@ class SetterForReferenceElement {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6720,21 +5941,9 @@ class SetterForReferenceElement {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6760,21 +5969,9 @@ class SetterForReferenceElement {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -6848,26 +6045,22 @@ export function referenceElementFromJsonable(
   AasTypes.ReferenceElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.ReferenceElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ReferenceElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.ReferenceElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.ReferenceElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForReferenceElement();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_REFERENCE_ELEMENT.get(key);
 
@@ -6882,7 +6075,7 @@ export function referenceElementFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.ReferenceElement,
@@ -6894,18 +6087,14 @@ export function referenceElementFromJsonable(
     }
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.ReferenceElement
+  const modelTypeError = checkModelType(setter.modelType, "ReferenceElement");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ReferenceElement,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "ReferenceElement") {
-    return newDeserializationError<
-      AasTypes.ReferenceElement
-    >(
-      "Expected model type 'ReferenceElement', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -6968,21 +6157,9 @@ class SetterForBlob {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7048,21 +6225,9 @@ class SetterForBlob {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7088,21 +6253,9 @@ class SetterForBlob {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7148,21 +6301,9 @@ class SetterForBlob {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7188,21 +6329,9 @@ class SetterForBlob {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7228,21 +6357,9 @@ class SetterForBlob {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7336,26 +6453,22 @@ export function blobFromJsonable(
   AasTypes.Blob,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Blob>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Blob,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Blob>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Blob>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForBlob();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_BLOB.get(key);
 
@@ -7370,7 +6483,7 @@ export function blobFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Blob,
@@ -7390,18 +6503,14 @@ export function blobFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Blob
+  const modelTypeError = checkModelType(setter.modelType, "Blob");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Blob,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Blob") {
-    return newDeserializationError<
-      AasTypes.Blob
-    >(
-      "Expected model type 'Blob', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -7465,21 +6574,9 @@ class SetterForFile {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7545,21 +6642,9 @@ class SetterForFile {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7585,21 +6670,9 @@ class SetterForFile {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7645,21 +6718,9 @@ class SetterForFile {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7685,21 +6746,9 @@ class SetterForFile {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7725,21 +6774,9 @@ class SetterForFile {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -7833,26 +6870,22 @@ export function fileFromJsonable(
   AasTypes.File,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.File>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.File,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.File>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.File>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForFile();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_FILE.get(key);
 
@@ -7867,7 +6900,7 @@ export function fileFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.File,
@@ -7887,18 +6920,14 @@ export function fileFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.File
+  const modelTypeError = checkModelType(setter.modelType, "File");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.File,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "File") {
-    return newDeserializationError<
-      AasTypes.File
-    >(
-      "Expected model type 'File', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -7964,21 +6993,9 @@ class SetterForAnnotatedRelationshipElement {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8044,21 +7061,9 @@ class SetterForAnnotatedRelationshipElement {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8084,21 +7089,9 @@ class SetterForAnnotatedRelationshipElement {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8144,21 +7137,9 @@ class SetterForAnnotatedRelationshipElement {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8184,21 +7165,9 @@ class SetterForAnnotatedRelationshipElement {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8224,21 +7193,9 @@ class SetterForAnnotatedRelationshipElement {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8304,21 +7261,9 @@ class SetterForAnnotatedRelationshipElement {
   setAnnotationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8372,26 +7317,22 @@ export function annotatedRelationshipElementFromJsonable(
   AasTypes.AnnotatedRelationshipElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.AnnotatedRelationshipElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AnnotatedRelationshipElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.AnnotatedRelationshipElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.AnnotatedRelationshipElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForAnnotatedRelationshipElement();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_ANNOTATED_RELATIONSHIP_ELEMENT.get(key);
 
@@ -8406,7 +7347,7 @@ export function annotatedRelationshipElementFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.AnnotatedRelationshipElement,
@@ -8434,18 +7375,14 @@ export function annotatedRelationshipElementFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.AnnotatedRelationshipElement
+  const modelTypeError = checkModelType(setter.modelType, "AnnotatedRelationshipElement");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AnnotatedRelationshipElement,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "AnnotatedRelationshipElement") {
-    return newDeserializationError<
-      AasTypes.AnnotatedRelationshipElement
-    >(
-      "Expected model type 'AnnotatedRelationshipElement', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -8514,21 +7451,9 @@ class SetterForEntity {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8594,21 +7519,9 @@ class SetterForEntity {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8634,21 +7547,9 @@ class SetterForEntity {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8694,21 +7595,9 @@ class SetterForEntity {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8734,21 +7623,9 @@ class SetterForEntity {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8774,21 +7651,9 @@ class SetterForEntity {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8814,21 +7679,9 @@ class SetterForEntity {
   setStatementsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8894,21 +7747,9 @@ class SetterForEntity {
   setSpecificAssetIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -8962,26 +7803,22 @@ export function entityFromJsonable(
   AasTypes.Entity,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Entity>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Entity,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Entity>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Entity>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForEntity();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_ENTITY.get(key);
 
@@ -8996,7 +7833,7 @@ export function entityFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Entity,
@@ -9016,18 +7853,14 @@ export function entityFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Entity
+  const modelTypeError = checkModelType(setter.modelType, "Entity");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Entity,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Entity") {
-    return newDeserializationError<
-      AasTypes.Entity
-    >(
-      "Expected model type 'Entity', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -9340,26 +8173,22 @@ export function eventPayloadFromJsonable(
   AasTypes.EventPayload,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.EventPayload>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.EventPayload,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.EventPayload>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.EventPayload>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForEventPayload();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_EVENT_PAYLOAD.get(key);
 
@@ -9374,7 +8203,7 @@ export function eventPayloadFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.EventPayload,
@@ -9441,23 +8270,19 @@ export function eventElementFromJsonable(
   AasTypes.IEventElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IEventElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IEventElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IEventElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IEventElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IEventElement>(
       "The required property modelType is missing"
@@ -9531,21 +8356,9 @@ class SetterForBasicEventElement {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -9611,21 +8424,9 @@ class SetterForBasicEventElement {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -9651,21 +8452,9 @@ class SetterForBasicEventElement {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -9711,21 +8500,9 @@ class SetterForBasicEventElement {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -9751,21 +8528,9 @@ class SetterForBasicEventElement {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -9791,21 +8556,9 @@ class SetterForBasicEventElement {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10019,26 +8772,22 @@ export function basicEventElementFromJsonable(
   AasTypes.BasicEventElement,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.BasicEventElement>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.BasicEventElement,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.BasicEventElement>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.BasicEventElement>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForBasicEventElement();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_BASIC_EVENT_ELEMENT.get(key);
 
@@ -10053,7 +8802,7 @@ export function basicEventElementFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.BasicEventElement,
@@ -10089,18 +8838,14 @@ export function basicEventElementFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.BasicEventElement
+  const modelTypeError = checkModelType(setter.modelType, "BasicEventElement");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.BasicEventElement,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "BasicEventElement") {
-    return newDeserializationError<
-      AasTypes.BasicEventElement
-    >(
-      "Expected model type 'BasicEventElement', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -10172,21 +8917,9 @@ class SetterForOperation {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10252,21 +8985,9 @@ class SetterForOperation {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10292,21 +9013,9 @@ class SetterForOperation {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10352,21 +9061,9 @@ class SetterForOperation {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10392,21 +9089,9 @@ class SetterForOperation {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10432,21 +9117,9 @@ class SetterForOperation {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10472,21 +9145,9 @@ class SetterForOperation {
   setInputVariablesFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10512,21 +9173,9 @@ class SetterForOperation {
   setOutputVariablesFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10552,21 +9201,9 @@ class SetterForOperation {
   setInoutputVariablesFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10620,26 +9257,22 @@ export function operationFromJsonable(
   AasTypes.Operation,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Operation>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Operation,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Operation>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Operation>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForOperation();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_OPERATION.get(key);
 
@@ -10654,7 +9287,7 @@ export function operationFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Operation,
@@ -10666,18 +9299,14 @@ export function operationFromJsonable(
     }
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Operation
+  const modelTypeError = checkModelType(setter.modelType, "Operation");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Operation,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Operation") {
-    return newDeserializationError<
-      AasTypes.Operation
-    >(
-      "Expected model type 'Operation', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -10745,26 +9374,22 @@ export function operationVariableFromJsonable(
   AasTypes.OperationVariable,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.OperationVariable>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.OperationVariable,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.OperationVariable>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.OperationVariable>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForOperationVariable();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_OPERATION_VARIABLE.get(key);
 
@@ -10779,7 +9404,7 @@ export function operationVariableFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.OperationVariable,
@@ -10845,21 +9470,9 @@ class SetterForCapability {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10925,21 +9538,9 @@ class SetterForCapability {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -10965,21 +9566,9 @@ class SetterForCapability {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11025,21 +9614,9 @@ class SetterForCapability {
   setSupplementalSemanticIdsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11065,21 +9642,9 @@ class SetterForCapability {
   setQualifiersFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11105,21 +9670,9 @@ class SetterForCapability {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11173,26 +9726,22 @@ export function capabilityFromJsonable(
   AasTypes.Capability,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Capability>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Capability,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Capability>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Capability>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForCapability();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_CAPABILITY.get(key);
 
@@ -11207,7 +9756,7 @@ export function capabilityFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Capability,
@@ -11219,18 +9768,14 @@ export function capabilityFromJsonable(
     }
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Capability
+  const modelTypeError = checkModelType(setter.modelType, "Capability");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Capability,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Capability") {
-    return newDeserializationError<
-      AasTypes.Capability
-    >(
-      "Expected model type 'Capability', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -11288,21 +9833,9 @@ class SetterForConceptDescription {
   setExtensionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11368,21 +9901,9 @@ class SetterForConceptDescription {
   setDisplayNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11408,21 +9929,9 @@ class SetterForConceptDescription {
   setDescriptionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11488,21 +9997,9 @@ class SetterForConceptDescription {
   setEmbeddedDataSpecificationsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11528,21 +10025,9 @@ class SetterForConceptDescription {
   setIsCaseOfFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11596,26 +10081,22 @@ export function conceptDescriptionFromJsonable(
   AasTypes.ConceptDescription,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.ConceptDescription>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ConceptDescription,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.ConceptDescription>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.ConceptDescription>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForConceptDescription();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_CONCEPT_DESCRIPTION.get(key);
 
@@ -11630,7 +10111,7 @@ export function conceptDescriptionFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.ConceptDescription,
@@ -11650,18 +10131,14 @@ export function conceptDescriptionFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.ConceptDescription
+  const modelTypeError = checkModelType(setter.modelType, "ConceptDescription");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ConceptDescription,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "ConceptDescription") {
-    return newDeserializationError<
-      AasTypes.ConceptDescription
-    >(
-      "Expected model type 'ConceptDescription', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -11774,21 +10251,9 @@ class SetterForReference {
   setKeysFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -11820,26 +10285,22 @@ export function referenceFromJsonable(
   AasTypes.Reference,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Reference>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Reference,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Reference>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Reference>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForReference();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_REFERENCE.get(key);
 
@@ -11854,7 +10315,7 @@ export function referenceFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Reference,
@@ -11959,26 +10420,22 @@ export function keyFromJsonable(
   AasTypes.Key,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Key>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Key,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Key>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Key>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForKey();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_KEY.get(key);
 
@@ -11993,7 +10450,7 @@ export function keyFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Key,
@@ -12106,23 +10563,19 @@ export function abstractLangStringFromJsonable(
   AasTypes.IAbstractLangString,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IAbstractLangString>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IAbstractLangString,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IAbstractLangString>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IAbstractLangString>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IAbstractLangString>(
       "The required property modelType is missing"
@@ -12209,26 +10662,22 @@ export function langStringNameTypeFromJsonable(
   AasTypes.LangStringNameType,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.LangStringNameType>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.LangStringNameType,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.LangStringNameType>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.LangStringNameType>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForLangStringNameType();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_LANG_STRING_NAME_TYPE.get(key);
 
@@ -12243,7 +10692,7 @@ export function langStringNameTypeFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.LangStringNameType,
@@ -12347,26 +10796,22 @@ export function langStringTextTypeFromJsonable(
   AasTypes.LangStringTextType,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.LangStringTextType>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.LangStringTextType,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.LangStringTextType>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.LangStringTextType>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForLangStringTextType();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_LANG_STRING_TEXT_TYPE.get(key);
 
@@ -12381,7 +10826,7 @@ export function langStringTextTypeFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.LangStringTextType,
@@ -12441,21 +10886,9 @@ class SetterForEnvironment {
   setAssetAdministrationShellsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -12481,21 +10914,9 @@ class SetterForEnvironment {
   setSubmodelsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -12521,21 +10942,9 @@ class SetterForEnvironment {
   setConceptDescriptionsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -12567,26 +10976,22 @@ export function environmentFromJsonable(
   AasTypes.Environment,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Environment>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Environment,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Environment>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Environment>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForEnvironment();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_ENVIRONMENT.get(key);
 
@@ -12601,7 +11006,7 @@ export function environmentFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Environment,
@@ -12639,23 +11044,19 @@ export function dataSpecificationContentFromJsonable(
   AasTypes.IDataSpecificationContent,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IDataSpecificationContent>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IDataSpecificationContent,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IDataSpecificationContent>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IDataSpecificationContent>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IDataSpecificationContent>(
       "The required property modelType is missing"
@@ -12742,26 +11143,22 @@ export function embeddedDataSpecificationFromJsonable(
   AasTypes.EmbeddedDataSpecification,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.EmbeddedDataSpecification>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.EmbeddedDataSpecification,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.EmbeddedDataSpecification>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.EmbeddedDataSpecification>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForEmbeddedDataSpecification();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_EMBEDDED_DATA_SPECIFICATION.get(key);
 
@@ -12776,7 +11173,7 @@ export function embeddedDataSpecificationFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.EmbeddedDataSpecification,
@@ -12954,26 +11351,22 @@ export function levelTypeFromJsonable(
   AasTypes.LevelType,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.LevelType>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.LevelType,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.LevelType>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.LevelType>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForLevelType();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_LEVEL_TYPE.get(key);
 
@@ -12988,7 +11381,7 @@ export function levelTypeFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.LevelType,
@@ -13110,26 +11503,22 @@ export function valueReferencePairFromJsonable(
   AasTypes.ValueReferencePair,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.ValueReferencePair>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ValueReferencePair,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.ValueReferencePair>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.ValueReferencePair>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForValueReferencePair();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_VALUE_REFERENCE_PAIR.get(key);
 
@@ -13144,7 +11533,7 @@ export function valueReferencePairFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.ValueReferencePair,
@@ -13200,21 +11589,9 @@ class SetterForValueList {
   setValueReferencePairsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -13246,26 +11623,22 @@ export function valueListFromJsonable(
   AasTypes.ValueList,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.ValueList>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ValueList,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.ValueList>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.ValueList>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForValueList();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_VALUE_LIST.get(key);
 
@@ -13280,7 +11653,7 @@ export function valueListFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.ValueList,
@@ -13375,26 +11748,22 @@ export function langStringPreferredNameTypeIec61360FromJsonable(
   AasTypes.LangStringPreferredNameTypeIec61360,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.LangStringPreferredNameTypeIec61360>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.LangStringPreferredNameTypeIec61360,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.LangStringPreferredNameTypeIec61360>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.LangStringPreferredNameTypeIec61360>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForLangStringPreferredNameTypeIec61360();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_LANG_STRING_PREFERRED_NAME_TYPE_IEC_61360.get(key);
 
@@ -13409,7 +11778,7 @@ export function langStringPreferredNameTypeIec61360FromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.LangStringPreferredNameTypeIec61360,
@@ -13513,26 +11882,22 @@ export function langStringShortNameTypeIec61360FromJsonable(
   AasTypes.LangStringShortNameTypeIec61360,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.LangStringShortNameTypeIec61360>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.LangStringShortNameTypeIec61360,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.LangStringShortNameTypeIec61360>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.LangStringShortNameTypeIec61360>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForLangStringShortNameTypeIec61360();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_LANG_STRING_SHORT_NAME_TYPE_IEC_61360.get(key);
 
@@ -13547,7 +11912,7 @@ export function langStringShortNameTypeIec61360FromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.LangStringShortNameTypeIec61360,
@@ -13651,26 +12016,22 @@ export function langStringDefinitionTypeIec61360FromJsonable(
   AasTypes.LangStringDefinitionTypeIec61360,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.LangStringDefinitionTypeIec61360>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.LangStringDefinitionTypeIec61360,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.LangStringDefinitionTypeIec61360>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.LangStringDefinitionTypeIec61360>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForLangStringDefinitionTypeIec61360();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_LANG_STRING_DEFINITION_TYPE_IEC_61360.get(key);
 
@@ -13685,7 +12046,7 @@ export function langStringDefinitionTypeIec61360FromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.LangStringDefinitionTypeIec61360,
@@ -13766,21 +12127,9 @@ class SetterForDataSpecificationIec61360 {
   setPreferredNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -13806,21 +12155,9 @@ class SetterForDataSpecificationIec61360 {
   setShortNameFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -13946,21 +12283,9 @@ class SetterForDataSpecificationIec61360 {
   setDefinitionFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -14094,26 +12419,22 @@ export function dataSpecificationIec61360FromJsonable(
   AasTypes.DataSpecificationIec61360,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.DataSpecificationIec61360>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.DataSpecificationIec61360,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.DataSpecificationIec61360>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.DataSpecificationIec61360>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForDataSpecificationIec61360();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_DATA_SPECIFICATION_IEC_61360.get(key);
 
@@ -14128,7 +12449,7 @@ export function dataSpecificationIec61360FromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.DataSpecificationIec61360,
@@ -14148,18 +12469,14 @@ export function dataSpecificationIec61360FromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.DataSpecificationIec61360
+  const modelTypeError = checkModelType(setter.modelType, "DataSpecificationIec61360");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.DataSpecificationIec61360,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "DataSpecificationIec61360") {
-    return newDeserializationError<
-      AasTypes.DataSpecificationIec61360
-    >(
-      "Expected model type 'DataSpecificationIec61360', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 

--- a/dev/test_data/main/typescript/expected/aas_core_meta.v3/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/aas_core_meta.v3/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -884,38 +925,23 @@ function parseExtensionFromSequence(
   let theValue: string | null = null;
   let theRefersTo: Array<AasTypes.Reference> | null = null;
 
+  const className = AasTypes.Extension.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Extension>(
-        `Unexpected end of token stream while parsing Extension`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Extension>(
-        "Expected an XML property start element or the closing element of " +
-        `Extension, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Extension, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -937,7 +963,7 @@ function parseExtensionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -973,7 +999,7 @@ function parseExtensionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1004,7 +1030,7 @@ function parseExtensionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1035,7 +1061,7 @@ function parseExtensionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1066,7 +1092,7 @@ function parseExtensionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1102,7 +1128,7 @@ function parseExtensionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1169,38 +1195,23 @@ function parseAdministrativeInformationFromSequence(
   let theCreator: AasTypes.Reference | null = null;
   let theTemplateId: string | null = null;
 
+  const className = AasTypes.AdministrativeInformation.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.AdministrativeInformation>(
-        `Unexpected end of token stream while parsing AdministrativeInformation`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.AdministrativeInformation>(
-        "Expected an XML property start element or the closing element of " +
-        `AdministrativeInformation, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.AdministrativeInformation, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -1229,7 +1240,7 @@ function parseAdministrativeInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1260,7 +1271,7 @@ function parseAdministrativeInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1291,7 +1302,7 @@ function parseAdministrativeInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1320,7 +1331,7 @@ function parseAdministrativeInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1351,7 +1362,7 @@ function parseAdministrativeInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1415,38 +1426,23 @@ function parseQualifierFromSequence(
   let theValue: string | null = null;
   let theValueId: AasTypes.Reference | null = null;
 
+  const className = AasTypes.Qualifier.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Qualifier>(
-        `Unexpected end of token stream while parsing Qualifier`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Qualifier>(
-        "Expected an XML property start element or the closing element of " +
-        `Qualifier, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Qualifier, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -1468,7 +1464,7 @@ function parseQualifierFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1504,7 +1500,7 @@ function parseQualifierFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1535,7 +1531,7 @@ function parseQualifierFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1566,7 +1562,7 @@ function parseQualifierFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1597,7 +1593,7 @@ function parseQualifierFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1628,7 +1624,7 @@ function parseQualifierFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1657,7 +1653,7 @@ function parseQualifierFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1737,38 +1733,23 @@ function parseAssetAdministrationShellFromSequence(
   let theAssetInformation: AasTypes.AssetInformation | null = null;
   let theSubmodels: Array<AasTypes.Reference> | null = null;
 
+  const className = AasTypes.AssetAdministrationShell.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.AssetAdministrationShell>(
-        `Unexpected end of token stream while parsing AssetAdministrationShell`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.AssetAdministrationShell>(
-        "Expected an XML property start element or the closing element of " +
-        `AssetAdministrationShell, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.AssetAdministrationShell, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -1797,7 +1778,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1828,7 +1809,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1859,7 +1840,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1895,7 +1876,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1931,7 +1912,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1960,7 +1941,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1991,7 +1972,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2027,7 +2008,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2056,7 +2037,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2085,7 +2066,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2121,7 +2102,7 @@ function parseAssetAdministrationShellFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2199,38 +2180,23 @@ function parseAssetInformationFromSequence(
   let theAssetType: string | null = null;
   let theDefaultThumbnail: AasTypes.Resource | null = null;
 
+  const className = AasTypes.AssetInformation.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.AssetInformation>(
-        `Unexpected end of token stream while parsing AssetInformation`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.AssetInformation>(
-        "Expected an XML property start element or the closing element of " +
-        `AssetInformation, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.AssetInformation, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -2254,7 +2220,7 @@ function parseAssetInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2285,7 +2251,7 @@ function parseAssetInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2321,7 +2287,7 @@ function parseAssetInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2352,7 +2318,7 @@ function parseAssetInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2381,7 +2347,7 @@ function parseAssetInformationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2444,38 +2410,23 @@ function parseResourceFromSequence(
   let thePath: string | null = null;
   let theContentType: string | null = null;
 
+  const className = AasTypes.Resource.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Resource>(
-        `Unexpected end of token stream while parsing Resource`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Resource>(
-        "Expected an XML property start element or the closing element of " +
-        `Resource, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Resource, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -2499,7 +2450,7 @@ function parseResourceFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2530,7 +2481,7 @@ function parseResourceFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2593,38 +2544,23 @@ function parseSpecificAssetIdFromSequence(
   let theValue: string | null = null;
   let theExternalSubjectId: AasTypes.Reference | null = null;
 
+  const className = AasTypes.SpecificAssetId.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.SpecificAssetId>(
-        `Unexpected end of token stream while parsing SpecificAssetId`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.SpecificAssetId>(
-        "Expected an XML property start element or the closing element of " +
-        `SpecificAssetId, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.SpecificAssetId, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -2646,7 +2582,7 @@ function parseSpecificAssetIdFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2682,7 +2618,7 @@ function parseSpecificAssetIdFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2713,7 +2649,7 @@ function parseSpecificAssetIdFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2744,7 +2680,7 @@ function parseSpecificAssetIdFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2773,7 +2709,7 @@ function parseSpecificAssetIdFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2853,38 +2789,23 @@ function parseSubmodelFromSequence(
   let theEmbeddedDataSpecifications: Array<AasTypes.EmbeddedDataSpecification> | null = null;
   let theSubmodelElements: Array<AasTypes.ISubmodelElement> | null = null;
 
+  const className = AasTypes.Submodel.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Submodel>(
-        `Unexpected end of token stream while parsing Submodel`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Submodel>(
-        "Expected an XML property start element or the closing element of " +
-        `Submodel, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Submodel, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -2913,7 +2834,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2944,7 +2865,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -2975,7 +2896,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3011,7 +2932,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3047,7 +2968,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3076,7 +2997,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3107,7 +3028,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3138,7 +3059,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3167,7 +3088,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3203,7 +3124,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3239,7 +3160,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3275,7 +3196,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3307,7 +3228,7 @@ function parseSubmodelFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3387,38 +3308,23 @@ function parseRelationshipElementFromSequence(
   let theFirst: AasTypes.Reference | null = null;
   let theSecond: AasTypes.Reference | null = null;
 
+  const className = AasTypes.RelationshipElement.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.RelationshipElement>(
-        `Unexpected end of token stream while parsing RelationshipElement`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.RelationshipElement>(
-        "Expected an XML property start element or the closing element of " +
-        `RelationshipElement, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.RelationshipElement, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -3447,7 +3353,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3478,7 +3384,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3509,7 +3415,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3545,7 +3451,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3581,7 +3487,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3610,7 +3516,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3646,7 +3552,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3682,7 +3588,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3718,7 +3624,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3747,7 +3653,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3776,7 +3682,7 @@ function parseRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3863,38 +3769,23 @@ function parseSubmodelElementListFromSequence(
   let theValueTypeListElement: AasTypes.DataTypeDefXsd | null = null;
   let theValue: Array<AasTypes.ISubmodelElement> | null = null;
 
+  const className = AasTypes.SubmodelElementList.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.SubmodelElementList>(
-        `Unexpected end of token stream while parsing SubmodelElementList`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.SubmodelElementList>(
-        "Expected an XML property start element or the closing element of " +
-        `SubmodelElementList, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.SubmodelElementList, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -3923,7 +3814,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3954,7 +3845,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -3985,7 +3876,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4021,7 +3912,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4057,7 +3948,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4086,7 +3977,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4122,7 +4013,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4158,7 +4049,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4194,7 +4085,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4225,7 +4116,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4254,7 +4145,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4285,7 +4176,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4316,7 +4207,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4348,7 +4239,7 @@ function parseSubmodelElementListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4428,38 +4319,23 @@ function parseSubmodelElementCollectionFromSequence(
   let theEmbeddedDataSpecifications: Array<AasTypes.EmbeddedDataSpecification> | null = null;
   let theValue: Array<AasTypes.ISubmodelElement> | null = null;
 
+  const className = AasTypes.SubmodelElementCollection.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.SubmodelElementCollection>(
-        `Unexpected end of token stream while parsing SubmodelElementCollection`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.SubmodelElementCollection>(
-        "Expected an XML property start element or the closing element of " +
-        `SubmodelElementCollection, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.SubmodelElementCollection, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -4488,7 +4364,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4519,7 +4395,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4550,7 +4426,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4586,7 +4462,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4622,7 +4498,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4651,7 +4527,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4687,7 +4563,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4723,7 +4599,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4759,7 +4635,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4791,7 +4667,7 @@ function parseSubmodelElementCollectionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4865,38 +4741,23 @@ function parsePropertyFromSequence(
   let theValue: string | null = null;
   let theValueId: AasTypes.Reference | null = null;
 
+  const className = AasTypes.Property.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Property>(
-        `Unexpected end of token stream while parsing Property`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Property>(
-        "Expected an XML property start element or the closing element of " +
-        `Property, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Property, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -4925,7 +4786,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4956,7 +4817,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -4987,7 +4848,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5023,7 +4884,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5059,7 +4920,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5088,7 +4949,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5124,7 +4985,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5160,7 +5021,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5196,7 +5057,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5227,7 +5088,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5258,7 +5119,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5287,7 +5148,7 @@ function parsePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5366,38 +5227,23 @@ function parseMultiLanguagePropertyFromSequence(
   let theValue: Array<AasTypes.LangStringTextType> | null = null;
   let theValueId: AasTypes.Reference | null = null;
 
+  const className = AasTypes.MultiLanguageProperty.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.MultiLanguageProperty>(
-        `Unexpected end of token stream while parsing MultiLanguageProperty`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.MultiLanguageProperty>(
-        "Expected an XML property start element or the closing element of " +
-        `MultiLanguageProperty, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.MultiLanguageProperty, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -5426,7 +5272,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5457,7 +5303,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5488,7 +5334,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5524,7 +5370,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5560,7 +5406,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5589,7 +5435,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5625,7 +5471,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5661,7 +5507,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5697,7 +5543,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5733,7 +5579,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5762,7 +5608,7 @@ function parseMultiLanguagePropertyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5837,38 +5683,23 @@ function parseRangeFromSequence(
   let theMin: string | null = null;
   let theMax: string | null = null;
 
+  const className = AasTypes.Range.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Range>(
-        `Unexpected end of token stream while parsing Range`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Range>(
-        "Expected an XML property start element or the closing element of " +
-        `Range, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Range, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -5897,7 +5728,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5928,7 +5759,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5959,7 +5790,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -5995,7 +5826,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6031,7 +5862,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6060,7 +5891,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6096,7 +5927,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6132,7 +5963,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6168,7 +5999,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6199,7 +6030,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6230,7 +6061,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6261,7 +6092,7 @@ function parseRangeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6339,38 +6170,23 @@ function parseReferenceElementFromSequence(
   let theEmbeddedDataSpecifications: Array<AasTypes.EmbeddedDataSpecification> | null = null;
   let theValue: AasTypes.Reference | null = null;
 
+  const className = AasTypes.ReferenceElement.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.ReferenceElement>(
-        `Unexpected end of token stream while parsing ReferenceElement`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.ReferenceElement>(
-        "Expected an XML property start element or the closing element of " +
-        `ReferenceElement, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.ReferenceElement, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -6399,7 +6215,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6430,7 +6246,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6461,7 +6277,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6497,7 +6313,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6533,7 +6349,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6562,7 +6378,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6598,7 +6414,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6634,7 +6450,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6670,7 +6486,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6699,7 +6515,7 @@ function parseReferenceElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6772,38 +6588,23 @@ function parseBlobFromSequence(
   let theValue: Uint8Array | null = null;
   let theContentType: string | null = null;
 
+  const className = AasTypes.Blob.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Blob>(
-        `Unexpected end of token stream while parsing Blob`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Blob>(
-        "Expected an XML property start element or the closing element of " +
-        `Blob, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Blob, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -6832,7 +6633,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6863,7 +6664,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6894,7 +6695,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6930,7 +6731,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6966,7 +6767,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -6995,7 +6796,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7031,7 +6832,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7067,7 +6868,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7103,7 +6904,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7134,7 +6935,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7165,7 +6966,7 @@ function parseBlobFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7243,38 +7044,23 @@ function parseFileFromSequence(
   let theValue: string | null = null;
   let theContentType: string | null = null;
 
+  const className = AasTypes.File.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.File>(
-        `Unexpected end of token stream while parsing File`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.File>(
-        "Expected an XML property start element or the closing element of " +
-        `File, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.File, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -7303,7 +7089,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7334,7 +7120,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7365,7 +7151,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7401,7 +7187,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7437,7 +7223,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7466,7 +7252,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7502,7 +7288,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7538,7 +7324,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7574,7 +7360,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7605,7 +7391,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7636,7 +7422,7 @@ function parseFileFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7715,38 +7501,23 @@ function parseAnnotatedRelationshipElementFromSequence(
   let theSecond: AasTypes.Reference | null = null;
   let theAnnotations: Array<AasTypes.IDataElement> | null = null;
 
+  const className = AasTypes.AnnotatedRelationshipElement.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.AnnotatedRelationshipElement>(
-        `Unexpected end of token stream while parsing AnnotatedRelationshipElement`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.AnnotatedRelationshipElement>(
-        "Expected an XML property start element or the closing element of " +
-        `AnnotatedRelationshipElement, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.AnnotatedRelationshipElement, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -7775,7 +7546,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7806,7 +7577,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7837,7 +7608,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7873,7 +7644,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7909,7 +7680,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7938,7 +7709,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -7974,7 +7745,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8010,7 +7781,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8046,7 +7817,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8075,7 +7846,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8104,7 +7875,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8136,7 +7907,7 @@ function parseAnnotatedRelationshipElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8223,38 +7994,23 @@ function parseEntityFromSequence(
   let theGlobalAssetId: string | null = null;
   let theSpecificAssetIds: Array<AasTypes.SpecificAssetId> | null = null;
 
+  const className = AasTypes.Entity.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Entity>(
-        `Unexpected end of token stream while parsing Entity`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Entity>(
-        "Expected an XML property start element or the closing element of " +
-        `Entity, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Entity, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -8283,7 +8039,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8314,7 +8070,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8345,7 +8101,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8381,7 +8137,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8417,7 +8173,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8446,7 +8202,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8482,7 +8238,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8518,7 +8274,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8554,7 +8310,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8586,7 +8342,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8617,7 +8373,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8648,7 +8404,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8684,7 +8440,7 @@ function parseEntityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8761,38 +8517,23 @@ function parseEventPayloadFromSequence(
   let theTimeStamp: string | null = null;
   let thePayload: Uint8Array | null = null;
 
+  const className = AasTypes.EventPayload.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.EventPayload>(
-        `Unexpected end of token stream while parsing EventPayload`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.EventPayload>(
-        "Expected an XML property start element or the closing element of " +
-        `EventPayload, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.EventPayload, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -8814,7 +8555,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8843,7 +8584,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8872,7 +8613,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8901,7 +8642,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8932,7 +8673,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8961,7 +8702,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -8992,7 +8733,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9023,7 +8764,7 @@ function parseEventPayloadFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9116,38 +8857,23 @@ function parseBasicEventElementFromSequence(
   let theMinInterval: string | null = null;
   let theMaxInterval: string | null = null;
 
+  const className = AasTypes.BasicEventElement.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.BasicEventElement>(
-        `Unexpected end of token stream while parsing BasicEventElement`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.BasicEventElement>(
-        "Expected an XML property start element or the closing element of " +
-        `BasicEventElement, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.BasicEventElement, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -9176,7 +8902,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9207,7 +8933,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9238,7 +8964,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9274,7 +9000,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9310,7 +9036,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9339,7 +9065,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9375,7 +9101,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9411,7 +9137,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9447,7 +9173,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9476,7 +9202,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9507,7 +9233,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9538,7 +9264,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9569,7 +9295,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9598,7 +9324,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9629,7 +9355,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9660,7 +9386,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9691,7 +9417,7 @@ function parseBasicEventElementFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9788,38 +9514,23 @@ function parseOperationFromSequence(
   let theOutputVariables: Array<AasTypes.OperationVariable> | null = null;
   let theInoutputVariables: Array<AasTypes.OperationVariable> | null = null;
 
+  const className = AasTypes.Operation.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Operation>(
-        `Unexpected end of token stream while parsing Operation`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Operation>(
-        "Expected an XML property start element or the closing element of " +
-        `Operation, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Operation, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -9848,7 +9559,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9879,7 +9590,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9910,7 +9621,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9946,7 +9657,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -9982,7 +9693,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10011,7 +9722,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10047,7 +9758,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10083,7 +9794,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10119,7 +9830,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10155,7 +9866,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10191,7 +9902,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10227,7 +9938,7 @@ function parseOperationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10292,38 +10003,23 @@ function parseOperationVariableFromSequence(
 ): AasCommon.Either<AasTypes.OperationVariable, DeserializationError> {
   let theValue: AasTypes.ISubmodelElement | null = null;
 
+  const className = AasTypes.OperationVariable.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.OperationVariable>(
-        `Unexpected end of token stream while parsing OperationVariable`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.OperationVariable>(
-        "Expected an XML property start element or the closing element of " +
-        `OperationVariable, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.OperationVariable, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -10345,7 +10041,7 @@ function parseOperationVariableFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10411,38 +10107,23 @@ function parseCapabilityFromSequence(
   let theQualifiers: Array<AasTypes.Qualifier> | null = null;
   let theEmbeddedDataSpecifications: Array<AasTypes.EmbeddedDataSpecification> | null = null;
 
+  const className = AasTypes.Capability.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Capability>(
-        `Unexpected end of token stream while parsing Capability`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Capability>(
-        "Expected an XML property start element or the closing element of " +
-        `Capability, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Capability, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -10471,7 +10152,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10502,7 +10183,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10533,7 +10214,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10569,7 +10250,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10605,7 +10286,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10634,7 +10315,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10670,7 +10351,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10706,7 +10387,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10742,7 +10423,7 @@ function parseCapabilityFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10812,38 +10493,23 @@ function parseConceptDescriptionFromSequence(
   let theEmbeddedDataSpecifications: Array<AasTypes.EmbeddedDataSpecification> | null = null;
   let theIsCaseOf: Array<AasTypes.Reference> | null = null;
 
+  const className = AasTypes.ConceptDescription.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.ConceptDescription>(
-        `Unexpected end of token stream while parsing ConceptDescription`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.ConceptDescription>(
-        "Expected an XML property start element or the closing element of " +
-        `ConceptDescription, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.ConceptDescription, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -10872,7 +10538,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10903,7 +10569,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10934,7 +10600,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -10970,7 +10636,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11006,7 +10672,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11035,7 +10701,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11066,7 +10732,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11102,7 +10768,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11138,7 +10804,7 @@ function parseConceptDescriptionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11206,38 +10872,23 @@ function parseReferenceFromSequence(
   let theReferredSemanticId: AasTypes.Reference | null = null;
   let theKeys: Array<AasTypes.Key> | null = null;
 
+  const className = AasTypes.Reference.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Reference>(
-        `Unexpected end of token stream while parsing Reference`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Reference>(
-        "Expected an XML property start element or the closing element of " +
-        `Reference, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Reference, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -11261,7 +10912,7 @@ function parseReferenceFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11290,7 +10941,7 @@ function parseReferenceFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11326,7 +10977,7 @@ function parseReferenceFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11393,38 +11044,23 @@ function parseKeyFromSequence(
   let theType: AasTypes.KeyTypes | null = null;
   let theValue: string | null = null;
 
+  const className = AasTypes.Key.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Key>(
-        `Unexpected end of token stream while parsing Key`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Key>(
-        "Expected an XML property start element or the closing element of " +
-        `Key, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Key, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -11448,7 +11084,7 @@ function parseKeyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11479,7 +11115,7 @@ function parseKeyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11545,38 +11181,23 @@ function parseLangStringNameTypeFromSequence(
   let theLanguage: string | null = null;
   let theText: string | null = null;
 
+  const className = AasTypes.LangStringNameType.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.LangStringNameType>(
-        `Unexpected end of token stream while parsing LangStringNameType`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.LangStringNameType>(
-        "Expected an XML property start element or the closing element of " +
-        `LangStringNameType, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.LangStringNameType, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -11600,7 +11221,7 @@ function parseLangStringNameTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11631,7 +11252,7 @@ function parseLangStringNameTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11697,38 +11318,23 @@ function parseLangStringTextTypeFromSequence(
   let theLanguage: string | null = null;
   let theText: string | null = null;
 
+  const className = AasTypes.LangStringTextType.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.LangStringTextType>(
-        `Unexpected end of token stream while parsing LangStringTextType`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.LangStringTextType>(
-        "Expected an XML property start element or the closing element of " +
-        `LangStringTextType, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.LangStringTextType, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -11752,7 +11358,7 @@ function parseLangStringTextTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11783,7 +11389,7 @@ function parseLangStringTextTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11850,38 +11456,23 @@ function parseEnvironmentFromSequence(
   let theSubmodels: Array<AasTypes.Submodel> | null = null;
   let theConceptDescriptions: Array<AasTypes.ConceptDescription> | null = null;
 
+  const className = AasTypes.Environment.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Environment>(
-        `Unexpected end of token stream while parsing Environment`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Environment>(
-        "Expected an XML property start element or the closing element of " +
-        `Environment, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Environment, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -11910,7 +11501,7 @@ function parseEnvironmentFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11946,7 +11537,7 @@ function parseEnvironmentFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -11982,7 +11573,7 @@ function parseEnvironmentFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12039,38 +11630,23 @@ function parseEmbeddedDataSpecificationFromSequence(
   let theDataSpecification: AasTypes.Reference | null = null;
   let theDataSpecificationContent: AasTypes.IDataSpecificationContent | null = null;
 
+  const className = AasTypes.EmbeddedDataSpecification.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.EmbeddedDataSpecification>(
-        `Unexpected end of token stream while parsing EmbeddedDataSpecification`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.EmbeddedDataSpecification>(
-        "Expected an XML property start element or the closing element of " +
-        `EmbeddedDataSpecification, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.EmbeddedDataSpecification, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -12092,7 +11668,7 @@ function parseEmbeddedDataSpecificationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12121,7 +11697,7 @@ function parseEmbeddedDataSpecificationFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12189,38 +11765,23 @@ function parseLevelTypeFromSequence(
   let theTyp: boolean | null = null;
   let theMax: boolean | null = null;
 
+  const className = AasTypes.LevelType.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.LevelType>(
-        `Unexpected end of token stream while parsing LevelType`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.LevelType>(
-        "Expected an XML property start element or the closing element of " +
-        `LevelType, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.LevelType, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -12244,7 +11805,7 @@ function parseLevelTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12275,7 +11836,7 @@ function parseLevelTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12306,7 +11867,7 @@ function parseLevelTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12337,7 +11898,7 @@ function parseLevelTypeFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12417,38 +11978,23 @@ function parseValueReferencePairFromSequence(
   let theValue: string | null = null;
   let theValueId: AasTypes.Reference | null = null;
 
+  const className = AasTypes.ValueReferencePair.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.ValueReferencePair>(
-        `Unexpected end of token stream while parsing ValueReferencePair`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.ValueReferencePair>(
-        "Expected an XML property start element or the closing element of " +
-        `ValueReferencePair, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.ValueReferencePair, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -12472,7 +12018,7 @@ function parseValueReferencePairFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12501,7 +12047,7 @@ function parseValueReferencePairFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12566,38 +12112,23 @@ function parseValueListFromSequence(
 ): AasCommon.Either<AasTypes.ValueList, DeserializationError> {
   let theValueReferencePairs: Array<AasTypes.ValueReferencePair> | null = null;
 
+  const className = AasTypes.ValueList.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.ValueList>(
-        `Unexpected end of token stream while parsing ValueList`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.ValueList>(
-        "Expected an XML property start element or the closing element of " +
-        `ValueList, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.ValueList, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -12626,7 +12157,7 @@ function parseValueListFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12685,38 +12216,23 @@ function parseLangStringPreferredNameTypeIec61360FromSequence(
   let theLanguage: string | null = null;
   let theText: string | null = null;
 
+  const className = AasTypes.LangStringPreferredNameTypeIec61360.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.LangStringPreferredNameTypeIec61360>(
-        `Unexpected end of token stream while parsing LangStringPreferredNameTypeIec61360`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.LangStringPreferredNameTypeIec61360>(
-        "Expected an XML property start element or the closing element of " +
-        `LangStringPreferredNameTypeIec61360, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.LangStringPreferredNameTypeIec61360, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -12740,7 +12256,7 @@ function parseLangStringPreferredNameTypeIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12771,7 +12287,7 @@ function parseLangStringPreferredNameTypeIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12837,38 +12353,23 @@ function parseLangStringShortNameTypeIec61360FromSequence(
   let theLanguage: string | null = null;
   let theText: string | null = null;
 
+  const className = AasTypes.LangStringShortNameTypeIec61360.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.LangStringShortNameTypeIec61360>(
-        `Unexpected end of token stream while parsing LangStringShortNameTypeIec61360`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.LangStringShortNameTypeIec61360>(
-        "Expected an XML property start element or the closing element of " +
-        `LangStringShortNameTypeIec61360, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.LangStringShortNameTypeIec61360, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -12892,7 +12393,7 @@ function parseLangStringShortNameTypeIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12923,7 +12424,7 @@ function parseLangStringShortNameTypeIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -12989,38 +12490,23 @@ function parseLangStringDefinitionTypeIec61360FromSequence(
   let theLanguage: string | null = null;
   let theText: string | null = null;
 
+  const className = AasTypes.LangStringDefinitionTypeIec61360.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.LangStringDefinitionTypeIec61360>(
-        `Unexpected end of token stream while parsing LangStringDefinitionTypeIec61360`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.LangStringDefinitionTypeIec61360>(
-        "Expected an XML property start element or the closing element of " +
-        `LangStringDefinitionTypeIec61360, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.LangStringDefinitionTypeIec61360, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -13044,7 +12530,7 @@ function parseLangStringDefinitionTypeIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13075,7 +12561,7 @@ function parseLangStringDefinitionTypeIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13151,38 +12637,23 @@ function parseDataSpecificationIec61360FromSequence(
   let theValue: string | null = null;
   let theLevelType: AasTypes.LevelType | null = null;
 
+  const className = AasTypes.DataSpecificationIec61360.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.DataSpecificationIec61360>(
-        `Unexpected end of token stream while parsing DataSpecificationIec61360`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.DataSpecificationIec61360>(
-        "Expected an XML property start element or the closing element of " +
-        `DataSpecificationIec61360, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.DataSpecificationIec61360, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -13211,7 +12682,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13247,7 +12718,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13278,7 +12749,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13307,7 +12778,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13338,7 +12809,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13369,7 +12840,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13400,7 +12871,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13436,7 +12907,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13467,7 +12938,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13496,7 +12967,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13527,7 +12998,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -13556,7 +13027,7 @@ function parseDataSpecificationIec61360FromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -15353,6 +14824,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -15423,37 +14925,25 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
 
-  parts.push(openTag("name"));
-    parts.push(serializeStringText(that.name));
-    parts.push(closeTag("name"));
+  writeVElement(parts, "name", serializeStringText(that.name));
 
   if (that.valueType !== null) {
-      parts.push(openTag("valueType"));
-      parts.push(serializeDataTypeDefXsdText(that.valueType));
-      parts.push(closeTag("valueType"));
+      writeVElement(parts, "valueType", serializeDataTypeDefXsdText(that.valueType));
     }
 
   if (that.value !== null) {
-      parts.push(openTag("value"));
-      parts.push(serializeStringText(that.value));
-      parts.push(closeTag("value"));
+      writeVElement(parts, "value", serializeStringText(that.value));
     }
 
   if (that.refersTo !== null) {
       parts.push(openTag("refersTo"));
       for (const itemRefersTo of that.refersTo) {
-        const serializedRefersToItem = this.transform(itemRefersTo);
-        parts.push(openTag(serializedRefersToItem.localName));
-        parts.push(serializedRefersToItem.innerXml);
-        parts.push(closeTag(serializedRefersToItem.localName));
+        writeClassElement(parts, this.transform(itemRefersTo));
       }
       parts.push(closeTag("refersTo"));
     }
@@ -15478,24 +14968,17 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
 
   if (that.version !== null) {
-      parts.push(openTag("version"));
-      parts.push(serializeStringText(that.version));
-      parts.push(closeTag("version"));
+      writeVElement(parts, "version", serializeStringText(that.version));
     }
 
   if (that.revision !== null) {
-      parts.push(openTag("revision"));
-      parts.push(serializeStringText(that.revision));
-      parts.push(closeTag("revision"));
+      writeVElement(parts, "revision", serializeStringText(that.revision));
     }
 
   if (that.creator !== null) {
@@ -15506,9 +14989,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     }
 
   if (that.templateId !== null) {
-      parts.push(openTag("templateId"));
-      parts.push(serializeStringText(that.templateId));
-      parts.push(closeTag("templateId"));
+      writeVElement(parts, "templateId", serializeStringText(that.templateId));
     }
 
   return {
@@ -15538,32 +15019,21 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
 
   if (that.kind !== null) {
-      parts.push(openTag("kind"));
-      parts.push(serializeQualifierKindText(that.kind));
-      parts.push(closeTag("kind"));
+      writeVElement(parts, "kind", serializeQualifierKindText(that.kind));
     }
 
-  parts.push(openTag("type"));
-    parts.push(serializeStringText(that.type));
-    parts.push(closeTag("type"));
+  writeVElement(parts, "type", serializeStringText(that.type));
 
-  parts.push(openTag("valueType"));
-    parts.push(serializeDataTypeDefXsdText(that.valueType));
-    parts.push(closeTag("valueType"));
+  writeVElement(parts, "valueType", serializeDataTypeDefXsdText(that.valueType));
 
   if (that.value !== null) {
-      parts.push(openTag("value"));
-      parts.push(serializeStringText(that.value));
-      parts.push(closeTag("value"));
+      writeVElement(parts, "value", serializeStringText(that.value));
     }
 
   if (that.valueId !== null) {
@@ -15593,33 +15063,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -15627,10 +15087,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -15642,17 +15099,12 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
       parts.push(closeTag("administration"));
     }
 
-  parts.push(openTag("id"));
-    parts.push(serializeStringText(that.id));
-    parts.push(closeTag("id"));
+  writeVElement(parts, "id", serializeStringText(that.id));
 
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -15672,10 +15124,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.submodels !== null) {
       parts.push(openTag("submodels"));
       for (const itemSubmodels of that.submodels) {
-        const serializedSubmodelsItem = this.transform(itemSubmodels);
-        parts.push(openTag(serializedSubmodelsItem.localName));
-        parts.push(serializedSubmodelsItem.innerXml);
-        parts.push(closeTag(serializedSubmodelsItem.localName));
+        writeClassElement(parts, this.transform(itemSubmodels));
       }
       parts.push(closeTag("submodels"));
     }
@@ -15697,31 +15146,22 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("assetKind"));
-    parts.push(serializeAssetKindText(that.assetKind));
-    parts.push(closeTag("assetKind"));
+  writeVElement(parts, "assetKind", serializeAssetKindText(that.assetKind));
 
   if (that.globalAssetId !== null) {
-      parts.push(openTag("globalAssetId"));
-      parts.push(serializeStringText(that.globalAssetId));
-      parts.push(closeTag("globalAssetId"));
+      writeVElement(parts, "globalAssetId", serializeStringText(that.globalAssetId));
     }
 
   if (that.specificAssetIds !== null) {
       parts.push(openTag("specificAssetIds"));
       for (const itemSpecificAssetIds of that.specificAssetIds) {
-        const serializedSpecificAssetIdsItem = this.transform(itemSpecificAssetIds);
-        parts.push(openTag(serializedSpecificAssetIdsItem.localName));
-        parts.push(serializedSpecificAssetIdsItem.innerXml);
-        parts.push(closeTag(serializedSpecificAssetIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSpecificAssetIds));
       }
       parts.push(closeTag("specificAssetIds"));
     }
 
   if (that.assetType !== null) {
-      parts.push(openTag("assetType"));
-      parts.push(serializeStringText(that.assetType));
-      parts.push(closeTag("assetType"));
+      writeVElement(parts, "assetType", serializeStringText(that.assetType));
     }
 
   if (that.defaultThumbnail !== null) {
@@ -15748,14 +15188,10 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("path"));
-    parts.push(serializeStringText(that.path));
-    parts.push(closeTag("path"));
+  writeVElement(parts, "path", serializeStringText(that.path));
 
   if (that.contentType !== null) {
-      parts.push(openTag("contentType"));
-      parts.push(serializeStringText(that.contentType));
-      parts.push(closeTag("contentType"));
+      writeVElement(parts, "contentType", serializeStringText(that.contentType));
     }
 
   return {
@@ -15785,21 +15221,14 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
 
-  parts.push(openTag("name"));
-    parts.push(serializeStringText(that.name));
-    parts.push(closeTag("name"));
+  writeVElement(parts, "name", serializeStringText(that.name));
 
-  parts.push(openTag("value"));
-    parts.push(serializeStringText(that.value));
-    parts.push(closeTag("value"));
+  writeVElement(parts, "value", serializeStringText(that.value));
 
   if (that.externalSubjectId !== null) {
       const serializedExternalSubjectId = this.transform(that.externalSubjectId);
@@ -15828,33 +15257,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -15862,10 +15281,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -15877,14 +15293,10 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
       parts.push(closeTag("administration"));
     }
 
-  parts.push(openTag("id"));
-    parts.push(serializeStringText(that.id));
-    parts.push(closeTag("id"));
+  writeVElement(parts, "id", serializeStringText(that.id));
 
   if (that.kind !== null) {
-      parts.push(openTag("kind"));
-      parts.push(serializeModellingKindText(that.kind));
-      parts.push(closeTag("kind"));
+      writeVElement(parts, "kind", serializeModellingKindText(that.kind));
     }
 
   if (that.semanticId !== null) {
@@ -15897,10 +15309,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -15908,10 +15317,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -15919,10 +15325,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -15930,10 +15333,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.submodelElements !== null) {
       parts.push(openTag("submodelElements"));
       for (const itemSubmodelElements of that.submodelElements) {
-        const serializedSubmodelElementsItem = this.transform(itemSubmodelElements);
-        parts.push(openTag(serializedSubmodelElementsItem.localName));
-        parts.push(serializedSubmodelElementsItem.innerXml);
-        parts.push(closeTag(serializedSubmodelElementsItem.localName));
+        writeClassElement(parts, this.transform(itemSubmodelElements));
       }
       parts.push(closeTag("submodelElements"));
     }
@@ -15958,33 +15358,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -15992,10 +15382,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16010,10 +15397,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16021,10 +15405,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16032,10 +15413,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -16070,33 +15448,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16104,10 +15472,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16122,10 +15487,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16133,10 +15495,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16144,18 +15503,13 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
 
   if (that.orderRelevant !== null) {
-      parts.push(openTag("orderRelevant"));
-      parts.push(serializeBooleanText(that.orderRelevant));
-      parts.push(closeTag("orderRelevant"));
+      writeVElement(parts, "orderRelevant", serializeBooleanText(that.orderRelevant));
     }
 
   if (that.semanticIdListElement !== null) {
@@ -16165,23 +15519,16 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
       parts.push(closeTag("semanticIdListElement"));
     }
 
-  parts.push(openTag("typeValueListElement"));
-    parts.push(serializeAasSubmodelElementsText(that.typeValueListElement));
-    parts.push(closeTag("typeValueListElement"));
+  writeVElement(parts, "typeValueListElement", serializeAasSubmodelElementsText(that.typeValueListElement));
 
   if (that.valueTypeListElement !== null) {
-      parts.push(openTag("valueTypeListElement"));
-      parts.push(serializeDataTypeDefXsdText(that.valueTypeListElement));
-      parts.push(closeTag("valueTypeListElement"));
+      writeVElement(parts, "valueTypeListElement", serializeDataTypeDefXsdText(that.valueTypeListElement));
     }
 
   if (that.value !== null) {
       parts.push(openTag("value"));
       for (const itemValue of that.value) {
-        const serializedValueItem = this.transform(itemValue);
-        parts.push(openTag(serializedValueItem.localName));
-        parts.push(serializedValueItem.innerXml);
-        parts.push(closeTag(serializedValueItem.localName));
+        writeClassElement(parts, this.transform(itemValue));
       }
       parts.push(closeTag("value"));
     }
@@ -16206,33 +15553,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16240,10 +15577,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16258,10 +15592,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16269,10 +15600,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16280,10 +15608,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -16291,10 +15616,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.value !== null) {
       parts.push(openTag("value"));
       for (const itemValue of that.value) {
-        const serializedValueItem = this.transform(itemValue);
-        parts.push(openTag(serializedValueItem.localName));
-        parts.push(serializedValueItem.innerXml);
-        parts.push(closeTag(serializedValueItem.localName));
+        writeClassElement(parts, this.transform(itemValue));
       }
       parts.push(closeTag("value"));
     }
@@ -16319,33 +15641,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16353,10 +15665,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16371,10 +15680,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16382,10 +15688,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16393,22 +15696,15 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
 
-  parts.push(openTag("valueType"));
-    parts.push(serializeDataTypeDefXsdText(that.valueType));
-    parts.push(closeTag("valueType"));
+  writeVElement(parts, "valueType", serializeDataTypeDefXsdText(that.valueType));
 
   if (that.value !== null) {
-      parts.push(openTag("value"));
-      parts.push(serializeStringText(that.value));
-      parts.push(closeTag("value"));
+      writeVElement(parts, "value", serializeStringText(that.value));
     }
 
   if (that.valueId !== null) {
@@ -16438,33 +15734,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16472,10 +15758,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16490,10 +15773,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16501,10 +15781,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16512,10 +15789,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -16523,10 +15797,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.value !== null) {
       parts.push(openTag("value"));
       for (const itemValue of that.value) {
-        const serializedValueItem = this.transform(itemValue);
-        parts.push(openTag(serializedValueItem.localName));
-        parts.push(serializedValueItem.innerXml);
-        parts.push(closeTag(serializedValueItem.localName));
+        writeClassElement(parts, this.transform(itemValue));
       }
       parts.push(closeTag("value"));
     }
@@ -16558,33 +15829,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16592,10 +15853,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16610,10 +15868,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16621,10 +15876,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16632,28 +15884,19 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
 
-  parts.push(openTag("valueType"));
-    parts.push(serializeDataTypeDefXsdText(that.valueType));
-    parts.push(closeTag("valueType"));
+  writeVElement(parts, "valueType", serializeDataTypeDefXsdText(that.valueType));
 
   if (that.min !== null) {
-      parts.push(openTag("min"));
-      parts.push(serializeStringText(that.min));
-      parts.push(closeTag("min"));
+      writeVElement(parts, "min", serializeStringText(that.min));
     }
 
   if (that.max !== null) {
-      parts.push(openTag("max"));
-      parts.push(serializeStringText(that.max));
-      parts.push(closeTag("max"));
+      writeVElement(parts, "max", serializeStringText(that.max));
     }
 
   return {
@@ -16676,33 +15919,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16710,10 +15943,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16728,10 +15958,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16739,10 +15966,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16750,10 +15974,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -16785,33 +16006,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16819,10 +16030,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16837,10 +16045,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16848,10 +16053,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16859,23 +16061,16 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
 
   if (that.value !== null) {
-      parts.push(openTag("value"));
-      parts.push(serializeBase64EncodedBytesText(that.value));
-      parts.push(closeTag("value"));
+      writeVElement(parts, "value", serializeBase64EncodedBytesText(that.value));
     }
 
-  parts.push(openTag("contentType"));
-    parts.push(serializeStringText(that.contentType));
-    parts.push(closeTag("contentType"));
+  writeVElement(parts, "contentType", serializeStringText(that.contentType));
 
   return {
       localName: "blob",
@@ -16897,33 +16092,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -16931,10 +16116,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -16949,10 +16131,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -16960,10 +16139,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -16971,23 +16147,16 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
 
   if (that.value !== null) {
-      parts.push(openTag("value"));
-      parts.push(serializeStringText(that.value));
-      parts.push(closeTag("value"));
+      writeVElement(parts, "value", serializeStringText(that.value));
     }
 
-  parts.push(openTag("contentType"));
-    parts.push(serializeStringText(that.contentType));
-    parts.push(closeTag("contentType"));
+  writeVElement(parts, "contentType", serializeStringText(that.contentType));
 
   return {
       localName: "file",
@@ -17009,33 +16178,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -17043,10 +16202,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -17061,10 +16217,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -17072,10 +16225,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -17083,10 +16233,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -17104,10 +16251,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.annotations !== null) {
       parts.push(openTag("annotations"));
       for (const itemAnnotations of that.annotations) {
-        const serializedAnnotationsItem = this.transform(itemAnnotations);
-        parts.push(openTag(serializedAnnotationsItem.localName));
-        parts.push(serializedAnnotationsItem.innerXml);
-        parts.push(closeTag(serializedAnnotationsItem.localName));
+        writeClassElement(parts, this.transform(itemAnnotations));
       }
       parts.push(closeTag("annotations"));
     }
@@ -17132,33 +16276,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -17166,10 +16300,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -17184,10 +16315,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -17195,10 +16323,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -17206,10 +16331,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -17217,31 +16339,21 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.statements !== null) {
       parts.push(openTag("statements"));
       for (const itemStatements of that.statements) {
-        const serializedStatementsItem = this.transform(itemStatements);
-        parts.push(openTag(serializedStatementsItem.localName));
-        parts.push(serializedStatementsItem.innerXml);
-        parts.push(closeTag(serializedStatementsItem.localName));
+        writeClassElement(parts, this.transform(itemStatements));
       }
       parts.push(closeTag("statements"));
     }
 
-  parts.push(openTag("entityType"));
-    parts.push(serializeEntityTypeText(that.entityType));
-    parts.push(closeTag("entityType"));
+  writeVElement(parts, "entityType", serializeEntityTypeText(that.entityType));
 
   if (that.globalAssetId !== null) {
-      parts.push(openTag("globalAssetId"));
-      parts.push(serializeStringText(that.globalAssetId));
-      parts.push(closeTag("globalAssetId"));
+      writeVElement(parts, "globalAssetId", serializeStringText(that.globalAssetId));
     }
 
   if (that.specificAssetIds !== null) {
       parts.push(openTag("specificAssetIds"));
       for (const itemSpecificAssetIds of that.specificAssetIds) {
-        const serializedSpecificAssetIdsItem = this.transform(itemSpecificAssetIds);
-        parts.push(openTag(serializedSpecificAssetIdsItem.localName));
-        parts.push(serializedSpecificAssetIdsItem.innerXml);
-        parts.push(closeTag(serializedSpecificAssetIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSpecificAssetIds));
       }
       parts.push(closeTag("specificAssetIds"));
     }
@@ -17288,9 +16400,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     }
 
   if (that.topic !== null) {
-      parts.push(openTag("topic"));
-      parts.push(serializeStringText(that.topic));
-      parts.push(closeTag("topic"));
+      writeVElement(parts, "topic", serializeStringText(that.topic));
     }
 
   if (that.subjectId !== null) {
@@ -17300,14 +16410,10 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
       parts.push(closeTag("subjectId"));
     }
 
-  parts.push(openTag("timeStamp"));
-    parts.push(serializeStringText(that.timeStamp));
-    parts.push(closeTag("timeStamp"));
+  writeVElement(parts, "timeStamp", serializeStringText(that.timeStamp));
 
   if (that.payload !== null) {
-      parts.push(openTag("payload"));
-      parts.push(serializeBase64EncodedBytesText(that.payload));
-      parts.push(closeTag("payload"));
+      writeVElement(parts, "payload", serializeBase64EncodedBytesText(that.payload));
     }
 
   return {
@@ -17330,33 +16436,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -17364,10 +16460,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -17382,10 +16475,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -17393,10 +16483,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -17404,10 +16491,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -17417,18 +16501,12 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     parts.push(serializedObserved.innerXml);
     parts.push(closeTag("observed"));
 
-  parts.push(openTag("direction"));
-    parts.push(serializeDirectionText(that.direction));
-    parts.push(closeTag("direction"));
+  writeVElement(parts, "direction", serializeDirectionText(that.direction));
 
-  parts.push(openTag("state"));
-    parts.push(serializeStateOfEventText(that.state));
-    parts.push(closeTag("state"));
+  writeVElement(parts, "state", serializeStateOfEventText(that.state));
 
   if (that.messageTopic !== null) {
-      parts.push(openTag("messageTopic"));
-      parts.push(serializeStringText(that.messageTopic));
-      parts.push(closeTag("messageTopic"));
+      writeVElement(parts, "messageTopic", serializeStringText(that.messageTopic));
     }
 
   if (that.messageBroker !== null) {
@@ -17439,21 +16517,15 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     }
 
   if (that.lastUpdate !== null) {
-      parts.push(openTag("lastUpdate"));
-      parts.push(serializeStringText(that.lastUpdate));
-      parts.push(closeTag("lastUpdate"));
+      writeVElement(parts, "lastUpdate", serializeStringText(that.lastUpdate));
     }
 
   if (that.minInterval !== null) {
-      parts.push(openTag("minInterval"));
-      parts.push(serializeStringText(that.minInterval));
-      parts.push(closeTag("minInterval"));
+      writeVElement(parts, "minInterval", serializeStringText(that.minInterval));
     }
 
   if (that.maxInterval !== null) {
-      parts.push(openTag("maxInterval"));
-      parts.push(serializeStringText(that.maxInterval));
-      parts.push(closeTag("maxInterval"));
+      writeVElement(parts, "maxInterval", serializeStringText(that.maxInterval));
     }
 
   return {
@@ -17476,33 +16548,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -17510,10 +16572,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -17528,10 +16587,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -17539,10 +16595,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -17550,10 +16603,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -17561,10 +16611,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.inputVariables !== null) {
       parts.push(openTag("inputVariables"));
       for (const itemInputVariables of that.inputVariables) {
-        const serializedInputVariablesItem = this.transform(itemInputVariables);
-        parts.push(openTag(serializedInputVariablesItem.localName));
-        parts.push(serializedInputVariablesItem.innerXml);
-        parts.push(closeTag(serializedInputVariablesItem.localName));
+        writeClassElement(parts, this.transform(itemInputVariables));
       }
       parts.push(closeTag("inputVariables"));
     }
@@ -17572,10 +16619,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.outputVariables !== null) {
       parts.push(openTag("outputVariables"));
       for (const itemOutputVariables of that.outputVariables) {
-        const serializedOutputVariablesItem = this.transform(itemOutputVariables);
-        parts.push(openTag(serializedOutputVariablesItem.localName));
-        parts.push(serializedOutputVariablesItem.innerXml);
-        parts.push(closeTag(serializedOutputVariablesItem.localName));
+        writeClassElement(parts, this.transform(itemOutputVariables));
       }
       parts.push(closeTag("outputVariables"));
     }
@@ -17583,10 +16627,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.inoutputVariables !== null) {
       parts.push(openTag("inoutputVariables"));
       for (const itemInoutputVariables of that.inoutputVariables) {
-        const serializedInoutputVariablesItem = this.transform(itemInoutputVariables);
-        parts.push(openTag(serializedInoutputVariablesItem.localName));
-        parts.push(serializedInoutputVariablesItem.innerXml);
-        parts.push(closeTag(serializedInoutputVariablesItem.localName));
+        writeClassElement(parts, this.transform(itemInoutputVariables));
       }
       parts.push(closeTag("inoutputVariables"));
     }
@@ -17609,10 +16650,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   const parts = new Array<string>();
 
   parts.push(openTag("value"));
-    const serializedValue = this.transform(that.value);
-      parts.push(openTag(serializedValue.localName));
-      parts.push(serializedValue.innerXml);
-      parts.push(closeTag(serializedValue.localName));
+    writeClassElement(parts, this.transform(that.value));
     parts.push(closeTag("value"));
 
   return {
@@ -17635,33 +16673,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -17669,10 +16697,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -17687,10 +16712,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.supplementalSemanticIds !== null) {
       parts.push(openTag("supplementalSemanticIds"));
       for (const itemSupplementalSemanticIds of that.supplementalSemanticIds) {
-        const serializedSupplementalSemanticIdsItem = this.transform(itemSupplementalSemanticIds);
-        parts.push(openTag(serializedSupplementalSemanticIdsItem.localName));
-        parts.push(serializedSupplementalSemanticIdsItem.innerXml);
-        parts.push(closeTag(serializedSupplementalSemanticIdsItem.localName));
+        writeClassElement(parts, this.transform(itemSupplementalSemanticIds));
       }
       parts.push(closeTag("supplementalSemanticIds"));
     }
@@ -17698,10 +16720,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.qualifiers !== null) {
       parts.push(openTag("qualifiers"));
       for (const itemQualifiers of that.qualifiers) {
-        const serializedQualifiersItem = this.transform(itemQualifiers);
-        parts.push(openTag(serializedQualifiersItem.localName));
-        parts.push(serializedQualifiersItem.innerXml);
-        parts.push(closeTag(serializedQualifiersItem.localName));
+        writeClassElement(parts, this.transform(itemQualifiers));
       }
       parts.push(closeTag("qualifiers"));
     }
@@ -17709,10 +16728,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -17737,33 +16753,23 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.extensions !== null) {
       parts.push(openTag("extensions"));
       for (const itemExtensions of that.extensions) {
-        const serializedExtensionsItem = this.transform(itemExtensions);
-        parts.push(openTag(serializedExtensionsItem.localName));
-        parts.push(serializedExtensionsItem.innerXml);
-        parts.push(closeTag(serializedExtensionsItem.localName));
+        writeClassElement(parts, this.transform(itemExtensions));
       }
       parts.push(closeTag("extensions"));
     }
 
   if (that.category !== null) {
-      parts.push(openTag("category"));
-      parts.push(serializeStringText(that.category));
-      parts.push(closeTag("category"));
+      writeVElement(parts, "category", serializeStringText(that.category));
     }
 
   if (that.idShort !== null) {
-      parts.push(openTag("idShort"));
-      parts.push(serializeStringText(that.idShort));
-      parts.push(closeTag("idShort"));
+      writeVElement(parts, "idShort", serializeStringText(that.idShort));
     }
 
   if (that.displayName !== null) {
       parts.push(openTag("displayName"));
       for (const itemDisplayName of that.displayName) {
-        const serializedDisplayNameItem = this.transform(itemDisplayName);
-        parts.push(openTag(serializedDisplayNameItem.localName));
-        parts.push(serializedDisplayNameItem.innerXml);
-        parts.push(closeTag(serializedDisplayNameItem.localName));
+        writeClassElement(parts, this.transform(itemDisplayName));
       }
       parts.push(closeTag("displayName"));
     }
@@ -17771,10 +16777,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.description !== null) {
       parts.push(openTag("description"));
       for (const itemDescription of that.description) {
-        const serializedDescriptionItem = this.transform(itemDescription);
-        parts.push(openTag(serializedDescriptionItem.localName));
-        parts.push(serializedDescriptionItem.innerXml);
-        parts.push(closeTag(serializedDescriptionItem.localName));
+        writeClassElement(parts, this.transform(itemDescription));
       }
       parts.push(closeTag("description"));
     }
@@ -17786,17 +16789,12 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
       parts.push(closeTag("administration"));
     }
 
-  parts.push(openTag("id"));
-    parts.push(serializeStringText(that.id));
-    parts.push(closeTag("id"));
+  writeVElement(parts, "id", serializeStringText(that.id));
 
   if (that.embeddedDataSpecifications !== null) {
       parts.push(openTag("embeddedDataSpecifications"));
       for (const itemEmbeddedDataSpecifications of that.embeddedDataSpecifications) {
-        const serializedEmbeddedDataSpecificationsItem = this.transform(itemEmbeddedDataSpecifications);
-        parts.push(openTag(serializedEmbeddedDataSpecificationsItem.localName));
-        parts.push(serializedEmbeddedDataSpecificationsItem.innerXml);
-        parts.push(closeTag(serializedEmbeddedDataSpecificationsItem.localName));
+        writeClassElement(parts, this.transform(itemEmbeddedDataSpecifications));
       }
       parts.push(closeTag("embeddedDataSpecifications"));
     }
@@ -17804,10 +16802,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.isCaseOf !== null) {
       parts.push(openTag("isCaseOf"));
       for (const itemIsCaseOf of that.isCaseOf) {
-        const serializedIsCaseOfItem = this.transform(itemIsCaseOf);
-        parts.push(openTag(serializedIsCaseOfItem.localName));
-        parts.push(serializedIsCaseOfItem.innerXml);
-        parts.push(closeTag(serializedIsCaseOfItem.localName));
+        writeClassElement(parts, this.transform(itemIsCaseOf));
       }
       parts.push(closeTag("isCaseOf"));
     }
@@ -17829,9 +16824,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("type"));
-    parts.push(serializeReferenceTypesText(that.type));
-    parts.push(closeTag("type"));
+  writeVElement(parts, "type", serializeReferenceTypesText(that.type));
 
   if (that.referredSemanticId !== null) {
       const serializedReferredSemanticId = this.transform(that.referredSemanticId);
@@ -17842,10 +16835,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
 
   parts.push(openTag("keys"));
     for (const itemKeys of that.keys) {
-      const serializedKeysItem = this.transform(itemKeys);
-      parts.push(openTag(serializedKeysItem.localName));
-      parts.push(serializedKeysItem.innerXml);
-      parts.push(closeTag(serializedKeysItem.localName));
+      writeClassElement(parts, this.transform(itemKeys));
     }
     parts.push(closeTag("keys"));
 
@@ -17866,13 +16856,9 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("type"));
-    parts.push(serializeKeyTypesText(that.type));
-    parts.push(closeTag("type"));
+  writeVElement(parts, "type", serializeKeyTypesText(that.type));
 
-  parts.push(openTag("value"));
-    parts.push(serializeStringText(that.value));
-    parts.push(closeTag("value"));
+  writeVElement(parts, "value", serializeStringText(that.value));
 
   return {
       localName: "key",
@@ -17891,13 +16877,9 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("language"));
-    parts.push(serializeStringText(that.language));
-    parts.push(closeTag("language"));
+  writeVElement(parts, "language", serializeStringText(that.language));
 
-  parts.push(openTag("text"));
-    parts.push(serializeStringText(that.text));
-    parts.push(closeTag("text"));
+  writeVElement(parts, "text", serializeStringText(that.text));
 
   return {
       localName: "langStringNameType",
@@ -17916,13 +16898,9 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("language"));
-    parts.push(serializeStringText(that.language));
-    parts.push(closeTag("language"));
+  writeVElement(parts, "language", serializeStringText(that.language));
 
-  parts.push(openTag("text"));
-    parts.push(serializeStringText(that.text));
-    parts.push(closeTag("text"));
+  writeVElement(parts, "text", serializeStringText(that.text));
 
   return {
       localName: "langStringTextType",
@@ -17944,10 +16922,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.assetAdministrationShells !== null) {
       parts.push(openTag("assetAdministrationShells"));
       for (const itemAssetAdministrationShells of that.assetAdministrationShells) {
-        const serializedAssetAdministrationShellsItem = this.transform(itemAssetAdministrationShells);
-        parts.push(openTag(serializedAssetAdministrationShellsItem.localName));
-        parts.push(serializedAssetAdministrationShellsItem.innerXml);
-        parts.push(closeTag(serializedAssetAdministrationShellsItem.localName));
+        writeClassElement(parts, this.transform(itemAssetAdministrationShells));
       }
       parts.push(closeTag("assetAdministrationShells"));
     }
@@ -17955,10 +16930,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.submodels !== null) {
       parts.push(openTag("submodels"));
       for (const itemSubmodels of that.submodels) {
-        const serializedSubmodelsItem = this.transform(itemSubmodels);
-        parts.push(openTag(serializedSubmodelsItem.localName));
-        parts.push(serializedSubmodelsItem.innerXml);
-        parts.push(closeTag(serializedSubmodelsItem.localName));
+        writeClassElement(parts, this.transform(itemSubmodels));
       }
       parts.push(closeTag("submodels"));
     }
@@ -17966,10 +16938,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   if (that.conceptDescriptions !== null) {
       parts.push(openTag("conceptDescriptions"));
       for (const itemConceptDescriptions of that.conceptDescriptions) {
-        const serializedConceptDescriptionsItem = this.transform(itemConceptDescriptions);
-        parts.push(openTag(serializedConceptDescriptionsItem.localName));
-        parts.push(serializedConceptDescriptionsItem.innerXml);
-        parts.push(closeTag(serializedConceptDescriptionsItem.localName));
+        writeClassElement(parts, this.transform(itemConceptDescriptions));
       }
       parts.push(closeTag("conceptDescriptions"));
     }
@@ -17997,10 +16966,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     parts.push(closeTag("dataSpecification"));
 
   parts.push(openTag("dataSpecificationContent"));
-    const serializedDataSpecificationContent = this.transform(that.dataSpecificationContent);
-      parts.push(openTag(serializedDataSpecificationContent.localName));
-      parts.push(serializedDataSpecificationContent.innerXml);
-      parts.push(closeTag(serializedDataSpecificationContent.localName));
+    writeClassElement(parts, this.transform(that.dataSpecificationContent));
     parts.push(closeTag("dataSpecificationContent"));
 
   return {
@@ -18020,21 +16986,13 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("min"));
-    parts.push(serializeBooleanText(that.min));
-    parts.push(closeTag("min"));
+  writeVElement(parts, "min", serializeBooleanText(that.min));
 
-  parts.push(openTag("nom"));
-    parts.push(serializeBooleanText(that.nom));
-    parts.push(closeTag("nom"));
+  writeVElement(parts, "nom", serializeBooleanText(that.nom));
 
-  parts.push(openTag("typ"));
-    parts.push(serializeBooleanText(that.typ));
-    parts.push(closeTag("typ"));
+  writeVElement(parts, "typ", serializeBooleanText(that.typ));
 
-  parts.push(openTag("max"));
-    parts.push(serializeBooleanText(that.max));
-    parts.push(closeTag("max"));
+  writeVElement(parts, "max", serializeBooleanText(that.max));
 
   return {
       localName: "levelType",
@@ -18053,9 +17011,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("value"));
-    parts.push(serializeStringText(that.value));
-    parts.push(closeTag("value"));
+  writeVElement(parts, "value", serializeStringText(that.value));
 
   const serializedValueId = this.transform(that.valueId);
     parts.push(openTag("valueId"));
@@ -18081,10 +17037,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
 
   parts.push(openTag("valueReferencePairs"));
     for (const itemValueReferencePairs of that.valueReferencePairs) {
-      const serializedValueReferencePairsItem = this.transform(itemValueReferencePairs);
-      parts.push(openTag(serializedValueReferencePairsItem.localName));
-      parts.push(serializedValueReferencePairsItem.innerXml);
-      parts.push(closeTag(serializedValueReferencePairsItem.localName));
+      writeClassElement(parts, this.transform(itemValueReferencePairs));
     }
     parts.push(closeTag("valueReferencePairs"));
 
@@ -18105,13 +17058,9 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("language"));
-    parts.push(serializeStringText(that.language));
-    parts.push(closeTag("language"));
+  writeVElement(parts, "language", serializeStringText(that.language));
 
-  parts.push(openTag("text"));
-    parts.push(serializeStringText(that.text));
-    parts.push(closeTag("text"));
+  writeVElement(parts, "text", serializeStringText(that.text));
 
   return {
       localName: "langStringPreferredNameTypeIec61360",
@@ -18130,13 +17079,9 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("language"));
-    parts.push(serializeStringText(that.language));
-    parts.push(closeTag("language"));
+  writeVElement(parts, "language", serializeStringText(that.language));
 
-  parts.push(openTag("text"));
-    parts.push(serializeStringText(that.text));
-    parts.push(closeTag("text"));
+  writeVElement(parts, "text", serializeStringText(that.text));
 
   return {
       localName: "langStringShortNameTypeIec61360",
@@ -18155,13 +17100,9 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("language"));
-    parts.push(serializeStringText(that.language));
-    parts.push(closeTag("language"));
+  writeVElement(parts, "language", serializeStringText(that.language));
 
-  parts.push(openTag("text"));
-    parts.push(serializeStringText(that.text));
-    parts.push(closeTag("text"));
+  writeVElement(parts, "text", serializeStringText(that.text));
 
   return {
       localName: "langStringDefinitionTypeIec61360",
@@ -18182,28 +17123,20 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
 
   parts.push(openTag("preferredName"));
     for (const itemPreferredName of that.preferredName) {
-      const serializedPreferredNameItem = this.transform(itemPreferredName);
-      parts.push(openTag(serializedPreferredNameItem.localName));
-      parts.push(serializedPreferredNameItem.innerXml);
-      parts.push(closeTag(serializedPreferredNameItem.localName));
+      writeClassElement(parts, this.transform(itemPreferredName));
     }
     parts.push(closeTag("preferredName"));
 
   if (that.shortName !== null) {
       parts.push(openTag("shortName"));
       for (const itemShortName of that.shortName) {
-        const serializedShortNameItem = this.transform(itemShortName);
-        parts.push(openTag(serializedShortNameItem.localName));
-        parts.push(serializedShortNameItem.innerXml);
-        parts.push(closeTag(serializedShortNameItem.localName));
+        writeClassElement(parts, this.transform(itemShortName));
       }
       parts.push(closeTag("shortName"));
     }
 
   if (that.unit !== null) {
-      parts.push(openTag("unit"));
-      parts.push(serializeStringText(that.unit));
-      parts.push(closeTag("unit"));
+      writeVElement(parts, "unit", serializeStringText(that.unit));
     }
 
   if (that.unitId !== null) {
@@ -18214,38 +17147,27 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     }
 
   if (that.sourceOfDefinition !== null) {
-      parts.push(openTag("sourceOfDefinition"));
-      parts.push(serializeStringText(that.sourceOfDefinition));
-      parts.push(closeTag("sourceOfDefinition"));
+      writeVElement(parts, "sourceOfDefinition", serializeStringText(that.sourceOfDefinition));
     }
 
   if (that.symbol !== null) {
-      parts.push(openTag("symbol"));
-      parts.push(serializeStringText(that.symbol));
-      parts.push(closeTag("symbol"));
+      writeVElement(parts, "symbol", serializeStringText(that.symbol));
     }
 
   if (that.dataType !== null) {
-      parts.push(openTag("dataType"));
-      parts.push(serializeDataTypeIec61360Text(that.dataType));
-      parts.push(closeTag("dataType"));
+      writeVElement(parts, "dataType", serializeDataTypeIec61360Text(that.dataType));
     }
 
   if (that.definition !== null) {
       parts.push(openTag("definition"));
       for (const itemDefinition of that.definition) {
-        const serializedDefinitionItem = this.transform(itemDefinition);
-        parts.push(openTag(serializedDefinitionItem.localName));
-        parts.push(serializedDefinitionItem.innerXml);
-        parts.push(closeTag(serializedDefinitionItem.localName));
+        writeClassElement(parts, this.transform(itemDefinition));
       }
       parts.push(closeTag("definition"));
     }
 
   if (that.valueFormat !== null) {
-      parts.push(openTag("valueFormat"));
-      parts.push(serializeStringText(that.valueFormat));
-      parts.push(closeTag("valueFormat"));
+      writeVElement(parts, "valueFormat", serializeStringText(that.valueFormat));
     }
 
   if (that.valueList !== null) {
@@ -18256,9 +17178,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     }
 
   if (that.value !== null) {
-      parts.push(openTag("value"));
-      parts.push(serializeStringText(that.value));
-      parts.push(closeTag("value"));
+      writeVElement(parts, "value", serializeStringText(that.value));
     }
 
   if (that.levelType !== null) {

--- a/dev/test_data/main/typescript/expected/conflict_with_utility_types/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/conflict_with_utility_types/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -362,26 +443,22 @@ export function readonlyFromJsonable(
   AasTypes.ReadonlY,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.ReadonlY>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ReadonlY,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.ReadonlY>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.ReadonlY>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForReadonly();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_READONLY.get(key);
 
@@ -396,7 +473,7 @@ export function readonlyFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.ReadonlY,
@@ -521,26 +598,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -555,7 +628,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/conflict_with_utility_types/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/conflict_with_utility_types/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -659,38 +700,23 @@ function parseReadonlyFromSequence(
 ): AasCommon.Either<AasTypes.ReadonlY, DeserializationError> {
   let theSomething: string | null = null;
 
+  const className = AasTypes.ReadonlY.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.ReadonlY>(
-        `Unexpected end of token stream while parsing ReadonlY`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.ReadonlY>(
-        "Expected an XML property start element or the closing element of " +
-        `ReadonlY, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.ReadonlY, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -714,7 +740,7 @@ function parseReadonlyFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -773,38 +799,23 @@ function parseSomethingFromSequence(
   let theAReadonly: AasTypes.ReadonlY | null = null;
   let theARecord: AasTypes.RecorD | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -826,7 +837,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -857,7 +868,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1008,6 +1019,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1068,9 +1110,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("something"));
-    parts.push(serializeStringText(that.something));
-    parts.push(closeTag("something"));
+  writeVElement(parts, "something", serializeStringText(that.something));
 
   return {
       localName: "readonly",
@@ -1094,9 +1134,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
     parts.push(serializedAReadonly.innerXml);
     parts.push(closeTag("aReadonly"));
 
-  parts.push(openTag("aRecord"));
-    parts.push(serializeRecordText(that.aRecord));
-    parts.push(closeTag("aRecord"));
+  writeVElement(parts, "aRecord", serializeRecordText(that.aRecord));
 
   return {
       localName: "something",

--- a/dev/test_data/main/typescript/expected/constrained_primitives/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/constrained_primitives/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -450,26 +531,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -484,7 +561,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/constrained_primitives/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/constrained_primitives/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -641,38 +682,23 @@ function parseSomethingFromSequence(
   let theSomeString: string | null = null;
   let theSomeBytes: Uint8Array | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -696,7 +722,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -727,7 +753,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -758,7 +784,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -789,7 +815,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -820,7 +846,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -988,6 +1014,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1048,25 +1105,15 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("someBool"));
-    parts.push(serializeBooleanText(that.someBool));
-    parts.push(closeTag("someBool"));
+  writeVElement(parts, "someBool", serializeBooleanText(that.someBool));
 
-  parts.push(openTag("someInt"));
-    parts.push(serializeIntegerText(that.someInt));
-    parts.push(closeTag("someInt"));
+  writeVElement(parts, "someInt", serializeIntegerText(that.someInt));
 
-  parts.push(openTag("someFloat"));
-    parts.push(serializeFloatText(that.someFloat));
-    parts.push(closeTag("someFloat"));
+  writeVElement(parts, "someFloat", serializeFloatText(that.someFloat));
 
-  parts.push(openTag("someString"));
-    parts.push(serializeStringText(that.someString));
-    parts.push(closeTag("someString"));
+  writeVElement(parts, "someString", serializeStringText(that.someString));
 
-  parts.push(openTag("someBytes"));
-    parts.push(serializeBase64EncodedBytesText(that.someBytes));
-    parts.push(closeTag("someBytes"));
+  writeVElement(parts, "someBytes", serializeBase64EncodedBytesText(that.someBytes));
 
   return {
       localName: "something",

--- a/dev/test_data/main/typescript/expected/custom_serialization_names/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/custom_serialization_names/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -384,26 +465,22 @@ export function queryConditionFromJsonable(
   AasTypes.QueryCondition,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.QueryCondition>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.QueryCondition,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.QueryCondition>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.QueryCondition>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForQueryCondition();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_QUERY_CONDITION.get(key);
 
@@ -418,7 +495,7 @@ export function queryConditionFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.QueryCondition,

--- a/dev/test_data/main/typescript/expected/custom_serialization_names/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/custom_serialization_names/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -638,38 +679,23 @@ function parseQueryConditionFromSequence(
   let theEq: string | null = null;
   let theNotEq: string | null = null;
 
+  const className = AasTypes.QueryCondition.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.QueryCondition>(
-        `Unexpected end of token stream while parsing QueryCondition`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.QueryCondition>(
-        "Expected an XML property start element or the closing element of " +
-        `QueryCondition, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.QueryCondition, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -693,7 +719,7 @@ function parseQueryConditionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -724,7 +750,7 @@ function parseQueryConditionFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -861,6 +887,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -922,15 +979,11 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   const parts = new Array<string>();
 
   if (that.eq !== null) {
-      parts.push(openTag("eq"));
-      parts.push(serializeStringText(that.eq));
-      parts.push(closeTag("eq"));
+      writeVElement(parts, "eq", serializeStringText(that.eq));
     }
 
   if (that.notEq !== null) {
-      parts.push(openTag("not-eq"));
-      parts.push(serializeStringText(that.notEq));
-      parts.push(closeTag("not-eq"));
+      writeVElement(parts, "not-eq", serializeStringText(that.notEq));
     }
 
   return {

--- a/dev/test_data/main/typescript/expected/deep_class_hierarchy/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/deep_class_hierarchy/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -333,23 +414,19 @@ export function nodeFromJsonable(
   AasTypes.INode,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.INode>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.INode,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.INode>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.INode>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.INode>(
       "The required property modelType is missing"
@@ -385,23 +462,19 @@ export function branchFromJsonable(
   AasTypes.IBranch,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IBranch>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IBranch,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IBranch>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IBranch>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IBranch>(
       "The required property modelType is missing"
@@ -520,26 +593,22 @@ function branchFromJsonableWithoutDispatch(
   AasTypes.Branch,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Branch>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Branch,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Branch>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Branch>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForBranch();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_BRANCH.get(key);
 
@@ -554,7 +623,7 @@ function branchFromJsonableWithoutDispatch(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Branch,
@@ -582,18 +651,14 @@ function branchFromJsonableWithoutDispatch(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Branch
+  const modelTypeError = checkModelType(setter.modelType, "Branch");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Branch,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Branch") {
-    return newDeserializationError<
-      AasTypes.Branch
-    >(
-      "Expected model type 'Branch', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -622,23 +687,19 @@ export function leafFromJsonable(
   AasTypes.ILeaf,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.ILeaf>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.ILeaf,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.ILeaf>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.ILeaf>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.ILeaf>(
       "The required property modelType is missing"
@@ -779,26 +840,22 @@ function leafFromJsonableWithoutDispatch(
   AasTypes.Leaf,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Leaf>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Leaf,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Leaf>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Leaf>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForLeaf();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_LEAF.get(key);
 
@@ -813,7 +870,7 @@ function leafFromJsonableWithoutDispatch(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Leaf,
@@ -849,18 +906,14 @@ function leafFromJsonableWithoutDispatch(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Leaf
+  const modelTypeError = checkModelType(setter.modelType, "Leaf");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Leaf,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Leaf") {
-    return newDeserializationError<
-      AasTypes.Leaf
-    >(
-      "Expected model type 'Leaf', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -1010,26 +1063,22 @@ export function blossomFromJsonable(
   AasTypes.Blossom,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Blossom>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Blossom,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Blossom>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Blossom>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForBlossom();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_BLOSSOM.get(key);
 
@@ -1044,7 +1093,7 @@ export function blossomFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Blossom,
@@ -1088,18 +1137,14 @@ export function blossomFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.Blossom
+  const modelTypeError = checkModelType(setter.modelType, "Blossom");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Blossom,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "Blossom") {
-    return newDeserializationError<
-      AasTypes.Blossom
-    >(
-      "Expected model type 'Blossom', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -1181,26 +1226,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -1215,7 +1256,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,
@@ -1319,26 +1360,22 @@ export function containerFromJsonable(
   AasTypes.Container,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Container>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Container,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Container>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Container>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForContainer();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_CONTAINER.get(key);
 
@@ -1353,7 +1390,7 @@ export function containerFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Container,

--- a/dev/test_data/main/typescript/expected/deep_class_hierarchy/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/deep_class_hierarchy/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -638,38 +679,23 @@ function parseBranchFromSequence(
   let theIdentifier: string | null = null;
   let theDescription: string | null = null;
 
+  const className = AasTypes.Branch.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Branch>(
-        `Unexpected end of token stream while parsing Branch`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Branch>(
-        "Expected an XML property start element or the closing element of " +
-        `Branch, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Branch, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -693,7 +719,7 @@ function parseBranchFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -724,7 +750,7 @@ function parseBranchFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -791,38 +817,23 @@ function parseLeafFromSequence(
   let theDescription: string | null = null;
   let theValue: number | null = null;
 
+  const className = AasTypes.Leaf.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Leaf>(
-        `Unexpected end of token stream while parsing Leaf`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Leaf>(
-        "Expected an XML property start element or the closing element of " +
-        `Leaf, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Leaf, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -846,7 +857,7 @@ function parseLeafFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -877,7 +888,7 @@ function parseLeafFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -908,7 +919,7 @@ function parseLeafFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -983,38 +994,23 @@ function parseBlossomFromSequence(
   let theValue: number | null = null;
   let theDetails: string | null = null;
 
+  const className = AasTypes.Blossom.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Blossom>(
-        `Unexpected end of token stream while parsing Blossom`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Blossom>(
-        "Expected an XML property start element or the closing element of " +
-        `Blossom, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Blossom, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -1038,7 +1034,7 @@ function parseBlossomFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1069,7 +1065,7 @@ function parseBlossomFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1100,7 +1096,7 @@ function parseBlossomFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1131,7 +1127,7 @@ function parseBlossomFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1211,38 +1207,23 @@ function parseSomethingFromSequence(
   let theSomeChoice: AasTypes.INode | null = null;
   let theSomethingWithoutChoice: AasTypes.Branch | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -1264,7 +1245,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1293,7 +1274,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1359,38 +1340,23 @@ function parseContainerFromSequence(
   let theNode: AasTypes.INode | null = null;
   let theSomething: AasTypes.Something | null = null;
 
+  const className = AasTypes.Container.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Container>(
-        `Unexpected end of token stream while parsing Container`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Container>(
-        "Expected an XML property start element or the closing element of " +
-        `Container, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Container, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -1412,7 +1378,7 @@ function parseContainerFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1441,7 +1407,7 @@ function parseContainerFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1892,6 +1858,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1952,13 +1949,9 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("identifier"));
-    parts.push(serializeStringText(that.identifier));
-    parts.push(closeTag("identifier"));
+  writeVElement(parts, "identifier", serializeStringText(that.identifier));
 
-  parts.push(openTag("description"));
-    parts.push(serializeStringText(that.description));
-    parts.push(closeTag("description"));
+  writeVElement(parts, "description", serializeStringText(that.description));
 
   return {
       localName: "branch",
@@ -1977,17 +1970,11 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("identifier"));
-    parts.push(serializeStringText(that.identifier));
-    parts.push(closeTag("identifier"));
+  writeVElement(parts, "identifier", serializeStringText(that.identifier));
 
-  parts.push(openTag("description"));
-    parts.push(serializeStringText(that.description));
-    parts.push(closeTag("description"));
+  writeVElement(parts, "description", serializeStringText(that.description));
 
-  parts.push(openTag("value"));
-    parts.push(serializeIntegerText(that.value));
-    parts.push(closeTag("value"));
+  writeVElement(parts, "value", serializeIntegerText(that.value));
 
   return {
       localName: "leaf",
@@ -2006,21 +1993,13 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("identifier"));
-    parts.push(serializeStringText(that.identifier));
-    parts.push(closeTag("identifier"));
+  writeVElement(parts, "identifier", serializeStringText(that.identifier));
 
-  parts.push(openTag("description"));
-    parts.push(serializeStringText(that.description));
-    parts.push(closeTag("description"));
+  writeVElement(parts, "description", serializeStringText(that.description));
 
-  parts.push(openTag("value"));
-    parts.push(serializeIntegerText(that.value));
-    parts.push(closeTag("value"));
+  writeVElement(parts, "value", serializeIntegerText(that.value));
 
-  parts.push(openTag("details"));
-    parts.push(serializeStringText(that.details));
-    parts.push(closeTag("details"));
+  writeVElement(parts, "details", serializeStringText(that.details));
 
   return {
       localName: "blossom",
@@ -2040,17 +2019,11 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   const parts = new Array<string>();
 
   parts.push(openTag("someChoice"));
-    const serializedSomeChoice = this.transform(that.someChoice);
-      parts.push(openTag(serializedSomeChoice.localName));
-      parts.push(serializedSomeChoice.innerXml);
-      parts.push(closeTag(serializedSomeChoice.localName));
+    writeClassElement(parts, this.transform(that.someChoice));
     parts.push(closeTag("someChoice"));
 
   parts.push(openTag("somethingWithoutChoice"));
-    const serializedSomethingWithoutChoice = this.transform(that.somethingWithoutChoice);
-      parts.push(openTag(serializedSomethingWithoutChoice.localName));
-      parts.push(serializedSomethingWithoutChoice.innerXml);
-      parts.push(closeTag(serializedSomethingWithoutChoice.localName));
+    writeClassElement(parts, this.transform(that.somethingWithoutChoice));
     parts.push(closeTag("somethingWithoutChoice"));
 
   return {
@@ -2071,10 +2044,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   const parts = new Array<string>();
 
   parts.push(openTag("node"));
-    const serializedNode = this.transform(that.node);
-      parts.push(openTag(serializedNode.localName));
-      parts.push(serializedNode.innerXml);
-      parts.push(closeTag(serializedNode.localName));
+    writeClassElement(parts, this.transform(that.node));
     parts.push(closeTag("node"));
 
   const serializedSomething = this.transform(that.something);

--- a/dev/test_data/main/typescript/expected/empty_class/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/empty_class/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -342,26 +423,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -376,7 +453,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/empty_class/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/empty_class/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -637,38 +678,23 @@ function parseSomethingFromSequence(
 ): AasCommon.Either<AasTypes.Something, DeserializationError> {
   // No properties
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -793,6 +819,37 @@ function openTag(localName: string, withNamespace = false): string {
 
 function closeTag(localName: string): string {
   return `</${localName}>`;
+}
+
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
 }
 
 function escapeXmlText(text: string): string {

--- a/dev/test_data/main/typescript/expected/enum/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/enum/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -392,26 +473,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -426,7 +503,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/enum/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/enum/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -659,38 +700,23 @@ function parseSomethingFromSequence(
 ): AasCommon.Either<AasTypes.Something, DeserializationError> {
   let theSomeResult: AasTypes.Result | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -714,7 +740,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -854,6 +880,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -914,9 +971,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("someResult"));
-    parts.push(serializeResultText(that.someResult));
-    parts.push(closeTag("someResult"));
+  writeVElement(parts, "someResult", serializeResultText(that.someResult));
 
   return {
       localName: "something",

--- a/dev/test_data/main/typescript/expected/list_of_classes/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_classes/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -333,23 +414,19 @@ export function abstractItemFromJsonable(
   AasTypes.IAbstractItem,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.IAbstractItem>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.IAbstractItem,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.IAbstractItem>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.IAbstractItem>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
-  const modelType = jsonable["modelType"];
+  const modelType = jsonObject["modelType"];
   if (modelType === undefined) {
     return newDeserializationError<AasTypes.IAbstractItem>(
       "The required property modelType is missing"
@@ -439,26 +516,22 @@ export function someItemFromJsonable(
   AasTypes.SomeItem,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.SomeItem>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.SomeItem,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.SomeItem>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.SomeItem>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomeItem();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOME_ITEM.get(key);
 
@@ -473,7 +546,7 @@ export function someItemFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.SomeItem,
@@ -493,18 +566,14 @@ export function someItemFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.SomeItem
+  const modelTypeError = checkModelType(setter.modelType, "SomeItem");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.SomeItem,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "SomeItem") {
-    return newDeserializationError<
-      AasTypes.SomeItem
-    >(
-      "Expected model type 'SomeItem', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -586,26 +655,22 @@ export function anotherItemFromJsonable(
   AasTypes.AnotherItem,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.AnotherItem>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AnotherItem,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.AnotherItem>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.AnotherItem>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForAnotherItem();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_ANOTHER_ITEM.get(key);
 
@@ -620,7 +685,7 @@ export function anotherItemFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.AnotherItem,
@@ -640,18 +705,14 @@ export function anotherItemFromJsonable(
     );
   }
 
-  if (setter.modelType === null) {
-    return newDeserializationError<
-      AasTypes.AnotherItem
+  const modelTypeError = checkModelType(setter.modelType, "AnotherItem");
+  if (modelTypeError !== null) {
+    return new AasCommon.Either<
+      AasTypes.AnotherItem,
+      DeserializationError
     >(
-      "The required property 'modelType' is missing"
-    );
-  } else if (setter.modelType != "AnotherItem") {
-    return newDeserializationError<
-      AasTypes.AnotherItem
-    >(
-      "Expected model type 'AnotherItem', " +
-      `but got: ${setter.modelType}`
+      null,
+      modelTypeError
     );
   }
 
@@ -708,26 +769,22 @@ export function simpleFromJsonable(
   AasTypes.Simple,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Simple>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Simple,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Simple>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Simple>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSimple();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SIMPLE.get(key);
 
@@ -742,7 +799,7 @@ export function simpleFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Simple,
@@ -791,21 +848,9 @@ class SetterForSomething {
   setSomeItemsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -831,21 +876,9 @@ class SetterForSomething {
   setSomeSimplesFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -877,26 +910,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -911,7 +940,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/list_of_classes/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_classes/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -637,38 +678,23 @@ function parseSomeItemFromSequence(
 ): AasCommon.Either<AasTypes.SomeItem, DeserializationError> {
   let theName: string | null = null;
 
+  const className = AasTypes.SomeItem.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.SomeItem>(
-        `Unexpected end of token stream while parsing SomeItem`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.SomeItem>(
-        "Expected an XML property start element or the closing element of " +
-        `SomeItem, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.SomeItem, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -692,7 +718,7 @@ function parseSomeItemFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -750,38 +776,23 @@ function parseAnotherItemFromSequence(
 ): AasCommon.Either<AasTypes.AnotherItem, DeserializationError> {
   let theSerialNumber: number | null = null;
 
+  const className = AasTypes.AnotherItem.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.AnotherItem>(
-        `Unexpected end of token stream while parsing AnotherItem`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.AnotherItem>(
-        "Expected an XML property start element or the closing element of " +
-        `AnotherItem, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.AnotherItem, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -805,7 +816,7 @@ function parseAnotherItemFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -863,38 +874,23 @@ function parseSimpleFromSequence(
 ): AasCommon.Either<AasTypes.Simple, DeserializationError> {
   let theName: string | null = null;
 
+  const className = AasTypes.Simple.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Simple>(
-        `Unexpected end of token stream while parsing Simple`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Simple>(
-        "Expected an XML property start element or the closing element of " +
-        `Simple, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Simple, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -918,7 +914,7 @@ function parseSimpleFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -977,38 +973,23 @@ function parseSomethingFromSequence(
   let theSomeItems: Array<AasTypes.IAbstractItem> | null = null;
   let theSomeSimples: Array<AasTypes.Simple> | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -1033,7 +1014,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1069,7 +1050,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -1322,6 +1303,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1382,9 +1394,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("name"));
-    parts.push(serializeStringText(that.name));
-    parts.push(closeTag("name"));
+  writeVElement(parts, "name", serializeStringText(that.name));
 
   return {
       localName: "someItem",
@@ -1403,9 +1413,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("serialNumber"));
-    parts.push(serializeIntegerText(that.serialNumber));
-    parts.push(closeTag("serialNumber"));
+  writeVElement(parts, "serialNumber", serializeIntegerText(that.serialNumber));
 
   return {
       localName: "anotherItem",
@@ -1424,9 +1432,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("name"));
-    parts.push(serializeStringText(that.name));
-    parts.push(closeTag("name"));
+  writeVElement(parts, "name", serializeStringText(that.name));
 
   return {
       localName: "simple",
@@ -1447,19 +1453,13 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
 
   parts.push(openTag("someItems"));
     for (const itemSomeItems of that.someItems) {
-      const serializedSomeItemsItem = this.transform(itemSomeItems);
-      parts.push(openTag(serializedSomeItemsItem.localName));
-      parts.push(serializedSomeItemsItem.innerXml);
-      parts.push(closeTag(serializedSomeItemsItem.localName));
+      writeClassElement(parts, this.transform(itemSomeItems));
     }
     parts.push(closeTag("someItems"));
 
   parts.push(openTag("someSimples"));
     for (const itemSomeSimples of that.someSimples) {
-      const serializedSomeSimplesItem = this.transform(itemSomeSimples);
-      parts.push(openTag(serializedSomeSimplesItem.localName));
-      parts.push(serializedSomeSimplesItem.innerXml);
-      parts.push(closeTag(serializedSomeSimplesItem.localName));
+      writeClassElement(parts, this.transform(itemSomeSimples));
     }
     parts.push(closeTag("someSimples"));
 

--- a/dev/test_data/main/typescript/expected/list_of_constrained_primitives/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_constrained_primitives/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -336,21 +417,9 @@ class SetterForSomething {
   setSomeNamesFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -382,26 +451,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -416,7 +481,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/list_of_constrained_primitives/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_constrained_primitives/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -637,38 +678,23 @@ function parseSomethingFromSequence(
 ): AasCommon.Either<AasTypes.Something, DeserializationError> {
   let theSomeNames: Array<string> | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -693,7 +719,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -833,6 +859,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -895,9 +952,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
 
   parts.push(openTag("someNames"));
     for (const itemSomeNames of that.someNames) {
-      parts.push(openTag("v"));
-      parts.push(serializeStringText(itemSomeNames));
-      parts.push(closeTag("v"));
+      writeVElement(parts, "v", serializeStringText(itemSomeNames));
     }
     parts.push(closeTag("someNames"));
 

--- a/dev/test_data/main/typescript/expected/list_of_enums/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_enums/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -366,21 +447,9 @@ class SetterForSomething {
   setSomeResultsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -412,26 +481,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -446,7 +511,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/list_of_enums/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_enums/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -659,38 +700,23 @@ function parseSomethingFromSequence(
 ): AasCommon.Either<AasTypes.Something, DeserializationError> {
   let theSomeResults: Array<AasTypes.Result> | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -715,7 +741,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -855,6 +881,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -917,9 +974,7 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
 
   parts.push(openTag("someResults"));
     for (const itemSomeResults of that.someResults) {
-      parts.push(openTag("v"));
-      parts.push(serializeResultText(itemSomeResults));
-      parts.push(closeTag("v"));
+      writeVElement(parts, "v", serializeResultText(itemSomeResults));
     }
     parts.push(closeTag("someResults"));
 

--- a/dev/test_data/main/typescript/expected/list_of_primitives/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_primitives/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -344,21 +425,9 @@ class SetterForSomething {
   setSomeBoolsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -384,21 +453,9 @@ class SetterForSomething {
   setSomeIntsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -424,21 +481,9 @@ class SetterForSomething {
   setSomeFloatsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -464,21 +509,9 @@ class SetterForSomething {
   setSomeStringsFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -504,21 +537,9 @@ class SetterForSomething {
   setSomeBytesFromJsonable(
     jsonable: JsonValue
   ): DeserializationError | null {
-    if (jsonable === null) {
-      return new DeserializationError(
-        "Expected an iterable, but got null"
-      );
-    }
-    if (typeof jsonable !== "object") {
-      return new DeserializationError(
-        `Expected an iterable, but got: ${typeof jsonable}`
-      );
-    }
-    if (typeof jsonable[Symbol.iterator] !== "function") {
-      return new DeserializationError(
-        "Expected an iterable with iterator function, " +
-          `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
-      );
+    const iterableError = checkIsIterable(jsonable);
+    if (iterableError !== null) {
+      return iterableError;
     }
 
     const iterable = <Iterable<JsonValue>>jsonable;
@@ -550,26 +571,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -584,7 +601,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/list_of_primitives/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/list_of_primitives/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -641,38 +682,23 @@ function parseSomethingFromSequence(
   let theSomeStrings: Array<string> | null = null;
   let theSomeBytes: Array<Uint8Array> | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -697,7 +723,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -729,7 +755,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -761,7 +787,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -793,7 +819,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -825,7 +851,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -993,6 +1019,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1055,41 +1112,31 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
 
   parts.push(openTag("someBools"));
     for (const itemSomeBools of that.someBools) {
-      parts.push(openTag("v"));
-      parts.push(serializeBooleanText(itemSomeBools));
-      parts.push(closeTag("v"));
+      writeVElement(parts, "v", serializeBooleanText(itemSomeBools));
     }
     parts.push(closeTag("someBools"));
 
   parts.push(openTag("someInts"));
     for (const itemSomeInts of that.someInts) {
-      parts.push(openTag("v"));
-      parts.push(serializeIntegerText(itemSomeInts));
-      parts.push(closeTag("v"));
+      writeVElement(parts, "v", serializeIntegerText(itemSomeInts));
     }
     parts.push(closeTag("someInts"));
 
   parts.push(openTag("someFloats"));
     for (const itemSomeFloats of that.someFloats) {
-      parts.push(openTag("v"));
-      parts.push(serializeFloatText(itemSomeFloats));
-      parts.push(closeTag("v"));
+      writeVElement(parts, "v", serializeFloatText(itemSomeFloats));
     }
     parts.push(closeTag("someFloats"));
 
   parts.push(openTag("someStrings"));
     for (const itemSomeStrings of that.someStrings) {
-      parts.push(openTag("v"));
-      parts.push(serializeStringText(itemSomeStrings));
-      parts.push(closeTag("v"));
+      writeVElement(parts, "v", serializeStringText(itemSomeStrings));
     }
     parts.push(closeTag("someStrings"));
 
   parts.push(openTag("someBytes"));
     for (const itemSomeBytes of that.someBytes) {
-      parts.push(openTag("v"));
-      parts.push(serializeBase64EncodedBytesText(itemSomeBytes));
-      parts.push(closeTag("v"));
+      writeVElement(parts, "v", serializeBase64EncodedBytesText(itemSomeBytes));
     }
     parts.push(closeTag("someBytes"));
 

--- a/dev/test_data/main/typescript/expected/primitive_types/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/primitive_types/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -450,26 +531,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -484,7 +561,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/primitive_types/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/primitive_types/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -641,38 +682,23 @@ function parseSomethingFromSequence(
   let theSomeString: string | null = null;
   let theSomeBytes: Uint8Array | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -696,7 +722,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -727,7 +753,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -758,7 +784,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -789,7 +815,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -820,7 +846,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -988,6 +1014,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1048,25 +1105,15 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("someBool"));
-    parts.push(serializeBooleanText(that.someBool));
-    parts.push(closeTag("someBool"));
+  writeVElement(parts, "someBool", serializeBooleanText(that.someBool));
 
-  parts.push(openTag("someInt"));
-    parts.push(serializeIntegerText(that.someInt));
-    parts.push(closeTag("someInt"));
+  writeVElement(parts, "someInt", serializeIntegerText(that.someInt));
 
-  parts.push(openTag("someFloat"));
-    parts.push(serializeFloatText(that.someFloat));
-    parts.push(closeTag("someFloat"));
+  writeVElement(parts, "someFloat", serializeFloatText(that.someFloat));
 
-  parts.push(openTag("someString"));
-    parts.push(serializeStringText(that.someString));
-    parts.push(closeTag("someString"));
+  writeVElement(parts, "someString", serializeStringText(that.someString));
 
-  parts.push(openTag("someBytes"));
-    parts.push(serializeBase64EncodedBytesText(that.someBytes));
-    parts.push(closeTag("someBytes"));
+  writeVElement(parts, "someBytes", serializeBase64EncodedBytesText(that.someBytes));
 
   return {
       localName: "something",

--- a/dev/test_data/main/typescript/expected/problematic_keywords/expected_output/src/jsonization.ts
+++ b/dev/test_data/main/typescript/expected/problematic_keywords/expected_output/src/jsonization.ts
@@ -157,6 +157,87 @@ function newDeserializationError<T>(
 }
 
 /**
+ * Check that `jsonable` looks like a JSON object, without parsing it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsJsonObject(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected a JSON object, but got null"
+    );
+  }
+  if (Array.isArray(jsonable)) {
+    return new DeserializationError(
+      "Expected a JSON object, but got a JSON array"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected a JSON object, but got: ${typeof jsonable}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that the parsed `modelType` matches `expected`.
+ *
+ * @param modelType - parsed value of the `modelType` property,
+ * or `null` if it was missing
+ * @param expected - expected model type
+ * @returns error, if any
+ */
+function checkModelType(
+  modelType: string | null,
+  expected: string
+): DeserializationError | null {
+  if (modelType === null) {
+    return new DeserializationError(
+      "The required property 'modelType' is missing"
+    );
+  }
+  if (modelType != expected) {
+    return new DeserializationError(
+      `Expected model type '${expected}', ` +
+      `but got: ${modelType}`
+    );
+  }
+
+  return null;
+}
+
+/**
+ * Check that `jsonable` looks like an iterable which can be parsed
+ * item-by-item, without consuming it.
+ *
+ * @param jsonable - to be checked
+ * @returns error, if any
+ */
+function checkIsIterable(jsonable: JsonValue): DeserializationError | null {
+  if (jsonable === null) {
+    return new DeserializationError(
+      "Expected an iterable, but got null"
+    );
+  }
+  if (typeof jsonable !== "object") {
+    return new DeserializationError(
+      `Expected an iterable, but got: ${typeof jsonable}`
+    );
+  }
+  if (typeof jsonable[Symbol.iterator] !== "function") {
+    return new DeserializationError(
+      "Expected an iterable with iterator function, " +
+        `but got iterator of type: ${typeof jsonable[Symbol.iterator]}`
+    );
+  }
+
+  return null;
+}
+
+/**
  * Parse every item of `iterable` with `parseItem`.
  *
  * @param iterable - to be parsed item-by-item
@@ -428,26 +509,22 @@ export function somethingFromJsonable(
   AasTypes.Something,
   DeserializationError
 > {
-  if (jsonable === null) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got null"
+  const objectError = checkIsJsonObject(jsonable);
+  if (objectError !== null) {
+    return new AasCommon.Either<
+      AasTypes.Something,
+      DeserializationError
+    >(
+      null,
+      objectError
     );
   }
-  if (Array.isArray(jsonable)) {
-    return newDeserializationError<AasTypes.Something>(
-      "Expected a JSON object, but got a JSON array"
-    );
-  }
-  if (typeof jsonable !== "object") {
-    return newDeserializationError<AasTypes.Something>(
-      `Expected a JSON object, but got: ${typeof jsonable}`
-    );
-  }
+  const jsonObject = <JsonObject>jsonable;
 
   const setter = new SetterForSomething();
 
-  for (const key in jsonable) {
-    const jsonableValue = jsonable[key];
+  for (const key in jsonObject) {
+    const jsonableValue = jsonObject[key];
     const setterMethod =
       SETTER_MAP_FOR_SOMETHING.get(key);
 
@@ -462,7 +539,7 @@ export function somethingFromJsonable(
     const error = setterMethod.call(setter, jsonableValue);
     if (error !== null) {
       error.path.prepend(
-        new PropertySegment(<JsonObject>jsonable, key)
+        new PropertySegment(jsonObject, key)
       );
       return new AasCommon.Either<
         AasTypes.Something,

--- a/dev/test_data/main/typescript/expected/problematic_keywords/expected_output/src/xmlization.ts
+++ b/dev/test_data/main/typescript/expected/problematic_keywords/expected_output/src/xmlization.ts
@@ -177,6 +177,47 @@ function checkExpectedOpenTagNamespace(
   return null;
 }
 
+/**
+ * Read the next property's opening tag while parsing the sequence of
+ * properties of `className`, advancing `cursor` past it.
+ *
+ * @param cursor - to be read from
+ * @param className - name of the class being parsed, for error reporting
+ * @returns
+ * the next property's opening tag, or `null` if the closing tag of
+ * `className` was reached instead, or an error
+ */
+function nextPropertyOpenTag(
+  cursor: XmlCursor,
+  className: string
+): OpenTagToken | DeserializationError | null {
+  const token = cursor.current();
+  if (token === null) {
+    return new DeserializationError(
+      `Unexpected end of token stream while parsing ${className}`
+    );
+  }
+
+  if (token instanceof CloseTagToken) {
+    return null;
+  }
+
+  if (!(token instanceof OpenTagToken)) {
+    return new DeserializationError(
+      "Expected an XML property start element or the closing element of " +
+      `${className}, but got token kind: ${token.kind}`
+    );
+  }
+
+  const namespaceError = checkExpectedOpenTagNamespace(token);
+  if (namespaceError !== null) {
+    return namespaceError;
+  }
+
+  cursor.advance();
+  return token;
+}
+
 function checkExpectedCloseTag(
   closeTag: CloseTagToken,
   expectedLocalName: string
@@ -640,38 +681,23 @@ function parseSomethingFromSequence(
   let theRange: string | null = null;
   let theVoid: string | null = null;
 
+  const className = AasTypes.Something.name;
+
   cursor.skipIgnorable();
   // eslint-disable-next-line no-constant-condition
   while (true) {
-    const token = cursor.current();
-    if (token === null) {
-      return newDeserializationError<AasTypes.Something>(
-        `Unexpected end of token stream while parsing Something`
-      );
-    }
-
-    if (token instanceof CloseTagToken) {
+    const nextTagOrError = nextPropertyOpenTag(cursor, className);
+    if (nextTagOrError === null) {
       break;
     }
-
-    if (!(token instanceof OpenTagToken)) {
-      return newDeserializationError<AasTypes.Something>(
-        "Expected an XML property start element or the closing element of " +
-        `Something, but got token kind: ${token.kind}`
-      );
-    }
-
-    const namespaceError = checkExpectedOpenTagNamespace(token);
-    if (namespaceError !== null) {
+    if (nextTagOrError instanceof DeserializationError) {
       return new AasCommon.Either<AasTypes.Something, DeserializationError>(
         null,
-        namespaceError
+        nextTagOrError
       );
     }
 
-    const propertyStartTag = token;
-    const propertyLocalName = localNameOfTag(propertyStartTag.tag);
-    cursor.advance();
+    const propertyLocalName = localNameOfTag(nextTagOrError.tag);
 
     let propertyError: DeserializationError | null = null;
     switch (propertyLocalName) {
@@ -695,7 +721,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -726,7 +752,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -757,7 +783,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -788,7 +814,7 @@ function parseSomethingFromSequence(
 
         const propertyCloseError = consumeCloseTag(
           cursor,
-          localNameOfTag(propertyStartTag.tag)
+          propertyLocalName
         );
         if (propertyCloseError !== null) {
           propertyError = propertyCloseError;
@@ -949,6 +975,37 @@ function closeTag(localName: string): string {
   return `</${localName}>`;
 }
 
+/**
+ * Push `content` wrapped in its own `localName` element onto `parts`.
+ *
+ * We push the opening tag, the content and the closing tag as three separate
+ * entries instead of pre-concatenating them, so that ``parts.join("")`` at
+ * the top level copies the (possibly large, deeply nested) `content` exactly
+ * once.
+ */
+function writeVElement(
+  parts: Array<string>,
+  localName: string,
+  content: string
+): void {
+  parts.push(openTag(localName));
+  parts.push(content);
+  parts.push(closeTag(localName));
+}
+
+/**
+ * Push a class instance already serialized to XML parts onto `parts`, wrapped
+ * in its own element as given by {@link SerializedElement.localName}.
+ */
+function writeClassElement(
+  parts: Array<string>,
+  serialized: SerializedElement
+): void {
+  parts.push(openTag(serialized.localName));
+  parts.push(serialized.innerXml);
+  parts.push(closeTag(serialized.localName));
+}
+
 function escapeXmlText(text: string): string {
   return text
     .replace(/&/g, "&amp;")
@@ -1009,21 +1066,13 @@ class Serializer extends AasTypes.AbstractTransformer<SerializedElement> {
   ): SerializedElement {
   const parts = new Array<string>();
 
-  parts.push(openTag("interface"));
-    parts.push(serializeStringText(that.interface));
-    parts.push(closeTag("interface"));
+  writeVElement(parts, "interface", serializeStringText(that.interface));
 
-  parts.push(openTag("type"));
-    parts.push(serializeStringText(that.type));
-    parts.push(closeTag("type"));
+  writeVElement(parts, "type", serializeStringText(that.type));
 
-  parts.push(openTag("range"));
-    parts.push(serializeStringText(that.range));
-    parts.push(closeTag("range"));
+  writeVElement(parts, "range", serializeStringText(that.range));
 
-  parts.push(openTag("void"));
-    parts.push(serializeStringText(that.void));
-    parts.push(closeTag("void"));
+  writeVElement(parts, "void", serializeStringText(that.void));
 
   return {
       localName: "something",


### PR DESCRIPTION
We factor out repeated boilerplate in the generated TypeScript de/serialization code into shared runtime helpers, reducing generated code size and fixing a couple of genuinely redundant computations.

JSON parsing:
* checkIsIterable(jsonable) replaces the null/typeof/Symbol.iterator checks that were duplicated at every list-typed property setter.
* checkIsJsonObject(jsonable) replaces the null/Array.isArray/typeof checks duplicated at every concrete class's and interface's fromJsonable function.
* checkModelType(modelType, expected) replaces the required/mismatch check duplicated once per class with a model type.

XML serialization:
* writeVElement/writeClassElement push directly into the shared `parts` array instead of each call site inlining openTag/content/closeTag, without introducing any extra string concatenation or array allocation compared to the original code.

XML parsing:
* nextPropertyOpenTag(cursor, className) replaces the ~25-line token-read/end-of-stream/close-tag/wrong-token-kind/namespace-check preamble that was duplicated in every class's property-parsing loop. It returns the token, `null`, or a DeserializationError directly, so it adds no allocation over the original inlined code despite running once per property parsed, not just once per instance.
* Property close-tag consumption now reuses the already-computed `propertyLocalName` instead of redundantly recomputing `localNameOfTag(propertyStartTag.tag)`.