### PR TITLE
Reuse StringFrom for modelType extraction in C#

### DIFF
--- a/aas_core_codegen/csharp/lib/_generate_jsonization.py
+++ b/aas_core_codegen/csharp/lib/_generate_jsonization.py
@@ -98,21 +98,16 @@ if (modelTypeNode == null)
 {II}"Expected a model type, but none is present");
 {I}return null;
 }}
-Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-if (modelTypeValue == null)
+string? modelType = DeserializeImplementation.StringFrom(
+{I}modelTypeNode, out error);
+if (error != null)
 {{
-{I}error = new Reporting.Error(
-{II}"Expected JsonValue, " +
-{II}$"but got {{modelTypeNode.GetType()}}");
 {I}return null;
 }}
-modelTypeValue.TryGetValue<string>(out string? modelType);
 if (modelType == null)
 {{
-{I}error = new Reporting.Error(
-{II}"Expected a string, " +
-{II}$"but the conversion failed from {{modelTypeValue}}");
-{I}return null;
+{I}throw new System.InvalidOperationException(
+{II}"Unexpected modelType null when error null");
 }}"""
         ),
     ]  # type: List[Stripped]
@@ -215,21 +210,16 @@ if (obj == null)
 Nodes.JsonNode? modelTypeNode = obj["modelType"];
 if (modelTypeNode != null)
 {{
-{I}Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-{I}if (modelTypeValue == null)
+{I}string? modelType = DeserializeImplementation.StringFrom(
+{II}modelTypeNode, out error);
+{I}if (error != null)
 {I}{{
-{II}error = new Reporting.Error(
-{III}"Expected JsonValue, " +
-{III}$"but got {{modelTypeNode.GetType()}}");
 {II}return null;
 {I}}}
-{I}modelTypeValue.TryGetValue<string>(out string? modelType);
 {I}if (modelType == null)
 {I}{{
-{II}error = new Reporting.Error(
-{III}"Expected a string, " +
-{III}$"but the conversion failed from {{modelTypeValue}}");
-{II}return null;
+{II}throw new System.InvalidOperationException(
+{III}"Unexpected modelType null when error null");
 {I}}}
 
 {I}switch (modelType)

--- a/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/jsonization.cs
@@ -353,21 +353,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -707,21 +702,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -812,21 +802,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -917,21 +902,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -1010,21 +990,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -1067,21 +1042,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -1377,21 +1347,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -3358,21 +3323,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -3454,21 +3414,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -5032,21 +4987,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -9416,21 +9366,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -11895,21 +11840,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -12342,21 +12282,16 @@ namespace AasCore.Aas3_0
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)

--- a/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/jsonization.cs
@@ -353,21 +353,16 @@ namespace dummy
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -416,21 +411,16 @@ namespace dummy
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -633,21 +623,16 @@ namespace dummy
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)

--- a/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/jsonization.cs
@@ -353,21 +353,16 @@ namespace dummy
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)

--- a/dev/test_data/main/csharp/expected/tuples/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/tuples/expected_output/dummy/jsonization.cs
@@ -705,21 +705,16 @@ namespace dummy
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)

--- a/dev/test_data/main/csharp/expected/unions/expected_output/dummy/jsonization.cs
+++ b/dev/test_data/main/csharp/expected/unions/expected_output/dummy/jsonization.cs
@@ -753,21 +753,16 @@ namespace dummy
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -961,21 +956,16 @@ namespace dummy
                         "Expected a model type, but none is present");
                     return null;
                 }
-                Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                if (modelTypeValue == null)
+                string? modelType = DeserializeImplementation.StringFrom(
+                    modelTypeNode, out error);
+                if (error != null)
                 {
-                    error = new Reporting.Error(
-                        "Expected JsonValue, " +
-                        $"but got {modelTypeNode.GetType()}");
                     return null;
                 }
-                modelTypeValue.TryGetValue<string>(out string? modelType);
                 if (modelType == null)
                 {
-                    error = new Reporting.Error(
-                        "Expected a string, " +
-                        $"but the conversion failed from {modelTypeValue}");
-                    return null;
+                    throw new System.InvalidOperationException(
+                        "Unexpected modelType null when error null");
                 }
 
                 switch (modelType)
@@ -1359,21 +1349,16 @@ namespace dummy
                 Nodes.JsonNode? modelTypeNode = obj["modelType"];
                 if (modelTypeNode != null)
                 {
-                    Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                    if (modelTypeValue == null)
+                    string? modelType = DeserializeImplementation.StringFrom(
+                        modelTypeNode, out error);
+                    if (error != null)
                     {
-                        error = new Reporting.Error(
-                            "Expected JsonValue, " +
-                            $"but got {modelTypeNode.GetType()}");
                         return null;
                     }
-                    modelTypeValue.TryGetValue<string>(out string? modelType);
                     if (modelType == null)
                     {
-                        error = new Reporting.Error(
-                            "Expected a string, " +
-                            $"but the conversion failed from {modelTypeValue}");
-                        return null;
+                        throw new System.InvalidOperationException(
+                            "Unexpected modelType null when error null");
                     }
 
                     switch (modelType)
@@ -1721,21 +1706,16 @@ namespace dummy
                 Nodes.JsonNode? modelTypeNode = obj["modelType"];
                 if (modelTypeNode != null)
                 {
-                    Nodes.JsonValue? modelTypeValue = modelTypeNode as Nodes.JsonValue;
-                    if (modelTypeValue == null)
+                    string? modelType = DeserializeImplementation.StringFrom(
+                        modelTypeNode, out error);
+                    if (error != null)
                     {
-                        error = new Reporting.Error(
-                            "Expected JsonValue, " +
-                            $"but got {modelTypeNode.GetType()}");
                         return null;
                     }
-                    modelTypeValue.TryGetValue<string>(out string? modelType);
                     if (modelType == null)
                     {
-                        error = new Reporting.Error(
-                            "Expected a string, " +
-                            $"but the conversion failed from {modelTypeValue}");
-                        return null;
+                        throw new System.InvalidOperationException(
+                            "Unexpected modelType null when error null");
                     }
 
                     switch (modelType)


### PR DESCRIPTION
The interface and named-union deserialization methods duplicated the JsonValue-cast-and-TryGetValue logic for extracting the modelType string inline, instead of reusing the existing
``DeserializeImplementation.StringFrom`` already used for this exact purpose elsewhere. This reduces the generated code size at every interface and named-union ``*From`` method.