### PR TITLE
Remove ``textwrap.dedent``

### DIFF
--- a/aas_core_codegen/csharp/lib/_generate_reporting.py
+++ b/aas_core_codegen/csharp/lib/_generate_reporting.py
@@ -74,8 +74,6 @@ private static readonly System.Text.RegularExpressions.Regex VariableNameRe = (
 {I}new System.Text.RegularExpressions.Regex(
 {II}@"^[a-zA-Z_][a-zA-Z_0-9]*$"));"""
         ),
-        # We have to indent a lot, so we do not use textwrap.dedent for better
-        # readability.
         Stripped(
             f"""\
 /// <summary>

--- a/aas_core_codegen/csharp/lib/_generate_types.py
+++ b/aas_core_codegen/csharp/lib/_generate_types.py
@@ -648,14 +648,12 @@ class _DescendBodyUnroller(csharp_unrolling.AbstractUnroller):
 
                     result.append(
                         csharp_unrolling.Node(
-                            text=textwrap.dedent(
-                                f"""\
-                            // Recurse
-                            foreach (var {recurse_var} in {unrollee_expr}.Underlying.Descend())
-                            {{
-                                yield return {recurse_var};
-                            }}"""
-                            ),
+                            text=f"""\
+// Recurse
+foreach (var {recurse_var} in {unrollee_expr}.Underlying.Descend())
+{{
+    yield return {recurse_var};
+}}""",
                             children=[],
                         )
                     )
@@ -680,14 +678,12 @@ class _DescendBodyUnroller(csharp_unrolling.AbstractUnroller):
 
                 result.append(
                     csharp_unrolling.Node(
-                        text=textwrap.dedent(
-                            f"""\
-                        // Recurse
-                        foreach (var {recurse_var} in {unrollee_expr}.Descend())
-                        {{
-                            yield return {recurse_var};
-                        }}"""
-                        ),
+                        text=f"""\
+// Recurse
+foreach (var {recurse_var} in {unrollee_expr}.Descend())
+{{
+    yield return {recurse_var};
+}}""",
                         children=[],
                     )
                 )

--- a/aas_core_codegen/csharp/lib/_generate_verification.py
+++ b/aas_core_codegen/csharp/lib/_generate_verification.py
@@ -821,14 +821,11 @@ def _generate_transform_property(
         )
         # Heuristic to break the lines, very rudimentary
         if len(foreach_error_in_verify) > 80:
-            foreach_error_in_verify = textwrap.dedent(
-                f"""\
-                foreach (
-                    {I}var error in {verify_method}(
-                    {II}{source_expr}))"""
-            )
+            foreach_error_in_verify = f"""\
+foreach (
+    {I}var error in {verify_method}(
+    {II}{source_expr}))"""
 
-        # We can't use textwrap.dedent due to foreach_snippet.
         stmts.append(
             Stripped(
                 f"""\
@@ -859,19 +856,15 @@ def _generate_transform_property(
         foreach_item_in_source_expr = f"foreach (var item in {source_expr})"
         # Rudimentary heuristics for line breaking
         if len(foreach_item_in_source_expr) > 80:
-            foreach_item_in_source_expr = textwrap.dedent(
-                f"""\
-                foreach(
-                {I}var item in {source_expr})"""
-            )
+            foreach_item_in_source_expr = f"""\
+foreach(
+{I}var item in {source_expr})"""
 
         foreach_error_in_verify_item = f"foreach (var error in {verify_method}(item))"
         if len(foreach_error_in_verify_item) > 70:
-            foreach_error_in_verify_item = textwrap.dedent(
-                f"""\
-                foreach (
-                {I}var error in {verify_method}(item))"""
-            )
+            foreach_error_in_verify_item = f"""\
+foreach (
+{I}var error in {verify_method}(item))"""
 
         stmts.append(
             Stripped(
@@ -910,14 +903,11 @@ int {index_var} = 0;
             )
             # Heuristic to break the lines, very rudimentary
             if len(foreach_error_in_verify) > 80:
-                foreach_error_in_verify = textwrap.dedent(
-                    f"""\
-                    foreach (
-                        {I}var error in {verify_method}(
-                        {II}{item_expr}))"""
-                )
+                foreach_error_in_verify = f"""\
+foreach (
+    {I}var error in {verify_method}(
+    {II}{item_expr}))"""
 
-            # We can't use textwrap.dedent due to foreach_snippet.
             stmts.append(
                 Stripped(
                     f"""\
@@ -1492,8 +1482,6 @@ namespace {namespace}
         an_instance_variable = csharp_naming.variable_name(Identifier("an_instance"))
 
         verification_writer.write(
-            # We can not use textwrap.dedent since we indent everything including the
-            # first line.
             f"""\
 {I}/// <example>
 {I}/// Here is an example how to verify an instance of {cls_name}:

--- a/aas_core_codegen/java/lib/_generate_reporting.py
+++ b/aas_core_codegen/java/lib/_generate_reporting.py
@@ -63,8 +63,6 @@ public static class IndexSegment extends Segment{{
             """\
 private static final Pattern variableNameRe = Pattern.compile("^[a-zA-Z_][a-zA-Z_0-9]*$");"""
         ),
-        # We have to indent a lot, so we do not use textwrap.dedent for better
-        # readability.
         Stripped(
             f"""\
 /**

--- a/aas_core_codegen/java/lib/_generate_verification.py
+++ b/aas_core_codegen/java/lib/_generate_verification.py
@@ -1574,8 +1574,6 @@ private static <A, B> Stream<_Pair<A, B>> zip(
         an_instance_variable = java_naming.variable_name(Identifier("an_instance"))
 
         verification_writer.write(
-            # We can not use textwrap.dedent since we indent everything including the
-            # first line.
             f"""\
 {I} * <p>Here is an example how to verify an instance of {cls_name}:
 {I} * {{@code

--- a/dev/tests/csharp/live_test_main.py
+++ b/dev/tests/csharp/live_test_main.py
@@ -9,7 +9,6 @@ import pathlib
 import subprocess
 import sys
 import tempfile
-import textwrap
 
 import aas_core_codegen.main
 import tests.common
@@ -77,19 +76,17 @@ def main() -> int:
             print("Generating the .csproj file...")
             csproj_pth = output_dir / "SomeProject.csproj"
             csproj_pth.write_text(
-                textwrap.dedent(
-                    """\
-                <Project Sdk="Microsoft.NET.Sdk">
-                    <PropertyGroup>
-                        <TargetFramework>net6.0</TargetFramework>
-                        <Nullable>enable</Nullable>
-                        <Configurations>Debug;Release;DebugSlow</Configurations>
-                        <Platforms>AnyCPU</Platforms>
-                        <LangVersion>8</LangVersion>
-                    </PropertyGroup>
-                </Project>
-                """
-                ),
+                """\
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <Configurations>Debug;Release;DebugSlow</Configurations>
+        <Platforms>AnyCPU</Platforms>
+        <LangVersion>8</LangVersion>
+    </PropertyGroup>
+</Project>
+""",
                 encoding="utf-8",
             )
 

--- a/dev/tests/csharp/test_description.py
+++ b/dev/tests/csharp/test_description.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest.mock
 
 # noinspection PyProtectedMember
@@ -33,14 +32,12 @@ class Test_to_render_description_of_meta_model(unittest.TestCase):
         return code
 
     def test_empty_description_not_allowed(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            """"""  # Intentionally left empty
+        source = '''\
+""""""  # Intentionally left empty
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = tests.common.translate_source_to_intermediate(source=source)
         assert error is not None
@@ -50,23 +47,19 @@ class Test_to_render_description_of_meta_model(unittest.TestCase):
 
     def test_only_summary(self) -> None:
         comment_code = self.__class__.render(
-            textwrap.dedent(
-                '''\
-                """Do & drink something."""
+            '''\
+"""Do & drink something."""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                /// <summary>
-                /// Do &amp; drink something.
-                /// </summary>"""
-            ),
+            """\
+/// <summary>
+/// Do &amp; drink something.
+/// </summary>""",
             comment_code,
         )
 
@@ -99,15 +92,13 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         return code
 
     def test_empty_description_not_allowed(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """"""  # Intentionally left empty
+        source = '''\
+class Some_class:
+    """"""  # Intentionally left empty
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = tests.common.translate_source_to_intermediate(source=source)
         assert error is not None
@@ -116,19 +107,17 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         )
 
     def test_no_summary(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """
-                * Some
-                * Bullet
-                * List
-                """
+        source = '''\
+class Some_class:
+    """
+    * Some
+    * Bullet
+    * List
+    """
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = tests.common.translate_source_to_intermediate(source=source)
 
@@ -146,20 +135,18 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         )
 
     def test_unexpected_directive(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """
-                Do something.
+        source = '''\
+class Some_class:
+    """
+    Do something.
 
-                :someDirective:
-                    I am unexpected.
-                """
+    :someDirective:
+        I am unexpected.
+    """
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = tests.common.translate_source_to_intermediate(source=source)
 
@@ -173,38 +160,32 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
     def test_only_summary(self) -> None:
         comment_code = Test_to_render_description_of_our_types.render(
-            textwrap.dedent(
-                '''\
-                class Something:
-                    """Do & drink something."""
+            '''\
+class Something:
+    """Do & drink something."""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                /// <summary>
-                /// Do &amp; drink something.
-                /// </summary>"""
-            ),
+            """\
+/// <summary>
+/// Do &amp; drink something.
+/// </summary>""",
             comment_code,
         )
 
     def test_summary_with_class_reference(self) -> None:
         comment_code = Test_to_render_description_of_our_types.render(
-            textwrap.dedent(
-                '''\
-                class Something:
-                    """Do & drink :class:`Something`."""
+            '''\
+class Something:
+    """Do & drink :class:`Something`."""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
@@ -217,68 +198,58 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
 
     def test_summary_with_interface_reference(self) -> None:
         comment_code = Test_to_render_description_of_our_types.render(
-            textwrap.dedent(
-                '''\
-                @abstract
-                class Something:
-                    """Do & drink :class:`Something`."""
+            '''\
+@abstract
+class Something:
+    """Do & drink :class:`Something`."""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                /// <summary>
-                /// Do &amp; drink <see cref="Aas.ISomething" />.
-                /// </summary>"""
-            ),
+            """\
+/// <summary>
+/// Do &amp; drink <see cref="Aas.ISomething" />.
+/// </summary>""",
             comment_code,
         )
 
     def test_summary_with_enumeration_reference(self) -> None:
         comment_code = Test_to_render_description_of_our_types.render(
-            textwrap.dedent(
-                '''\
-                class Something(Enum):
-                    """Do & drink :class:`Something`."""
+            '''\
+class Something(Enum):
+    """Do & drink :class:`Something`."""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                /// <summary>
-                /// Do &amp; drink <see cref="Aas.Something" />.
-                /// </summary>"""
-            ),
+            """\
+/// <summary>
+/// Do &amp; drink <see cref="Aas.Something" />.
+/// </summary>""",
             comment_code,
         )
 
     def test_summary_and_remarks(self) -> None:
         comment_code = Test_to_render_description_of_our_types.render(
-            textwrap.dedent(
-                '''\
-                class Something:
-                    """
-                    Do & drink something.
+            '''\
+class Something:
+    """
+    Do & drink something.
 
-                    First & remark.
+    First & remark.
 
-                    Second & remark.
-                    """
+    Second & remark.
+    """
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
@@ -304,33 +275,31 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
             # 1) a single-paragraph constraint,
             # 2) a two-paragraph constraint, and
             # 3) a constraint with an unordered list.
-            textwrap.dedent(
-                '''\
-                class Something:
-                    """
-                    Do & drink something.
+            '''\
+class Something:
+    """
+    Do & drink something.
 
-                    First & remark.
+    First & remark.
 
-                    :constraint AAS-001:
-                        You shall parse.
+    :constraint AAS-001:
+        You shall parse.
 
-                    :constraint AAS-002:
-                        You have to do something.
+    :constraint AAS-002:
+        You have to do something.
 
-                        Really.
+        Really.
 
-                    :constraint AAS-003:
-                        You shall:
+    :constraint AAS-003:
+        You shall:
 
-                        * Do something,
-                        * And do it now.
-                    """
+        * Do something,
+        * And do it now.
+    """
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
         self.assertEqual(
             """\
@@ -383,22 +352,20 @@ class Test_to_render_description_of_our_types(unittest.TestCase):
         # a regression test as we did not render it correctly at first. There was
         # a ``<para>`` nested in the ``<remarks>`` element.
         comment_code = Test_to_render_description_of_our_types.render(
-            textwrap.dedent(
-                '''\
-                class Something:
-                    """
-                    Global reference to the data specification template used by
-                    the element.
+            '''\
+class Something:
+    """
+    Global reference to the data specification template used by
+    the element.
 
-                    .. note::
+    .. note::
 
-                        This is a global reference.
-                    """
+        This is a global reference.
+    """
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
@@ -445,17 +412,15 @@ class Test_to_render_description_of_signature(unittest.TestCase):
         return code
 
     def test_empty_description_not_allowed(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            @verification
-            def verify_something(text: str) -> bool:
-                """"""  # Intentionally left empty
-                return match(r'.*', text) is not None
+        source = '''\
+@verification
+def verify_something(text: str) -> bool:
+    """"""  # Intentionally left empty
+    return match(r'.*', text) is not None
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = tests.common.translate_source_to_intermediate(source=source)
 
@@ -466,58 +431,52 @@ class Test_to_render_description_of_signature(unittest.TestCase):
         )
 
     def test_only_summary(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            @verification
-            def verify_something(text: str) -> bool:
-                """Verify something."""
-                return match(r'^.*$', text) is not None
+        source = '''\
+@verification
+def verify_something(text: str) -> bool:
+    """Verify something."""
+    return match(r'^.*$', text) is not None
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         code = Test_to_render_description_of_signature.render(source=source)
 
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                /// <summary>
-                /// Verify something.
-                /// </summary>"""
-            ),
+            """\
+/// <summary>
+/// Verify something.
+/// </summary>""",
             code,
         )
 
     def test_params_and_returns(self) -> None:
         # NOTE (mristin, 2022-07-21):
         # We explicitly check here for multiple paragraphs in the param and returns.
-        source = textwrap.dedent(
-            '''\
-            @verification
-            def verify_something(first: str, second: str) -> bool:
-                """
-                Verify something.
+        source = '''\
+@verification
+def verify_something(first: str, second: str) -> bool:
+    """
+    Verify something.
 
-                :param first: to be checked
-                :param second:
-                    another thing to be checked.
+    :param first: to be checked
+    :param second:
+        another thing to be checked.
 
-                    really to be checked.
+        really to be checked.
 
-                :returns:
-                    True if :paramref:`first` and :paramref:`second` are
-                    a valid something.
+    :returns:
+        True if :paramref:`first` and :paramref:`second` are
+        a valid something.
 
-                    Otherwise, return false.
-                """
-                return match(r'.*', text) is not None
+        Otherwise, return false.
+    """
+    return match(r'.*', text) is not None
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         code = Test_to_render_description_of_signature.render(source=source)
 
@@ -575,42 +534,36 @@ class Test_to_render_paragraphs(unittest.TestCase):
 
     def test_single_paragraph(self) -> None:
         comment_code = self.__class__.render(
-            textwrap.dedent(
-                '''\
-                """Write a single paragraph."""
+            '''\
+"""Write a single paragraph."""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
-            textwrap.dedent(
-                """\
-                /// <summary>
-                /// Write a single paragraph.
-                /// </summary>"""
-            ),
+            """\
+/// <summary>
+/// Write a single paragraph.
+/// </summary>""",
             comment_code,
         )
 
     def test_multiple_text_remarks(self) -> None:
         comment_code = self.__class__.render(
-            textwrap.dedent(
-                '''\
-                """
-                This is summary.
+            '''\
+"""
+This is summary.
 
-                This is first paragraph of remarks.
+This is first paragraph of remarks.
 
-                This is second paragraph of remarks.
-                """
+This is second paragraph of remarks.
+"""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(
@@ -631,25 +584,23 @@ class Test_to_render_paragraphs(unittest.TestCase):
 
     def test_multiple_remarks_of_mixed_lists_and_text(self) -> None:
         comment_code = self.__class__.render(
-            textwrap.dedent(
-                '''\
-                """
-                This is summary.
+            '''\
+"""
+This is summary.
 
-                This is first paragraph of remarks.
+This is first paragraph of remarks.
 
-                This is a list:
+This is a list:
 
-                * First item
-                * Second item
+* First item
+* Second item
 
-                This is the third paragraph.
-                """
+This is the third paragraph.
+"""
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                '''
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
         )
 
         self.assertEqual(

--- a/dev/tests/infer_for_schema/test_len_on_properties.py
+++ b/dev/tests/infer_for_schema/test_len_on_properties.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest
 
 import tests.common
@@ -10,18 +9,16 @@ from aas_core_codegen import infer_for_schema
 
 class Test_expected(unittest.TestCase):
     def test_no_constraints(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                some_property: str
+        source = """\
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -43,23 +40,21 @@ class Test_expected(unittest.TestCase):
         assert constraints is None
 
     def test_min_value_constant_left(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: 10 < len(self.some_property),
-                "Some property must be more than 10 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: 10 < len(self.some_property),
+    "Some property must be more than 10 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -93,23 +88,21 @@ Constraints(
         )
 
     def test_min_value_constant_right(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) > 10,
-                "Some property must be more than 10 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) > 10,
+    "Some property must be more than 10 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -143,23 +136,21 @@ Constraints(
         )
 
     def test_max_value_constant_right(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) < 10,
-                "Some property must be less than 10 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) < 10,
+    "Some property must be less than 10 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -193,23 +184,21 @@ Constraints(
         )
 
     def test_max_value_constant_left(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: 10 > len(self.some_property),
-                "Some property must be less than 10 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: 10 > len(self.some_property),
+    "Some property must be less than 10 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -243,25 +232,23 @@ Constraints(
         )
 
     def test_max_value_constant_right_and_not_required(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self:
-                not (self.some_property is not None)
-                or len(self.some_property) <= 128,
-                "Some property must be at most 128 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self:
+    not (self.some_property is not None)
+    or len(self.some_property) <= 128,
+    "Some property must be at most 128 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -295,23 +282,21 @@ Constraints(
         )
 
     def test_exact_value_constant_left(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: 10 == len(self.some_property),
-                "Some property must be exactly 10 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: 10 == len(self.some_property),
+    "Some property must be exactly 10 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -345,23 +330,21 @@ Constraints(
         )
 
     def test_exact_value_constant_right(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) == 10,
-                "Some property must be exactly 10 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) == 10,
+    "Some property must be exactly 10 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -395,25 +378,23 @@ Constraints(
         )
 
     def test_conditioned_on_property(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self:
-                not (self.some_property is not None)
-                or len(self.some_property) == 10,
-                "Some property must be exactly 10 characters long."
-            )
-            class Something:
-                some_property: Optional[str]
+        source = """\
+@invariant(
+    lambda self:
+    not (self.some_property is not None)
+    or len(self.some_property) == 10,
+    "Some property must be exactly 10 characters long."
+)
+class Something:
+    some_property: Optional[str]
 
-                def __init__(self, some_property: Optional[str] = None) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Optional[str] = None) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -449,27 +430,25 @@ Constraints(
 
 class Test_unexpected(unittest.TestCase):
     def test_conflicting_min_and_max(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) > 10,
-                "Some property must be more than 10 characters long."
-            )
-            @invariant(
-                lambda self: len(self.some_property) < 3,
-                "Some property must be less than 3 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) > 10,
+    "Some property must be more than 10 characters long."
+)
+@invariant(
+    lambda self: len(self.some_property) < 3,
+    "Some property must be less than 3 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         (
             symbol_table,
@@ -490,27 +469,25 @@ class Test_unexpected(unittest.TestCase):
         )
 
     def test_conflicting_min_and_exact(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) > 10,
-                "Some property must be more than 10 characters long."
-            )
-            @invariant(
-                lambda self: len(self.some_property) == 3,
-                "Some property must be exactly 3 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) > 10,
+    "Some property must be more than 10 characters long."
+)
+@invariant(
+    lambda self: len(self.some_property) == 3,
+    "Some property must be exactly 3 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         (
             symbol_table,
@@ -531,27 +508,25 @@ class Test_unexpected(unittest.TestCase):
         )
 
     def test_conflicting_max_and_exact(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) < 10,
-                "Some property must be less than 10 characters long."
-            )
-            @invariant(
-                lambda self: len(self.some_property) == 30,
-                "Some property must be exactly 30 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) < 10,
+    "Some property must be less than 10 characters long."
+)
+@invariant(
+    lambda self: len(self.some_property) == 30,
+    "Some property must be exactly 30 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         (
             symbol_table,
@@ -574,23 +549,21 @@ class Test_unexpected(unittest.TestCase):
 
 class Test_stacking(unittest.TestCase):
     def test_no_inheritance_involved(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) < 10,
-                "Some property must be less than 10 characters long."
-            )
-            class Something:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) < 10,
+    "Some property must be less than 10 characters long."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -624,31 +597,29 @@ Constraints(
         )
 
     def test_inheritance_from_parent_with_no_patterns_of_own(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) > 3,
-                "Some property must be more than 3 characters long."
-            )
-            class Parent:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) > 3,
+    "Some property must be more than 3 characters long."
+)
+class Parent:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
-
-
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(
-                        self,
-                        some_property=some_property
-                    )
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
+class Something(Parent):
+    def __init__(self, some_property: str) -> None:
+        Parent.__init__(
+            self,
+            some_property=some_property
         )
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -682,35 +653,33 @@ Constraints(
         )
 
     def test_merge_with_parent(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self.some_property) > 3,
-                "Some property must be more than 3 characters long."
-            )
-            class Parent:
-                some_property: str
+        source = """\
+@invariant(
+    lambda self: len(self.some_property) > 3,
+    "Some property must be more than 3 characters long."
+)
+class Parent:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
-
-
-            @invariant(
-                lambda self: len(self.some_property) < 10,
-                "Some property must be less than 10 characters long."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(
-                        self,
-                        some_property=some_property
-                    )
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
+@invariant(
+    lambda self: len(self.some_property) < 10,
+    "Some property must be less than 10 characters long."
+)
+class Something(Parent):
+    def __init__(self, some_property: str) -> None:
+        Parent.__init__(
+            self,
+            some_property=some_property
         )
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -751,33 +720,31 @@ Constraints(
         #
         # This unit test illustrates the setting, and prevents regressions.
 
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Abstract_lang_string(DBC):
-                text: str
+        source = """\
+@abstract
+class Abstract_lang_string(DBC):
+    text: str
 
-                def __init__(
-                    self, text: str
-                ) -> None:
-                    self.text = text
-
-
-            @invariant(
-                lambda self: len(self.text) <= 128,
-                "String shall have a maximum length of 128 characters."
-            )
-            class Something(Abstract_lang_string, DBC):
-                def __init__(
-                    self, text: str
-                ) -> None:
-                    Abstract_lang_string.__init__(self, text=text)
+    def __init__(
+        self, text: str
+    ) -> None:
+        self.text = text
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+@invariant(
+    lambda self: len(self.text) <= 128,
+    "String shall have a maximum length of 128 characters."
+)
+class Something(Abstract_lang_string, DBC):
+    def __init__(
+        self, text: str
+    ) -> None:
+        Abstract_lang_string.__init__(self, text=text)
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (

--- a/dev/tests/infer_for_schema/test_len_on_self.py
+++ b/dev/tests/infer_for_schema/test_len_on_self.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest
 
 import tests.common
@@ -10,23 +9,21 @@ from aas_core_codegen import infer_for_schema
 
 class Test_expected(unittest.TestCase):
     def test_no_constraints(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -48,27 +45,25 @@ class Test_expected(unittest.TestCase):
         assert constraints is None
 
     def test_min_value_constant_left(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: 10 < len(self),
-                "The string must be more than 10 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: 10 < len(self),
+    "The string must be more than 10 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -102,27 +97,25 @@ Constraints(
         )
 
     def test_min_value_constant_right(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self) > 10,
-                "The string must be more than 10 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: len(self) > 10,
+    "The string must be more than 10 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -156,27 +149,25 @@ Constraints(
         )
 
     def test_max_value_constant_right(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self) < 10,
-                "The string must be less than 10 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: len(self) < 10,
+    "The string must be less than 10 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -210,27 +201,25 @@ Constraints(
         )
 
     def test_max_value_constant_left(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: 10 > len(self),
-                "The string must be less than 10 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: 10 > len(self),
+    "The string must be less than 10 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -264,27 +253,25 @@ Constraints(
         )
 
     def test_exact_value_constant_left(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: 10 == len(self),
-                "The string must be exactly 10 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: 10 == len(self),
+    "The string must be exactly 10 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -318,27 +305,25 @@ Constraints(
         )
 
     def test_exact_value_constant_right(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self) == 10,
-                "The string must be exactly 10 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: len(self) == 10,
+    "The string must be exactly 10 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -372,35 +357,33 @@ Constraints(
         )
 
     def test_inheritance_between_constrained_primitives(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self) > 3,
-                "The string must be more than 3 characters long."
-            )
-            class Parent_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: len(self) > 3,
+    "The string must be more than 3 characters long."
+)
+class Parent_constrained_primitive(str):
+    pass
 
 
-            @invariant(
-                lambda self: len(self) < 6,
-                "The string must be less than 6 characters long."
-            )
-            class Some_constrained_primitive(Parent_constrained_primitive):
-                pass
+@invariant(
+    lambda self: len(self) < 6,
+    "The string must be less than 6 characters long."
+)
+class Some_constrained_primitive(Parent_constrained_primitive):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -436,31 +419,29 @@ Constraints(
 
 class Test_unexpected(unittest.TestCase):
     def test_conflicting_min_and_max(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self) > 10,
-                "The string must be more than 10 characters long."
-            )
-            @invariant(
-                lambda self: len(self) < 3,
-                "The string must be less than 3 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: len(self) > 10,
+    "The string must be more than 10 characters long."
+)
+@invariant(
+    lambda self: len(self) < 3,
+    "The string must be less than 3 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         (
             symbol_table,
@@ -481,31 +462,29 @@ class Test_unexpected(unittest.TestCase):
         )
 
     def test_conflicting_min_and_exact(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self) > 10,
-                "The string must be more than 10 characters long."
-            )
-            @invariant(
-                lambda self: len(self) == 3,
-                "The string must be exactly 3 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: len(self) > 10,
+    "The string must be more than 10 characters long."
+)
+@invariant(
+    lambda self: len(self) == 3,
+    "The string must be exactly 3 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         (
             symbol_table,
@@ -526,31 +505,29 @@ class Test_unexpected(unittest.TestCase):
         )
 
     def test_conflicting_max_and_exact(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self: len(self) < 10,
-                "The string must be less than 10 characters long."
-            )
-            @invariant(
-                lambda self: len(self) == 30,
-                "The string must be exactly 30 characters long."
-            )
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(
+    lambda self: len(self) < 10,
+    "The string must be less than 10 characters long."
+)
+@invariant(
+    lambda self: len(self) == 30,
+    "The string must be exactly 30 characters long."
+)
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         (
             symbol_table,

--- a/dev/tests/infer_for_schema/test_patterns_on_properties.py
+++ b/dev/tests/infer_for_schema/test_patterns_on_properties.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest
 
 import tests.common
@@ -10,19 +9,17 @@ from aas_core_codegen import infer_for_schema
 
 class Test_expected(unittest.TestCase):
     def test_no_pattern(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                some_property: str
+        source = """\
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -44,29 +41,27 @@ class Test_expected(unittest.TestCase):
         assert constraints is None
 
     def test_single_pattern(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                prefix = "something"
-                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    prefix = "something"
+    return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
-            @invariant(
-                lambda self: matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class Something:
-                some_property: str
+@invariant(
+    lambda self: matches_something(self.some_property),
+    "Some property must match something."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -100,36 +95,34 @@ Constraints(
         )
 
     def test_two_patterns(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    return match("^something-[a-zA-Z]+$", text) is not None
 
-            @verification
-            def matches_acme(text: str) -> bool:
-                return match("^.*acme.*$", text) is not None
-
-
-            @invariant(
-                lambda self: matches_acme(self.some_property),
-                "Some property must match acme."
-            )
-            @invariant(
-                lambda self: matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class Something:
-                some_property: str
-
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+@verification
+def matches_acme(text: str) -> bool:
+    return match("^.*acme.*$", text) is not None
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+@invariant(
+    lambda self: matches_acme(self.some_property),
+    "Some property must match acme."
+)
+@invariant(
+    lambda self: matches_something(self.some_property),
+    "Some property must match something."
+)
+class Something:
+    some_property: str
+
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -165,29 +158,27 @@ Constraints(
         )
 
     def test_conditioned_on_property(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    return match("^something-[a-zA-Z]+$", text) is not None
 
-            @invariant(
-                lambda self:
-                not (self.some_property is not None)
-                or  matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class Something:
-                some_property: Optional[str]
+@invariant(
+    lambda self:
+    not (self.some_property is not None)
+    or  matches_something(self.some_property),
+    "Some property must match something."
+)
+class Something:
+    some_property: Optional[str]
 
-                def __init__(self, some_property: Optional[str] = None) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Optional[str] = None) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -223,29 +214,27 @@ Constraints(
 
 class Test_stacking(unittest.TestCase):
     def test_no_inheritance_involved(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                prefix = "something"
-                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    prefix = "something"
+    return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
-            @invariant(
-                lambda self: matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class Something:
-                some_property: str
+@invariant(
+    lambda self: matches_something(self.some_property),
+    "Some property must match something."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -279,29 +268,27 @@ Constraints(
         )
 
     def test_inheritance_from_parent_with_no_patterns_of_own(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                prefix = "something"
-                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    prefix = "something"
+    return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
-            @invariant(
-                lambda self: matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class Something:
-                some_property: str
+@invariant(
+    lambda self: matches_something(self.some_property),
+    "Some property must match something."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -335,40 +322,38 @@ Constraints(
         )
 
     def test_merge_with_parent(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    return match("^something-[a-zA-Z]+$", text) is not None
 
-            @verification
-            def matches_acme(text: str) -> bool:
-                return match("^.*acme.*$", text) is not None
+@verification
+def matches_acme(text: str) -> bool:
+    return match("^.*acme.*$", text) is not None
 
-            @invariant(
-                lambda self: matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class Parent:
-                some_property: str
+@invariant(
+    lambda self: matches_something(self.some_property),
+    "Some property must match something."
+)
+class Parent:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
-
-
-            @invariant(
-                lambda self: matches_acme(self.some_property),
-                "Some property must match acme."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(self, some_property=some_property)
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+@invariant(
+    lambda self: matches_acme(self.some_property),
+    "Some property must match acme."
+)
+class Something(Parent):
+    def __init__(self, some_property: str) -> None:
+        Parent.__init__(self, some_property=some_property)
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -404,35 +389,33 @@ Constraints(
         )
 
     def test_merge_with_parent_and_grand_parent(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    return match("^something-[a-zA-Z]+$", text) is not None
 
-            @invariant(
-                lambda self: matches_something(self.some_property),
-                "Some property must match something."
-            )
-            class GrandParent:
-                some_property: str
+@invariant(
+    lambda self: matches_something(self.some_property),
+    "Some property must match something."
+)
+class GrandParent:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            class Parent(GrandParent):
-                def __init__(self, some_property: str) -> None:
-                    GrandParent.__init__(self, some_property=some_property)
+class Parent(GrandParent):
+    def __init__(self, some_property: str) -> None:
+        GrandParent.__init__(self, some_property=some_property)
 
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(self, some_property=some_property)
+class Something(Parent):
+    def __init__(self, some_property: str) -> None:
+        Parent.__init__(self, some_property=some_property)
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -466,34 +449,32 @@ Constraints(
         )
 
     def test_merge_with_parent_over_constrained_primitive(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    return match("^something-[a-zA-Z]+$", text) is not None
 
-            @invariant(
-                lambda self: matches_something(self),
-                "Some property must match something."
-            )
-            class SomeConstrainedPrimitive(str):
-                pass
+@invariant(
+    lambda self: matches_something(self),
+    "Some property must match something."
+)
+class SomeConstrainedPrimitive(str):
+    pass
 
-            class Parent:
-                some_property: SomeConstrainedPrimitive
+class Parent:
+    some_property: SomeConstrainedPrimitive
 
-                def __init__(self, some_property: SomeConstrainedPrimitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: SomeConstrainedPrimitive) -> None:
+        self.some_property = some_property
 
-            class Something(Parent):
-                def __init__(self, some_property: SomeConstrainedPrimitive) -> None:
-                    Parent.__init__(self, some_property=some_property)
+class Something(Parent):
+    def __init__(self, some_property: SomeConstrainedPrimitive) -> None:
+        Parent.__init__(self, some_property=some_property)
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (

--- a/dev/tests/infer_for_schema/test_patterns_on_self.py
+++ b/dev/tests/infer_for_schema/test_patterns_on_self.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest
 
 import tests.common
@@ -10,23 +9,21 @@ from aas_core_codegen import infer_for_schema
 
 class Test_expected(unittest.TestCase):
     def test_no_pattern(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+class Some_constrained_primitive(str):
+    pass
 
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -48,32 +45,30 @@ class Test_expected(unittest.TestCase):
         assert constraints is None
 
     def test_single_pattern(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                prefix = "something"
-                return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    prefix = "something"
+    return match(f"^{prefix}-[a-zA-Z]+$", text) is not None
 
 
-            @invariant(
-                lambda self: matches_something(self),
-                "Some property must match something."
-            )
-            class Some_constrained_primitive(str):
-                pass
+@invariant(
+    lambda self: matches_something(self),
+    "Some property must match something."
+)
+class Some_constrained_primitive(str):
+    pass
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -107,39 +102,37 @@ Constraints(
         )
 
     def test_two_patterns(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    return match("^something-[a-zA-Z]+$", text) is not None
 
-            @verification
-            def matches_acme(text: str) -> bool:
-                return match("^.*acme.*$", text) is not None
-
-
-            @invariant(
-                lambda self: matches_acme(self),
-                "Some property must match acme."
-            )
-            @invariant(
-                lambda self: matches_something(self),
-                "Some property must match something."
-            )
-            class Some_constrained_primitive(str):
-                pass
-
-            class Something:
-                some_property: Some_constrained_primitive
-
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+@verification
+def matches_acme(text: str) -> bool:
+    return match("^.*acme.*$", text) is not None
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+@invariant(
+    lambda self: matches_acme(self),
+    "Some property must match acme."
+)
+@invariant(
+    lambda self: matches_something(self),
+    "Some property must match something."
+)
+class Some_constrained_primitive(str):
+    pass
+
+class Something:
+    some_property: Some_constrained_primitive
+
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -175,41 +168,39 @@ Constraints(
         )
 
     def test_inheritance_between_constrained_primitives_parent_first(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def matches_something(text: str) -> bool:
-                return match("^something-[a-zA-Z]+$", text) is not None
+        source = """\
+@verification
+def matches_something(text: str) -> bool:
+    return match("^something-[a-zA-Z]+$", text) is not None
 
-            @verification
-            def matches_acme(text: str) -> bool:
-                return match("^.*acme.*$", text) is not None
+@verification
+def matches_acme(text: str) -> bool:
+    return match("^.*acme.*$", text) is not None
 
-            @invariant(
-                lambda self: matches_something(self),
-                "Some property must match something."
-            )
-            class Parent_constrained_primitive(str):
-                pass
+@invariant(
+    lambda self: matches_something(self),
+    "Some property must match something."
+)
+class Parent_constrained_primitive(str):
+    pass
 
-            @invariant(
-                lambda self: matches_acme(self),
-                "Some property must match acme."
-            )
-            class Some_constrained_primitive(Parent_constrained_primitive):
-                pass
+@invariant(
+    lambda self: matches_acme(self),
+    "Some property must match acme."
+)
+class Some_constrained_primitive(Parent_constrained_primitive):
+    pass
 
-            class Something:
-                some_property: Some_constrained_primitive
+class Something:
+    some_property: Some_constrained_primitive
 
-                def __init__(self, some_property: Some_constrained_primitive) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_constrained_primitive) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (

--- a/dev/tests/infer_for_schema/test_property_in_set_of_enumeration_literals.py
+++ b/dev/tests/infer_for_schema/test_property_in_set_of_enumeration_literals.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 
 
-import textwrap
 import unittest
 
 import tests.common
@@ -11,22 +10,20 @@ from aas_core_codegen import infer_for_schema
 
 class Test_property_in_set(unittest.TestCase):
     def test_no_constraints(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
 
-            class Something:
-                some_property: Some_enum
+class Something:
+    some_property: Some_enum
 
-                def __init__(self, some_property: Some_enum) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_enum) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -48,33 +45,31 @@ class Test_property_in_set(unittest.TestCase):
         assert constraints is None
 
     def test_property_in_set(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
-                C = "C"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
 
-            Some_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.A,
-                    Some_enum.B
-                ])
+Some_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.A,
+        Some_enum.B
+    ])
 
-            @invariant(
-                lambda self: self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Something:
-                some_property: Some_enum
+@invariant(
+    lambda self: self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Something:
+    some_property: Some_enum
 
-                def __init__(self, some_property: Some_enum) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_enum) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -110,42 +105,40 @@ Constraints(
         )
 
     def test_property_in_set_in_conjunction(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
-                C = "C"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
 
-            Some_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.A,
-                    Some_enum.B
-                ])
+Some_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.A,
+        Some_enum.B
+    ])
 
-            Another_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.B,
-                    Some_enum.C
-                ])
+Another_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.B,
+        Some_enum.C
+    ])
 
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set
-                and self.some_property in Another_set,
-                "Some property must be part of some set and another set."
-            )
-            class Something:
-                some_property: Some_enum
+@invariant(
+    lambda self:
+    self.some_property in Some_set
+    and self.some_property in Another_set,
+    "Some property must be part of some set and another set."
+)
+class Something:
+    some_property: Some_enum
 
-                def __init__(self, some_property: Some_enum) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_enum) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -180,35 +173,33 @@ Constraints(
         )
 
     def test_property_in_set_in_implication(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
-                C = "C"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
 
-            Some_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.A,
-                    Some_enum.B
-                ])
+Some_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.A,
+        Some_enum.B
+    ])
 
-            @invariant(
-                lambda self:
-                not (self.some_property is not None)
-                or self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Something:
-                some_property: Optional[Some_enum]
+@invariant(
+    lambda self:
+    not (self.some_property is not None)
+    or self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Something:
+    some_property: Optional[Some_enum]
 
-                def __init__(self, some_property: Optional[Some_enum] = None) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Optional[Some_enum] = None) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -244,44 +235,42 @@ Constraints(
         )
 
     def test_property_in_set_in_implication_and_conjunction(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
-                C = "C"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
 
-            Some_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.A,
-                    Some_enum.B
-                ])
+Some_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.A,
+        Some_enum.B
+    ])
 
-            Another_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.B,
-                    Some_enum.C
-                ])
+Another_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.B,
+        Some_enum.C
+    ])
 
-            @invariant(
-                lambda self:
-                not (self.some_property is not None)
-                or (
-                    self.some_property in Some_set
-                    and self.some_property in Another_set
-                ),
-                "Some property must be part of some set and another set."
-            )
-            class Something:
-                some_property: Optional[Some_enum]
+@invariant(
+    lambda self:
+    not (self.some_property is not None)
+    or (
+        self.some_property in Some_set
+        and self.some_property in Another_set
+    ),
+    "Some property must be part of some set and another set."
+)
+class Something:
+    some_property: Optional[Some_enum]
 
-                def __init__(self, some_property: Optional[Some_enum] = None) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Optional[Some_enum] = None) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -318,39 +307,37 @@ Constraints(
 
 class Test_stacking(unittest.TestCase):
     def test_only_inherited_and_no_constraints_of_its_own(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
-                C = "C"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
 
-            Some_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.A,
-                    Some_enum.B
-                ])
+Some_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.A,
+        Some_enum.B
+    ])
 
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Parent(DBC):
-                some_property: Some_enum
+@invariant(
+    lambda self:
+    self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Parent(DBC):
+    some_property: Some_enum
 
-                def __init__(self, some_property: Some_enum) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_enum) -> None:
+        self.some_property = some_property
 
-            class Something(Parent):
-                def __init__(self, some_property: Some_enum) -> None:
-                    Parent.__init__(self, some_property)
+class Something(Parent):
+    def __init__(self, some_property: Some_enum) -> None:
+        Parent.__init__(self, some_property)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -386,49 +373,47 @@ Constraints(
         )
 
     def test_merge_with_parent(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
-                C = "C"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
 
-            Some_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.A,
-                    Some_enum.B
-                ])
+Some_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.A,
+        Some_enum.B
+    ])
 
-            Another_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.B,
-                    Some_enum.C
-                ])
+Another_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.B,
+        Some_enum.C
+    ])
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Parent(DBC):
-                some_property: Some_enum
+@invariant(
+    lambda self:
+    self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Parent(DBC):
+    some_property: Some_enum
 
-                def __init__(self, some_property: Some_enum) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_enum) -> None:
+        self.some_property = some_property
 
-            @invariant(
-                lambda self:
-                self.some_property in Another_set,
-                "Some property must be part of another set."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: Some_enum) -> None:
-                    Parent.__init__(self, some_property)
+@invariant(
+    lambda self:
+    self.some_property in Another_set,
+    "Some property must be part of another set."
+)
+class Something(Parent):
+    def __init__(self, some_property: Some_enum) -> None:
+        Parent.__init__(self, some_property)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -463,70 +448,68 @@ Constraints(
         )
 
     def test_merge_with_parent_and_grand_parent(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                A = "A"
-                B = "B"
-                C = "C"
-                D = "D"
-                E = "E"
+        source = """\
+class Some_enum(Enum):
+    A = "A"
+    B = "B"
+    C = "C"
+    D = "D"
+    E = "E"
 
-            Some_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.A,
-                    Some_enum.B,
-                    Some_enum.C,
-                ])
+Some_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.A,
+        Some_enum.B,
+        Some_enum.C,
+    ])
 
-            Another_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.B,
-                    Some_enum.C,
-                    Some_enum.D
-                ])
+Another_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.B,
+        Some_enum.C,
+        Some_enum.D
+    ])
 
-            Yet_another_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.C,
-                    Some_enum.D,
-                    Some_enum.E
-                ])
+Yet_another_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.C,
+        Some_enum.D,
+        Some_enum.E
+    ])
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Grand_parent(DBC):
-                some_property: Some_enum
+@invariant(
+    lambda self:
+    self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Grand_parent(DBC):
+    some_property: Some_enum
 
-                def __init__(self, some_property: Some_enum) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Some_enum) -> None:
+        self.some_property = some_property
 
-            @invariant(
-                lambda self:
-                self.some_property in Another_set,
-                "Some property must be part of another set."
-            )
-            class Parent(Grand_parent):
-                def __init__(self, some_property: Some_enum) -> None:
-                    Grand_parent.__init__(self, some_property)
+@invariant(
+    lambda self:
+    self.some_property in Another_set,
+    "Some property must be part of another set."
+)
+class Parent(Grand_parent):
+    def __init__(self, some_property: Some_enum) -> None:
+        Grand_parent.__init__(self, some_property)
 
-            @invariant(
-                lambda self:
-                self.some_property in Yet_another_set,
-                "Some property must be part of yet another set."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: Some_enum) -> None:
-                    Parent.__init__(self, some_property)
+@invariant(
+    lambda self:
+    self.some_property in Yet_another_set,
+    "Some property must be part of yet another set."
+)
+class Something(Parent):
+    def __init__(self, some_property: Some_enum) -> None:
+        Parent.__init__(self, some_property)
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (

--- a/dev/tests/infer_for_schema/test_property_in_set_of_primitives.py
+++ b/dev/tests/infer_for_schema/test_property_in_set_of_primitives.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 
 
-import textwrap
 import unittest
 
 import tests.common
@@ -11,18 +10,16 @@ from aas_core_codegen import infer_for_schema
 
 class Test_property_in_set(unittest.TestCase):
     def test_no_constraints(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                some_property: str
+        source = """\
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -44,26 +41,24 @@ class Test_property_in_set(unittest.TestCase):
         assert constraints is None
 
     def test_property_in_set(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_set: Set[str] = constant_set(
-                values=["A", "B"])
+        source = """\
+Some_set: Set[str] = constant_set(
+    values=["A", "B"])
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Something:
-                some_property: str
+@invariant(
+    lambda self:
+    self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -105,30 +100,28 @@ Constraints(
         )
 
     def test_property_in_set_in_conjunction(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_set: Set[str] = constant_set(
-                values=["A", "B"])
+        source = """\
+Some_set: Set[str] = constant_set(
+    values=["A", "B"])
 
-            Another_set: Set[str] = constant_set(
-                values=["B", "C"])
+Another_set: Set[str] = constant_set(
+    values=["B", "C"])
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set
-                and self.some_property in Another_set,
-                "Some property must be part of some set and another set."
-            )
-            class Something:
-                some_property: str
+@invariant(
+    lambda self:
+    self.some_property in Some_set
+    and self.some_property in Another_set,
+    "Some property must be part of some set and another set."
+)
+class Something:
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -166,27 +159,25 @@ Constraints(
         )
 
     def test_property_in_set_in_implication(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_set: Set[str] = constant_set(
-                values=["A", "B"])
+        source = """\
+Some_set: Set[str] = constant_set(
+    values=["A", "B"])
 
-            @invariant(
-                lambda self:
-                not (self.some_property is not None)
-                or self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Something:
-                some_property: Optional[str]
+@invariant(
+    lambda self:
+    not (self.some_property is not None)
+    or self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Something:
+    some_property: Optional[str]
 
-                def __init__(self, some_property: Optional[str] = None) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Optional[str] = None) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -228,33 +219,31 @@ Constraints(
         )
 
     def test_property_in_set_in_implication_and_conjunction(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_set: Set[str] = constant_set(
-                values=["A", "B"])
+        source = """\
+Some_set: Set[str] = constant_set(
+    values=["A", "B"])
 
-            Another_set: Set[str] = constant_set(
-                values=["B", "C"])
+Another_set: Set[str] = constant_set(
+    values=["B", "C"])
 
-            @invariant(
-                lambda self:
-                not (self.some_property is not None)
-                or (
-                    self.some_property in Some_set
-                    and self.some_property in Another_set
-                ),
-                "Some property must be part of some set and another set."
-            )
-            class Something:
-                some_property: Optional[str]
+@invariant(
+    lambda self:
+    not (self.some_property is not None)
+    or (
+        self.some_property in Some_set
+        and self.some_property in Another_set
+    ),
+    "Some property must be part of some set and another set."
+)
+class Something:
+    some_property: Optional[str]
 
-                def __init__(self, some_property: Optional[str] = None) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Optional[str] = None) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -294,30 +283,28 @@ Constraints(
 
 class Test_stacking(unittest.TestCase):
     def test_only_inherited_and_no_constraints_of_its_own(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_set: Set[str] = constant_set(
-                values=["A", "B"])
+        source = """\
+Some_set: Set[str] = constant_set(
+    values=["A", "B"])
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Parent(DBC):
-                some_property: str
+@invariant(
+    lambda self:
+    self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Parent(DBC):
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(self, some_property)
+class Something(Parent):
+    def __init__(self, some_property: str) -> None:
+        Parent.__init__(self, some_property)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -359,38 +346,36 @@ Constraints(
         )
 
     def test_merge_with_parent(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_set: Set[str] = constant_set(
-                values=["A", "B"])
+        source = """\
+Some_set: Set[str] = constant_set(
+    values=["A", "B"])
 
-            Another_set: Set[str] = constant_set(
-                values=["B", "C"])
+Another_set: Set[str] = constant_set(
+    values=["B", "C"])
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Parent(DBC):
-                some_property: str
+@invariant(
+    lambda self:
+    self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Parent(DBC):
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            @invariant(
-                lambda self:
-                self.some_property in Another_set,
-                "Some property must be part of another set."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(self, some_property)
+@invariant(
+    lambda self:
+    self.some_property in Another_set,
+    "Some property must be part of another set."
+)
+class Something(Parent):
+    def __init__(self, some_property: str) -> None:
+        Parent.__init__(self, some_property)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (
@@ -428,51 +413,49 @@ Constraints(
         )
 
     def test_merge_with_parent_and_grand_parent(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_set: Set[str] = constant_set(
-                values=["A", "B", "C"])
+        source = """\
+Some_set: Set[str] = constant_set(
+    values=["A", "B", "C"])
 
-            Another_set: Set[str] = constant_set(
-                values=["B", "C", "D"])
+Another_set: Set[str] = constant_set(
+    values=["B", "C", "D"])
 
-            Yet_another_set: Set[str] = constant_set(
-                values=["C", "D", "E"])
+Yet_another_set: Set[str] = constant_set(
+    values=["C", "D", "E"])
 
-            @invariant(
-                lambda self:
-                self.some_property in Some_set,
-                "Some property must be part of some set."
-            )
-            class Grand_parent(DBC):
-                some_property: str
+@invariant(
+    lambda self:
+    self.some_property in Some_set,
+    "Some property must be part of some set."
+)
+class Grand_parent(DBC):
+    some_property: str
 
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
 
-            @invariant(
-                lambda self:
-                self.some_property in Another_set,
-                "Some property must be part of another set."
-            )
-            class Parent(Grand_parent):
-                def __init__(self, some_property: str) -> None:
-                    Grand_parent.__init__(self, some_property)
+@invariant(
+    lambda self:
+    self.some_property in Another_set,
+    "Some property must be part of another set."
+)
+class Parent(Grand_parent):
+    def __init__(self, some_property: str) -> None:
+        Grand_parent.__init__(self, some_property)
 
-            @invariant(
-                lambda self:
-                self.some_property in Yet_another_set,
-                "Some property must be part of yet another set."
-            )
-            class Something(Parent):
-                def __init__(self, some_property: str) -> None:
-                    Parent.__init__(self, some_property)
+@invariant(
+    lambda self:
+    self.some_property in Yet_another_set,
+    "Some property must be part of yet another set."
+)
+class Something(Parent):
+    def __init__(self, some_property: str) -> None:
+        Parent.__init__(self, some_property)
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         # fmt: off
         (

--- a/dev/tests/intermediate/test_constructor.py
+++ b/dev/tests/intermediate/test_constructor.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 
 import re
-import textwrap
 import unittest
 from typing import Tuple, Optional, Sequence
 
@@ -55,15 +54,13 @@ def must_find_item_for(
 
 class Test_empty_ok(unittest.TestCase):
     def test_no_constructor(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                pass
+        source = """\
+class Something:
+    pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         constructor_table, error = understand_constructor_table(source=source)
         assert error is None, tests.common.most_underlying_messages(error)
@@ -76,16 +73,14 @@ class Test_empty_ok(unittest.TestCase):
         self.assertEqual(0, len(statements))
 
     def test_pass(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                def __init__(self) -> None:
-                    pass
+        source = """\
+class Something:
+    def __init__(self) -> None:
+        pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         constructor_table, error = understand_constructor_table(source=source)
         assert error is None, tests.common.most_underlying_messages(error)
@@ -99,21 +94,19 @@ class Test_empty_ok(unittest.TestCase):
 
 class Test_call_to_super_constructor_ok(unittest.TestCase):
     def test_without_arguments(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent:
-                def __init__(self) -> None:
-                    pass
+        source = """\
+@abstract
+class Parent:
+    def __init__(self) -> None:
+        pass
 
-            class Something(Parent):
-                def __init__(self) -> None:
-                    Parent.__init__(self)
+class Something(Parent):
+    def __init__(self) -> None:
+        Parent.__init__(self)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         constructor_table, error = understand_constructor_table(source=source)
         assert error is None, tests.common.most_underlying_messages(error)
@@ -129,25 +122,23 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
         self.assertEqual("Parent", statement.super_name)
 
     def test_with_arguments(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent:
-                a: int
-                b: int
+        source = """\
+@abstract
+class Parent:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(Parent):
-                def __init__(self, a: int, b: int) -> None:
-                    Parent.__init__(self, a, b)
+class Something(Parent):
+    def __init__(self, a: int, b: int) -> None:
+        Parent.__init__(self, a, b)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         constructor_table, error = understand_constructor_table(source=source)
         assert error is None, tests.common.most_underlying_messages(error)
@@ -165,18 +156,16 @@ class Test_call_to_super_constructor_ok(unittest.TestCase):
 
 class Test_assign_property_ok(unittest.TestCase):
     def test_argument_assignment(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                x: int
+        source = """\
+class Something:
+    x: int
 
-                def __init__(self, x: int) -> None:
-                    self.x = x
+    def __init__(self, x: int) -> None:
+        self.x = x
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         constructor_table, error = understand_constructor_table(source=source)
         assert error is None, tests.common.most_underlying_messages(error)
@@ -192,19 +181,17 @@ class Test_assign_property_ok(unittest.TestCase):
 
 class Test_assign_fail(unittest.TestCase):
     def test_multiple_targets_in_assignment(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                a: int
-                b: int
+        source = """\
+class Something:
+    a: int
+    b: int
 
-                def __init__(self, a: int) -> None:
-                    self.a = self.b = a
+    def __init__(self, a: int) -> None:
+        self.a = self.b = a
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -215,19 +202,17 @@ class Test_assign_fail(unittest.TestCase):
         )
 
     def test_tuple_in_assignment_targets(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                a: int
-                b: int
+        source = """\
+class Something:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a, self.b = a, b
+    def __init__(self, a: int, b: int) -> None:
+        self.a, self.b = a, b
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -239,19 +224,17 @@ class Test_assign_fail(unittest.TestCase):
         )
 
     def test_variable_instead_of_property_assignment(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                a: int
-                b: int
+        source = """\
+class Something:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    x = a
+    def __init__(self, a: int, b: int) -> None:
+        x = a
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -262,16 +245,14 @@ class Test_assign_fail(unittest.TestCase):
         )
 
     def test_assignment_to_undefined_property(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                def __init__(self, a: int) -> None:
-                    self.a = a
+        source = """\
+class Something:
+    def __init__(self, a: int) -> None:
+        self.a = a
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -282,18 +263,16 @@ class Test_assign_fail(unittest.TestCase):
         )
 
     def test_assignment_value_is_not_a_name(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                a: int
+        source = """\
+class Something:
+    a: int
 
-                def __init__(self, a: int) -> None:
-                    self.a = a + 100
+    def __init__(self, a: int) -> None:
+        self.a = a + 100
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -308,19 +287,17 @@ class Test_assign_fail(unittest.TestCase):
         )
 
     def test_argument_and_property_name_differ(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                a: int
+        source = """\
+class Something:
+    a: int
 
-                def __init__(self, b: int) -> None:
-                    self.a = b
+    def __init__(self, b: int) -> None:
+        self.a = b
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -334,30 +311,28 @@ class Test_assign_fail(unittest.TestCase):
 
 class Test_call_to_super_constructor_fail(unittest.TestCase):
     def test_super_class_not_a_name(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            @abstract
-            class Parent:
-                """Represent something abstract."""
+        source = '''\
+@abstract
+class Parent:
+    """Represent something abstract."""
 
-                a: int
-                b: int
+    a: int
+    b: int
 
-                @require(lambda a: a > 0)
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    @require(lambda a: a > 0)
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(Parent):
-                """Represent something concrete."""
+class Something(Parent):
+    """Represent something concrete."""
 
-                def __init__(self, a: int, b: int) -> None:
-                    super().__init__(self, a, b)
+    def __init__(self, a: int, b: int) -> None:
+        super().__init__(self, a, b)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -369,30 +344,28 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_passed_double_start_keyword_argument(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            @abstract
-            class Parent(DBC):
-                """Represent something abstract."""
+        source = '''\
+@abstract
+class Parent(DBC):
+    """Represent something abstract."""
 
-                a: int
-                b: int
+    a: int
+    b: int
 
-                @require(lambda a: a > 0)
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    @require(lambda a: a > 0)
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(DBC, Parent):
-                """Represent something concrete."""
+class Something(DBC, Parent):
+    """Represent something concrete."""
 
-                def __init__(self, a: int, b: int) -> None:
-                    Parent.__init__(self, **{'a': a, 'b': b})
+    def __init__(self, a: int, b: int) -> None:
+        Parent.__init__(self, **{'a': a, 'b': b})
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -404,24 +377,22 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_calling_constructor_from_a_non_super_class(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Unrelated:
-                a: int
-                b: int
+        source = """\
+class Unrelated:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something:
-                def __init__(self, a: int, b: int) -> None:
-                    Unrelated.__init__(self, a=a, b=b)
+class Something:
+    def __init__(self, a: int, b: int) -> None:
+        Unrelated.__init__(self, a=a, b=b)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -433,21 +404,19 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_super_class_has_no_init(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent:
-                pass
+        source = """\
+@abstract
+class Parent:
+    pass
 
-            class Something(Parent):
+class Something(Parent):
 
-                def __init__(self, a: int, b: int) -> None:
-                    Parent.__init__(self)
+    def __init__(self, a: int, b: int) -> None:
+        Parent.__init__(self)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -458,23 +427,21 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_positional_argument_to_super_init_transformed(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent(DBC):
-                a: int
+        source = """\
+@abstract
+class Parent(DBC):
+    a: int
 
-                def __init__(self, a: int) -> None:
-                    self.a = a
+    def __init__(self, a: int) -> None:
+        self.a = a
 
-            class Something(DBC, Parent):
-                def __init__(self, a: int) -> None:
-                    Parent.__init__(self, a + 100)
+class Something(DBC, Parent):
+    def __init__(self, a: int) -> None:
+        Parent.__init__(self, a + 100)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -486,23 +453,21 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_keyword_argument_to_super_init_transformed(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent(DBC):
-                a: int
+        source = """\
+@abstract
+class Parent(DBC):
+    a: int
 
-                def __init__(self, a: int) -> None:
-                    self.a = a
+    def __init__(self, a: int) -> None:
+        self.a = a
 
-            class Something(DBC, Parent):
-                def __init__(self, a: int) -> None:
-                    Parent.__init__(self, a=a + 100)
+class Something(DBC, Parent):
+    def __init__(self, a: int) -> None:
+        Parent.__init__(self, a=a + 100)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -514,25 +479,23 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_too_many_positional_arguments(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent:
-                a: int
-                b: int
+        source = """\
+@abstract
+class Parent:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(Parent):
-                def __init__(self, a: int, b: int, c: int) -> None:
-                    Parent.__init__(self, a, b, c)
+class Something(Parent):
+    def __init__(self, a: int, b: int, c: int) -> None:
+        Parent.__init__(self, a, b, c)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -544,25 +507,23 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_unexpected_keyword_arguments_supplied_to_super_init(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent:
-                a: int
-                b: int
+        source = """\
+@abstract
+class Parent:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(DBC, Parent):
-                def __init__(self, a: int, b: int, c: int) -> None:
-                    Parent.__init__(self, a=a, b=b, c=c)
+class Something(DBC, Parent):
+    def __init__(self, a: int, b: int, c: int) -> None:
+        Parent.__init__(self, a=a, b=b, c=c)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -573,27 +534,25 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_non_init_names_passed_to_super_init(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            @abstract
-            class Parent:
-                """Represent something abstract."""
+        source = '''\
+@abstract
+class Parent:
+    """Represent something abstract."""
 
-                a: int
-                b: int
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(Parent):
-                def __init__(self, a: int) -> None:
-                    Parent.__init__(self, a, b)
+class Something(Parent):
+    def __init__(self, a: int) -> None:
+        Parent.__init__(self, a, b)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -606,25 +565,23 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_arguments_not_passed_as_are(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent:
-                a: int
-                b: int
+        source = """\
+@abstract
+class Parent:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(DBC, Parent):
-                def __init__(self, a: int, y: int) -> None:
-                    Parent.__init__(self, a, b=y)
+class Something(DBC, Parent):
+    def __init__(self, a: int, y: int) -> None:
+        Parent.__init__(self, a, b=y)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -638,25 +595,23 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
         )
 
     def test_missing_argument_to_super_init(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Parent:
-                a: int
-                b: int
+        source = """\
+@abstract
+class Parent:
+    a: int
+    b: int
 
-                def __init__(self, a: int, b: int) -> None:
-                    self.a = a
-                    self.b = b
+    def __init__(self, a: int, b: int) -> None:
+        self.a = a
+        self.b = b
 
-            class Something(Parent):
-                def __init__(self, a: int) -> None:
-                    Parent.__init__(self, a)
+class Something(Parent):
+    def __init__(self, a: int) -> None:
+        Parent.__init__(self, a)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -669,18 +624,16 @@ class Test_call_to_super_constructor_fail(unittest.TestCase):
 
 class Test_unexpected_statements(unittest.TestCase):
     def test_unexpected_call(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                a: int
+        source = """\
+class Something:
+    a: int
 
-                def __init__(self, a: int) -> None:
-                    print("something")
+    def __init__(self, a: int) -> None:
+        print("something")
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None
@@ -692,18 +645,16 @@ class Test_unexpected_statements(unittest.TestCase):
         )
 
     def test_unexpected_expr(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                a: int
+        source = """\
+class Something:
+    a: int
 
-                def __init__(self, a: int) -> None:
-                    1 + 2
+    def __init__(self, a: int) -> None:
+        1 + 2
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         _, error = understand_constructor_table(source=source)
         assert error is not None

--- a/dev/tests/intermediate/test_hierarchy.py
+++ b/dev/tests/intermediate/test_hierarchy.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest
 
 from aas_core_codegen.intermediate import _hierarchy as intermediate_hierarchy
@@ -12,15 +11,13 @@ import tests.common
 class Test_ontology_ok(unittest.TestCase):
     def test_no_ancestors(self) -> None:
         symbol_table, error = tests.common.parse_source(
-            textwrap.dedent(
-                """\
-                class Something:
-                    pass
+            """\
+class Something:
+    pass
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                """
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
         )
 
         assert error is None, tests.common.most_underlying_messages(error)
@@ -41,31 +38,29 @@ class Test_ontology_ok(unittest.TestCase):
 
     def test_complex_graph(self) -> None:
         symbol_table, error = tests.common.parse_source(
-            textwrap.dedent(
-                """\
-                @abstract
-                class Another_grand_parent:
-                    pass
+            """\
+@abstract
+class Another_grand_parent:
+    pass
 
-                @abstract
-                class Grand_parent:
-                    pass
+@abstract
+class Grand_parent:
+    pass
 
-                @abstract
-                class Parent(Grand_parent, Another_grand_parent):
-                    pass
+@abstract
+class Parent(Grand_parent, Another_grand_parent):
+    pass
 
-                @abstract
-                class Another_parent(Grand_parent, Another_grand_parent):
-                    pass
+@abstract
+class Another_parent(Grand_parent, Another_grand_parent):
+    pass
 
-                class Something(Parent, Another_parent):
-                    pass
+class Something(Parent, Another_parent):
+    pass
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                """
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
         )
 
         assert error is None, tests.common.most_underlying_messages(error)
@@ -99,20 +94,18 @@ class Test_ontology_ok(unittest.TestCase):
 class Test_ontology_fail(unittest.TestCase):
     def test_duplicate_properties_in_ancestors(self) -> None:
         symbol_table, error = tests.common.parse_source(
-            textwrap.dedent(
-                """\
-                @abstract
-                class SomethingAbstract:
-                    x: int
+            """\
+@abstract
+class SomethingAbstract:
+    x: int
 
-                @abstract
-                class Something(SomethingAbstract):
-                    x: int
+@abstract
+class Something(SomethingAbstract):
+    x: int
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                """
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
         )
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
@@ -128,22 +121,20 @@ class Test_ontology_fail(unittest.TestCase):
 
     def test_duplicate_methods_in_ancestors(self) -> None:
         symbol_table, error = tests.common.parse_source(
-            textwrap.dedent(
-                """\
-                @abstract
-                class SomethingAbstract:
-                    def do_something(self) -> None:
-                        pass
+            """\
+@abstract
+class SomethingAbstract:
+    def do_something(self) -> None:
+        pass
 
-                @abstract
-                class Something(SomethingAbstract):
-                    def do_something(self) -> None:
-                        pass
+@abstract
+class Something(SomethingAbstract):
+    def do_something(self) -> None:
+        pass
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                """
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
         )
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
@@ -159,20 +150,18 @@ class Test_ontology_fail(unittest.TestCase):
 
     def test_missing_constructor_when_the_parent_has_one(self) -> None:
         symbol_table, error = tests.common.parse_source(
-            textwrap.dedent(
-                """\
-                @abstract
-                class SomethingAbstract:
-                    def __init__(self, x: int) -> None:
-                        pass
+            """\
+@abstract
+class SomethingAbstract:
+    def __init__(self, x: int) -> None:
+        pass
 
-                class Something(SomethingAbstract):
-                    pass
+class Something(SomethingAbstract):
+    pass
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                """
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
         )
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None
@@ -189,20 +178,18 @@ class Test_ontology_fail(unittest.TestCase):
 
     def test_cycle_inheritance(self) -> None:
         symbol_table, error = tests.common.parse_source(
-            textwrap.dedent(
-                """\
-                @abstract
-                class Cycle(Something):
-                    pass
+            """\
+@abstract
+class Cycle(Something):
+    pass
 
-                @abstract
-                class Something(Cycle):
-                    pass
+@abstract
+class Something(Cycle):
+    pass
 
-                __version__ = "dummy"
-                __xml_namespace__ = "https://dummy.com"
-                """
-            )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
         )
         assert error is None, tests.common.most_underlying_messages(error)
         assert symbol_table is not None

--- a/dev/tests/intermediate/test_pickle.py
+++ b/dev/tests/intermediate/test_pickle.py
@@ -7,7 +7,6 @@ import inspect
 import pathlib
 import pickle
 import re
-import textwrap
 import unittest
 from typing import List, Dict, Optional, Final, Sequence
 
@@ -24,18 +23,16 @@ import tests.common
 
 class TestPickle(unittest.TestCase):
     def test_enumeration(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from enum import Enum
+        source = """\
+from enum import Enum
 
-            class Some_enum(Enum):
-                Literal1 = "literal_1"
-                Literal2 = "literal_2"
+class Some_enum(Enum):
+    Literal1 = "literal_1"
+    Literal2 = "literal_2"
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -71,20 +68,18 @@ class TestPickle(unittest.TestCase):
         self.assertNotEqual(original_id_set, new_id_set)
 
     def test_abstract_class(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Some_abstract_class:
-                some_property: int
+        source = """\
+@abstract
+class Some_abstract_class:
+    some_property: int
 
-                @require(lambda some_property: some_property > 0)
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
+    @require(lambda some_property: some_property > 0)
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -108,16 +103,14 @@ class TestPickle(unittest.TestCase):
         self.assertIn(id(unpickled.properties[0]), unpickled.property_id_set)
 
     def test_argument(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                def some_method(self, some_arg: int) -> None:
-                    pass
+        source = """\
+class Some_class:
+    def some_method(self, some_arg: int) -> None:
+        pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -136,21 +129,19 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.name, "some_arg")
 
     def test_class(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: int
-                
-                def __init__(
-                        self,
-                        some_property: int
-                ) -> None:
-                    self.some_property = some_property
+        source = """\
+class Some_class:
+    some_property: int
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: int
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -171,21 +162,19 @@ class TestPickle(unittest.TestCase):
         self.assertIn(id(unpickled.properties[0]), unpickled.property_id_set)
 
     def test_concrete_class(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_concrete_class:
-                some_property: int
+        source = """\
+class Some_concrete_class:
+    some_property: int
 
-                def __init__(
-                        self,
-                        some_property: int
-                ) -> None:
-                    self.some_property = some_property
+    def __init__(
+            self,
+            some_property: int
+    ) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -209,16 +198,14 @@ class TestPickle(unittest.TestCase):
         self.assertIn(id(unpickled.properties[0]), unpickled.property_id_set)
 
     def test_constant_primitive(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_constant: str = constant_str(
-                value="some_value",
-            )
+        source = """\
+Some_constant: str = constant_str(
+    value="some_value",
+)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -240,20 +227,18 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.value, "some_value")
 
     def test_constant_set_of_primitives(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from aas_core_meta.marker import (
-                constant_set
-            )
+        source = """\
+from aas_core_meta.marker import (
+    constant_set
+)
 
-            Some_constant_set: Set[str] = constant_set(
-                values=["value1", "value2"]
-            )
+Some_constant_set: Set[str] = constant_set(
+    values=["value1", "value2"]
+)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -275,16 +260,14 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(len(unpickled.literals), 2)
 
     def test_constrained_primitive(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(lambda self: len(self) > 0, "Non-empty")
-            class Some_constrained_primitive(str):
-                pass
+        source = """\
+@invariant(lambda self: len(self) > 0, "Non-empty")
+class Some_constrained_primitive(str):
+    pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -307,18 +290,16 @@ class TestPickle(unittest.TestCase):
         self.assertIn(id(unpickled.invariants[0]), unpickled.invariant_id_set)
 
     def test_constructor(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: int
+        source = """\
+class Some_class:
+    some_property: int
 
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -338,18 +319,16 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(len(unpickled.arguments), 1)
 
     def test_contract(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                @require(lambda self: True)
-                @ensure(lambda result: True)
-                def some_method(self) -> bool:
-                    return True
+        source = """\
+class Some_class:
+    @require(lambda self: True)
+    @ensure(lambda result: True)
+    def some_method(self) -> bool:
+        return True
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -370,17 +349,15 @@ class TestPickle(unittest.TestCase):
         self.assertIsNotNone(unpickled.body)
 
     def test_contracts(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                @require(lambda self: True)
-                def some_method(self) -> None:
-                    pass
+        source = """\
+class Some_class:
+    @require(lambda self: True)
+    def some_method(self) -> None:
+        pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -401,18 +378,16 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(len(unpickled.preconditions), 1)
 
     def test_default_primitive(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: str
-            
-                def __init__(self, some_property: str = 'some_default') -> None:
-                    self.some_property = some_property
+        source = """\
+class Some_class:
+    some_property: str
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(self, some_property: str = 'some_default') -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -433,25 +408,23 @@ class TestPickle(unittest.TestCase):
         assert isinstance(unpickled, intermediate.DefaultPrimitive)
 
     def test_default_enumeration_literal(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                Literal1 = "literal-1"
-                Literal2 = "literal-2"
-            
-            class Some_class:
-                some_property: Some_enum
+        source = """\
+class Some_enum(Enum):
+    Literal1 = "literal-1"
+    Literal2 = "literal-2"
 
-                def __init__(
-                        self, 
-                        some_property: Some_enum = Some_enum.Literal1
-                ) -> None:
-                    self.some_property = some_property
+class Some_class:
+    some_property: Some_enum
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self, 
+            some_property: Some_enum = Some_enum.Literal1
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -472,17 +445,15 @@ class TestPickle(unittest.TestCase):
         assert isinstance(unpickled, intermediate.DefaultEnumerationLiteral)
 
     def test_description_of_constant(self) -> None:
-        source = textwrap.dedent(
-            """\
-            Some_constant: str = constant_str(
-                value="some_value",
-                description="This is some constant."
-            )
+        source = """\
+Some_constant: str = constant_str(
+    value="some_value",
+    description="This is some constant."
+)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -507,18 +478,16 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.summary[0], "This is some constant.")
 
     def test_description_of_enumeration_literal(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from enum import Enum
+        source = '''\
+from enum import Enum
 
-            class Some_enum(Enum):
-                literal1 = "value1"
-                \"\"\"Describe the literal.\"\"\"
+class Some_enum(Enum):
+    literal1 = "value1"
+    """Describe the literal."""
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -539,17 +508,15 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.summary[0], "Describe the literal.")
 
     def test_description_of_meta_model(self) -> None:
-        source = textwrap.dedent(
-            """\
-            \"\"\"Meta-model description.\"\"\"
+        source = '''\
+"""Meta-model description."""
 
-            class Some_class:
-                pass
+class Some_class:
+    pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -569,16 +536,14 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.summary[0], "Meta-model description.")
 
     def test_description_of_our_type(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                \"\"\"Describe the class.\"\"\"
-                pass
+        source = '''\
+class Some_class:
+    """Describe the class."""
+    pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -598,22 +563,20 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.summary[0], "Describe the class.")
 
     def test_description_of_property(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: int
-                \"\"\"Describe the property.\"\"\"
-                
-                def __init__(
-                        self,
-                        some_property: int
-                ) -> None:
-                    self.some_property = some_property
+        source = '''\
+class Some_class:
+    some_property: int
+    """Describe the property."""
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: int
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -634,17 +597,15 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.summary[0], "Describe the property.")
 
     def test_description_of_signature(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                def some_method(self) -> None:
-                    \"\"\"Describe the method.\"\"\"
-                    pass
+        source = '''\
+class Some_class:
+    def some_method(self) -> None:
+        """Describe the method."""
+        pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -665,17 +626,15 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.summary[0], "Describe the method.")
 
     def test_enumeration_literal(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from enum import Enum
+        source = """\
+from enum import Enum
 
-            class Some_enum(Enum):
-                literal1 = "value1"
+class Some_enum(Enum):
+    literal1 = "value1"
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -696,17 +655,15 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.value, "value1")
 
     def test_implementation_specific_method(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                @implementation_specific
-                def some_method(self) -> None:
-                    pass
+        source = """\
+class Some_class:
+    @implementation_specific
+    def some_method(self) -> None:
+        pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -726,17 +683,15 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.name, "some_method")
 
     def test_implementation_specific_verification(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            @implementation_specific
-            def some_verification(x: int) -> bool:
-                pass
+        source = """\
+@verification
+@implementation_specific
+def some_verification(x: int) -> bool:
+    pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -755,25 +710,23 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.name, "some_verification")
 
     def test_interface(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Some_abstract_class:
-                some_property: int
-                
-                def __init__(
-                        self,
-                        some_property: int
-                ) -> None:
-                    self.some_property = some_property
-                
-                def some_func(self) -> None:
-                    pass
+        source = """\
+@abstract
+class Some_abstract_class:
+    some_property: int
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: int
+    ) -> None:
+        self.some_property = some_property
+
+    def some_func(self) -> None:
+        pass
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -798,19 +751,17 @@ class TestPickle(unittest.TestCase):
         self.assertIn(id(unpickled.properties[0]), unpickled.property_id_set)
 
     def test_invariant(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(lambda self: self.some_property > 0, "Some property is positive")
-            class Some_class:
-                some_property: int                                
+        source = """\
+@invariant(lambda self: self.some_property > 0, "Some property is positive")
+class Some_class:
+    some_property: int                                
 
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -830,21 +781,19 @@ class TestPickle(unittest.TestCase):
         self.assertIsNotNone(unpickled.body)
 
     def test_list_type_annotation(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: List[str]
-                
-                def __init__(
-                        self,
-                        some_property: List[str]
-                ) -> None:
-                    self.some_property = some_property
+        source = """\
+class Some_class:
+    some_property: List[str]
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: List[str]
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -863,21 +812,19 @@ class TestPickle(unittest.TestCase):
         self.assertIsInstance(unpickled, intermediate_types.ListTypeAnnotation)
 
     def test_tuple_type_annotation(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: Tuple[str, int]
+        source = """\
+class Some_class:
+    some_property: Tuple[str, int]
 
-                def __init__(
-                        self,
-                        some_property: Tuple[str, int]
-                ) -> None:
-                    self.some_property = some_property
+    def __init__(
+            self,
+            some_property: Tuple[str, int]
+    ) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -896,15 +843,13 @@ class TestPickle(unittest.TestCase):
         self.assertIsInstance(unpickled, intermediate_types.TupleTypeAnnotation)
 
     def test_meta_model(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                pass
+        source = """\
+class Some_class:
+    pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -923,16 +868,14 @@ class TestPickle(unittest.TestCase):
         self.assertEqual(unpickled.version, "dummy")
 
     def test_method(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                def some_method(self) -> None:
-                    pass
+        source = """\
+class Some_class:
+    def some_method(self) -> None:
+        pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1004,21 +947,19 @@ __xml_namespace__ = "https://dummy.com"
         )
 
     def test_optional_type_annotation(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: Optional[str]
+        source = """\
+class Some_class:
+    some_property: Optional[str]
 
-                def __init__(
-                    self,
-                    some_property: Optional[str] = None
-                ) -> None:
-                    self.some_property = some_property
+    def __init__(
+        self,
+        some_property: Optional[str] = None
+    ) -> None:
+        self.some_property = some_property
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1037,24 +978,22 @@ __xml_namespace__ = "https://dummy.com"
         self.assertIsInstance(unpickled, intermediate_types.OptionalTypeAnnotation)
 
     def test_our_type_annotation(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                pass
+        source = """\
+class Some_class:
+    pass
 
-            class Some_another_class:
-                some_property: Some_class
-                
-                def __init__(
-                        self,
-                        some_property: Some_class
-                ) -> None:
-                    self.some_property = some_property
+class Some_another_class:
+    some_property: Some_class
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: Some_class
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1075,16 +1014,14 @@ __xml_namespace__ = "https://dummy.com"
         self.assertIsInstance(unpickled, intermediate_types.OurTypeAnnotation)
 
     def test_pattern_verification(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def some_verification(x: str) -> bool:
-                return match(r"^[a-z]+$", x) is not None
+        source = """\
+@verification
+def some_verification(x: str) -> bool:
+    return match(r"^[a-z]+$", x) is not None
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1103,20 +1040,18 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.name, "some_verification")
 
     def test_primitive_set_literal(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from aas_core_meta.marker import (
-                constant_set
-            )
+        source = """\
+from aas_core_meta.marker import (
+    constant_set
+)
 
-            Some_constant_set: Set[str] = constant_set(
-                values=["value1", "value2"]
-            )
+Some_constant_set: Set[str] = constant_set(
+    values=["value1", "value2"]
+)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1138,21 +1073,19 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.value, "value1")
 
     def test_primitive_type(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: str
-                
-                def __init__(
-                        self,
-                        some_property: str
-                ) -> None:
-                    self.some_property = some_property
+        source = """\
+class Some_class:
+    some_property: str
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: str
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1173,21 +1106,19 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled, intermediate_types.PrimitiveType.STR)
 
     def test_primitive_type_annotation(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: str
-                
-                def __init__(
-                        self,
-                        some_property: str
-                ) -> None:
-                    self.some_property = some_property
+        source = """\
+class Some_class:
+    some_property: str
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: str
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1206,21 +1137,19 @@ __xml_namespace__ = "https://dummy.com"
         self.assertIsInstance(unpickled, intermediate_types.PrimitiveTypeAnnotation)
 
     def test_property(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: str
-                
-                def __init__(
-                        self,
-                        some_property: str
-                ) -> None:
-                    self.some_property = some_property
+        source = """\
+class Some_class:
+    some_property: str
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: str
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1240,19 +1169,17 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.name, "some_property")
 
     def test_serialization(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @serialization(with_model_type=True)
-            class Some_class:
-                some_property: str
-                
-                def __init__(self, some_property: str) -> None:
-                    self.some_property = some_property
+        source = """\
+@serialization(with_model_type=True)
+class Some_class:
+    some_property: str
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(self, some_property: str) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1272,23 +1199,21 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.with_model_type, True)
 
     def test_signature(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Some_abstract_class:
-                some_property: int
-            
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
-            
-                def some_func(self) -> None:
-                    pass
-            
-            
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+        source = """\
+@abstract
+class Some_abstract_class:
+    some_property: int
+
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
+
+    def some_func(self) -> None:
+        pass
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1311,23 +1236,21 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.name, "some_func")
 
     def test_signature_like(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Some_abstract_class:
-                some_property: int
+        source = """\
+@abstract
+class Some_abstract_class:
+    some_property: int
 
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
-            
-                def some_func(self) -> None:
-                    pass
-            
-            
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
+
+    def some_func(self) -> None:
+        pass
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1336,24 +1259,22 @@ __xml_namespace__ = "https://dummy.com"
             raise AssertionError(tests.common.most_underlying_messages(error))
         assert symbol_table is not None
 
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class Some_abstract_class:
-                some_property: int
+        source = """\
+@abstract
+class Some_abstract_class:
+    some_property: int
 
-                @require(lambda some_property: some_property > 0)
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
+    @require(lambda some_property: some_property > 0)
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
 
-                def some_func(self) -> None:
-                    pass
+    def some_func(self) -> None:
+        pass
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1378,22 +1299,20 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.name, "some_func")
 
     def test_snapshot(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: int
-                
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
-            
-                @snapshot(lambda self: self.some_property + 1)
-                def some_method(self) -> None:
-                    pass
+        source = """\
+class Some_class:
+    some_property: int
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
+
+    @snapshot(lambda self: self.some_property + 1)
+    def some_method(self) -> None:
+        pass
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1414,21 +1333,19 @@ __xml_namespace__ = "https://dummy.com"
         self.assertIsNotNone(unpickled.body)
 
     def test_summary_remarks_constraints_description(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                \"\"\"
-                Summary line.
+        source = '''\
+class Some_class:
+    """
+    Summary line.
 
-                Some remark.
-                    
-                :constraint A10: Soem constraint
-                \"\"\"
+    Some remark.
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    :constraint A10: Soem constraint
+    """
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1448,23 +1365,21 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.summary[0], "Summary line.")
 
     def test_summary_remarks_description(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from enum import Enum
+        source = '''\
+from enum import Enum
 
-            class Some_class:
-                \"\"\"
-                Summary line.
+class Some_class:
+    """
+    Summary line.
 
-                Some remarks.
+    Some remarks.
 
-                Some description.
-                \"\"\"
+    Some description.
+    """
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1486,15 +1401,13 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.summary[0], "Summary line.")
 
     def test_symbol_table(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                pass
+        source = """\
+class Some_class:
+    pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1511,16 +1424,14 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(len(unpickled.concrete_classes), 1)
 
     def test_transpilable_verification(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def some_verification(x: int) -> bool:
-                return x > 0
+        source = """\
+@verification
+def some_verification(x: int) -> bool:
+    return x > 0
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1539,21 +1450,19 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.name, "some_verification")
 
     def test_type_annotation(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                some_property: str
-                
-                def __init__(
-                        self,
-                        some_property: str
-                ) -> None:
-                    self.some_property = some_property
+        source = """\
+class Some_class:
+    some_property: str
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+    def __init__(
+            self,
+            some_property: str
+    ) -> None:
+        self.some_property = some_property
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1572,16 +1481,14 @@ __xml_namespace__ = "https://dummy.com"
         self.assertIsInstance(unpickled, intermediate_types.TypeAnnotation)
 
     def test_understood_method(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                def some_method(self) -> None:
-                    pass
+        source = """\
+class Some_class:
+    def some_method(self) -> None:
+        pass
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1601,16 +1508,14 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.name, "some_method")
 
     def test_verification(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def some_verification(x: int) -> bool:
-                return x > 0
+        source = """\
+@verification
+def some_verification(x: int) -> bool:
+    return x > 0
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -1629,28 +1534,26 @@ __xml_namespace__ = "https://dummy.com"
         self.assertEqual(unpickled.name, "some_verification")
 
     def test_constant_set_of_enumeration_literals(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from enum import Enum
+        source = """\
+from enum import Enum
 
-            from aas_core_meta.marker import (
-                constant_set
-            )
+from aas_core_meta.marker import (
+    constant_set
+)
 
-            class Some_enum(Enum):
-                Literal1 = "lit1"
-                Literal2 = "lit2"
+class Some_enum(Enum):
+    Literal1 = "lit1"
+    Literal2 = "lit2"
 
-            Some_constant_set: Set[Some_enum] = constant_set(
-                values=[
-                    Some_enum.Literal1
-                ]
-            )
+Some_constant_set: Set[Some_enum] = constant_set(
+    values=[
+        Some_enum.Literal1
+    ]
+)
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source

--- a/dev/tests/intermediate/test_translate.py
+++ b/dev/tests/intermediate/test_translate.py
@@ -2,7 +2,6 @@
 
 import os
 import pathlib
-import textwrap
 import unittest
 from typing import List, Tuple
 
@@ -15,44 +14,42 @@ import tests.common
 
 class Test_in_lining_of_constructor_statements(unittest.TestCase):
     def test_case(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @abstract
-            class VeryAbstract:
-                some_property: int
+        source = """\
+@abstract
+class VeryAbstract:
+    some_property: int
 
-                @require(lambda some_property: some_property > 0)
-                def __init__(self, some_property: int) -> None:
-                    self.some_property = some_property
-
-
-            @abstract
-            class SomethingAbstract(VeryAbstract):
-                another_property: int
-
-                @require(lambda another_property: another_property > 0)
-                def __init__(self, some_property: int, another_property: int) -> None:
-                    VeryAbstract.__init__(self, some_property)
-                    self.another_property = another_property
-
-            class Concrete(SomethingAbstract):
-                yet_another_property: int
-
-                @require(lambda yet_another_property: yet_another_property > 0)
-                def __init__(
-                        self,
-                        some_property: int,
-                        another_property: int,
-                        yet_another_property: int
-                ) -> None:
-                    SomethingAbstract.__init__(self, some_property, another_property)
-                    self.yet_another_property = yet_another_property
+    @require(lambda some_property: some_property > 0)
+    def __init__(self, some_property: int) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+@abstract
+class SomethingAbstract(VeryAbstract):
+    another_property: int
+
+    @require(lambda another_property: another_property > 0)
+    def __init__(self, some_property: int, another_property: int) -> None:
+        VeryAbstract.__init__(self, some_property)
+        self.another_property = another_property
+
+class Concrete(SomethingAbstract):
+    yet_another_property: int
+
+    @require(lambda yet_another_property: yet_another_property > 0)
+    def __init__(
+            self,
+            some_property: int,
+            another_property: int,
+            yet_another_property: int
+    ) -> None:
+        SomethingAbstract.__init__(self, some_property, another_property)
+        self.yet_another_property = yet_another_property
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -71,19 +68,17 @@ class Test_in_lining_of_constructor_statements(unittest.TestCase):
 
 class Test_parsing_docstrings(unittest.TestCase):
     def test_class_reference(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """
-                This is some documentation.
+        source = '''\
+class Some_class:
+    """
+    This is some documentation.
 
-                Nested reference :class:`Some_class`
-                """
+    Nested reference :class:`Some_class`
+    """
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -107,22 +102,20 @@ class Test_parsing_docstrings(unittest.TestCase):
         self.assertIsInstance(references_to_our_types[0].our_type, intermediate.Class)
 
     def test_constraint_and_constraintref(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """
-                This is some documentation.
+        source = '''\
+class Some_class:
+    """
+    This is some documentation.
 
-                See :constraintref:`AAS-001`.
+    See :constraintref:`AAS-001`.
 
-                :constraint AAS-001:
-                    some constraint
-                """
+    :constraint AAS-001:
+        some constraint
+    """
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source

--- a/dev/tests/intermediate/test_type_inference.py
+++ b/dev/tests/intermediate/test_type_inference.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest
 from typing import List
 
@@ -139,202 +138,186 @@ class Test_with_smoke(unittest.TestCase):
         self.assertEqual(expected_joined_message, joined_message, source)
 
     def test_enumeration_literal_as_member(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_enum(Enum):
-                Literal_a = "LITERAL-A"
-                Literal_b = "LITERAL-B"
-                Literal_c = "LITERAL-C"
+        source = """\
+class Some_enum(Enum):
+    Literal_a = "LITERAL-A"
+    Literal_b = "LITERAL-B"
+    Literal_c = "LITERAL-C"
 
-            @invariant(
-                lambda self:
-                self.something == Some_enum.Literal_a
-                or self.something == Some_enum.Literal_b,
-                "Something must be either LITERAL-A or LITERAL-B."
-            )
-            class Some_class:
-                something: Some_enum
+@invariant(
+    lambda self:
+    self.something == Some_enum.Literal_a
+    or self.something == Some_enum.Literal_b,
+    "Something must be either LITERAL-A or LITERAL-B."
+)
+class Some_class:
+    something: Some_enum
 
-                def __init__(self, something: Some_enum) -> None:
-                    self.something = something
+    def __init__(self, something: Some_enum) -> None:
+        self.something = something
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         Test_with_smoke.execute(source=source)
 
     def test_class_member(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self:
-                self.something >= 1,
-                "Something must be at least 1."
-            )
-            class Some_class:
-                something: int
+        source = """\
+@invariant(
+    lambda self:
+    self.something >= 1,
+    "Something must be at least 1."
+)
+class Some_class:
+    something: int
 
-                def __init__(self, something: int) -> None:
-                    self.something = something
+    def __init__(self, something: int) -> None:
+        self.something = something
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         Test_with_smoke.execute(source=source)
 
     def test_non_nullness_of_members_member_in_implication(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                something: Optional[str]
+        source = """\
+class Some_class:
+    something: Optional[str]
 
-                def __init__(self, something: Optional[str] = None) -> None:
-                    self.something = something
+    def __init__(self, something: Optional[str] = None) -> None:
+        self.something = something
 
-            @invariant(
-                lambda self:
-                not (
-                    self.some_instance is not None
-                    and self.some_instance.something is not None
-                ) or (
-                    self.some_instance.something == "some-literal"
-                ),
-                "If something of some instance is defined, it must be set "
-                "to some-literal."
-            )
-            class Another_class:
-                some_instance: Optional[Some_class]
+@invariant(
+    lambda self:
+    not (
+        self.some_instance is not None
+        and self.some_instance.something is not None
+    ) or (
+        self.some_instance.something == "some-literal"
+    ),
+    "If something of some instance is defined, it must be set "
+    "to some-literal."
+)
+class Another_class:
+    some_instance: Optional[Some_class]
 
-                def __init__(self, some_instance: Optional[Some_class] = None) -> None:
-                    self.some_instance = some_instance
+    def __init__(self, some_instance: Optional[Some_class] = None) -> None:
+        self.some_instance = some_instance
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         Test_with_smoke.execute(source=source)
 
     def test_non_nullness_of_members_member_in_conjunction(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                something: Optional[str]
+        source = """\
+class Some_class:
+    something: Optional[str]
 
-                def __init__(self, something: Optional[str] = None) -> None:
-                    self.something = something
+    def __init__(self, something: Optional[str] = None) -> None:
+        self.something = something
 
-            @invariant(
-                lambda self:
-                self.some_instance is not None
-                and self.some_instance.something is not None
-                and self.some_instance.something == "some-literal",
-                "Something of some instance must be defined and set to some-literal."
-            )
-            class Another_class:
-                some_instance: Optional[Some_class]
+@invariant(
+    lambda self:
+    self.some_instance is not None
+    and self.some_instance.something is not None
+    and self.some_instance.something == "some-literal",
+    "Something of some instance must be defined and set to some-literal."
+)
+class Another_class:
+    some_instance: Optional[Some_class]
 
-                def __init__(self, some_instance: Optional[Some_class] = None) -> None:
-                    self.some_instance = some_instance
+    def __init__(self, some_instance: Optional[Some_class] = None) -> None:
+        self.some_instance = some_instance
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         Test_with_smoke.execute(source=source)
 
     def test_non_nullness_in_disjunction_with_is_none(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self:
-                (self.some_property is None) or (self.some_property == "dummy"),
-                "Dummy description"
-            )
-            class Something:
-                some_property: Optional[str]
+        source = """\
+@invariant(
+    lambda self:
+    (self.some_property is None) or (self.some_property == "dummy"),
+    "Dummy description"
+)
+class Something:
+    some_property: Optional[str]
 
-                def __init__(self, some_property: Optional[str] = None) -> None:
-                    self.some_property = some_property
+    def __init__(self, some_property: Optional[str] = None) -> None:
+        self.some_property = some_property
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         Test_with_smoke.execute(source=source)
 
     def test_tuple_literal(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @verification
-            def some_verification(x: str, y: int) -> bool:
-                return (x, y)[0] == x
+        source = """\
+@verification
+def some_verification(x: str, y: int) -> bool:
+    return (x, y)[0] == x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         Test_with_smoke.execute(source=source)
 
     def test_tuple_of_classes(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Some_class:
-                something: int
+        source = """\
+class Some_class:
+    something: int
 
-                def __init__(self, something: int) -> None:
-                    self.something = something
+    def __init__(self, something: int) -> None:
+        self.something = something
 
-            @invariant(
-                lambda self:
-                self.pair[0].something >= 1,
-                "Something of the first item must be at least 1."
-            )
-            class Another_class:
-                pair: Tuple[Some_class, Some_class]
+@invariant(
+    lambda self:
+    self.pair[0].something >= 1,
+    "Something of the first item must be at least 1."
+)
+class Another_class:
+    pair: Tuple[Some_class, Some_class]
 
-                def __init__(self, pair: Tuple[Some_class, Some_class]) -> None:
-                    self.pair = pair
+    def __init__(self, pair: Tuple[Some_class, Some_class]) -> None:
+        self.pair = pair
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         Test_with_smoke.execute(source=source)
 
     def test_is_none_fails_on_non_optional(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self:
-                self.something is None,
-                "Dummy invariant description"
-            )
-            class Some_class:
-                something: str
+        source = """\
+@invariant(
+    lambda self:
+    self.something is None,
+    "Dummy invariant description"
+)
+class Some_class:
+    something: str
 
-                def __init__(self, something: str) -> None:
-                    self.something = something
+    def __init__(self, something: str) -> None:
+        self.something = something
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         self.expect_type_inference_to_fail(
             source=source,
@@ -345,23 +328,21 @@ class Test_with_smoke(unittest.TestCase):
         )
 
     def test_is_not_none_fails_on_non_optional(self) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(
-                lambda self:
-                self.something is not None,
-                "Dummy invariant description"
-            )
-            class Some_class:
-                something: str
+        source = """\
+@invariant(
+    lambda self:
+    self.something is not None,
+    "Dummy invariant description"
+)
+class Some_class:
+    something: str
 
-                def __init__(self, something: str) -> None:
-                    self.something = something
+    def __init__(self, something: str) -> None:
+        self.something = something
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         self.expect_type_inference_to_fail(
             source=source,

--- a/dev/tests/intermediate/test_types.py
+++ b/dev/tests/intermediate/test_types.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 
-import textwrap
 import unittest
 
 import tests.common
@@ -68,20 +67,18 @@ class TestMappingOfPrimitiveTypesProperlyExposed(unittest.TestCase):
 
 class TestIsSubclassOf(unittest.TestCase):
     def test_no_inheritances(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                pass
+        source = """\
+class Concrete:
+    pass
 
 
-            class AnotherConcrete:
-                pass
+class AnotherConcrete:
+    pass
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -100,24 +97,22 @@ class TestIsSubclassOf(unittest.TestCase):
         self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
 
     def test_one_level_ancestor(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Parent:
-                pass
+        source = """\
+class Parent:
+    pass
 
 
-            class Concrete(Parent):
-                pass
+class Concrete(Parent):
+    pass
 
 
-            class AnotherConcrete:
-                pass
+class AnotherConcrete:
+    pass
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -139,28 +134,26 @@ class TestIsSubclassOf(unittest.TestCase):
         self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
 
     def test_two_level_ancestor(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class GrandParent:
-                pass
+        source = """\
+class GrandParent:
+    pass
 
 
-            class Parent(GrandParent):
-                pass
+class Parent(GrandParent):
+    pass
 
 
-            class Concrete(Parent):
-                pass
+class Concrete(Parent):
+    pass
 
 
-            class AnotherConcrete:
-                pass
+class AnotherConcrete:
+    pass
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -185,24 +178,22 @@ class TestIsSubclassOf(unittest.TestCase):
         self.assertFalse(concrete.is_subclass_of(cls=another_concrete))
 
     def test_common_ancestor_but_no_subclass(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Parent:
-                pass
+        source = """\
+class Parent:
+    pass
 
 
-            class Concrete(Parent):
-                pass
+class Concrete(Parent):
+    pass
 
 
-            class AnotherConcrete(Parent):
-                pass
+class AnotherConcrete(Parent):
+    pass
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -226,19 +217,17 @@ class TestIsSubclassOf(unittest.TestCase):
 
 class TestIsStructuralSubtypeOf(unittest.TestCase):
     def test_self(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: int
+        source = """\
+class Concrete:
+    x: int
 
-                def __init__(self, x: int) -> None:
-                    self.x = x
+    def __init__(self, x: int) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -251,30 +240,28 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertTrue(concrete.is_structural_subtype_of(cls=concrete))
 
     def test_unrelated_classes_with_same_shape(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: int
-                y: str
+        source = """\
+class Concrete:
+    x: int
+    y: str
 
-                def __init__(self, x: int, y: str) -> None:
-                    self.x = x
-                    self.y = y
-
-
-            class Structurally_same:
-                x: int
-                y: str
-
-                def __init__(self, x: int, y: str) -> None:
-                    self.x = x
-                    self.y = y
+    def __init__(self, x: int, y: str) -> None:
+        self.x = x
+        self.y = y
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Structurally_same:
+    x: int
+    y: str
+
+    def __init__(self, x: int, y: str) -> None:
+        self.x = x
+        self.y = y
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -291,26 +278,24 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertTrue(concrete.is_structural_subtype_of(cls=structurally_same))
 
     def test_mismatch_in_property_type(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: int
+        source = """\
+class Concrete:
+    x: int
 
-                def __init__(self, x: int) -> None:
-                    self.x = x
-
-
-            class Different_type:
-                x: str
-
-                def __init__(self, x: str) -> None:
-                    self.x = x
+    def __init__(self, x: int) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Different_type:
+    x: str
+
+    def __init__(self, x: str) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -327,28 +312,26 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertFalse(concrete.is_structural_subtype_of(cls=different_type))
 
     def test_missing_property(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: int
-                y: str
+        source = """\
+class Concrete:
+    x: int
+    y: str
 
-                def __init__(self, x: int, y: str) -> None:
-                    self.x = x
-                    self.y = y
-
-
-            class Missing_property:
-                x: int
-
-                def __init__(self, x: int) -> None:
-                    self.x = x
+    def __init__(self, x: int, y: str) -> None:
+        self.x = x
+        self.y = y
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Missing_property:
+    x: int
+
+    def __init__(self, x: int) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -370,27 +353,25 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
     def test_nominal_subclass_is_not_automatically_a_structural_subtype(
         self,
     ) -> None:
-        source = textwrap.dedent(
-            """\
-            class Parent:
-                x: int
+        source = """\
+class Parent:
+    x: int
 
-                def __init__(self, x: int) -> None:
-                    self.x = x
-
-
-            class Concrete(Parent):
-                y: str
-
-                def __init__(self, x: int, y: str) -> None:
-                    Parent.__init__(self, x)
-                    self.y = y
+    def __init__(self, x: int) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Concrete(Parent):
+    y: str
+
+    def __init__(self, x: int, y: str) -> None:
+        Parent.__init__(self, x)
+        self.y = y
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -408,36 +389,34 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
     def test_matching_primitive_type_but_different_constrained_primitive(
         self,
     ) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(lambda self: len(self) > 0, "Non-empty")
-            class Constrained_str_a(str):
-                pass
+        source = """\
+@invariant(lambda self: len(self) > 0, "Non-empty")
+class Constrained_str_a(str):
+    pass
 
 
-            @invariant(lambda self: len(self) < 100, "Not too long")
-            class Constrained_str_b(str):
-                pass
+@invariant(lambda self: len(self) < 100, "Not too long")
+class Constrained_str_b(str):
+    pass
 
 
-            class Concrete:
-                x: Constrained_str_a
+class Concrete:
+    x: Constrained_str_a
 
-                def __init__(self, x: Constrained_str_a) -> None:
-                    self.x = x
-
-
-            class Different_constrained_primitive:
-                x: Constrained_str_b
-
-                def __init__(self, x: Constrained_str_b) -> None:
-                    self.x = x
+    def __init__(self, x: Constrained_str_a) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Different_constrained_primitive:
+    x: Constrained_str_b
+
+    def __init__(self, x: Constrained_str_b) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -464,31 +443,29 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
     def test_constrained_primitive_is_not_substitutable_for_plain_primitive(
         self,
     ) -> None:
-        source = textwrap.dedent(
-            """\
-            @invariant(lambda self: len(self) > 0, "Non-empty")
-            class Constrained_str(str):
-                pass
+        source = """\
+@invariant(lambda self: len(self) > 0, "Non-empty")
+class Constrained_str(str):
+    pass
 
 
-            class Concrete:
-                x: str
+class Concrete:
+    x: str
 
-                def __init__(self, x: str) -> None:
-                    self.x = x
-
-
-            class With_constrained_primitive:
-                x: Constrained_str
-
-                def __init__(self, x: Constrained_str) -> None:
-                    self.x = x
+    def __init__(self, x: str) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class With_constrained_primitive:
+    x: Constrained_str
+
+    def __init__(self, x: Constrained_str) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -511,26 +488,24 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         )
 
     def test_different_list_items(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: List[int]
+        source = """\
+class Concrete:
+    x: List[int]
 
-                def __init__(self, x: List[int]) -> None:
-                    self.x = x
-
-
-            class Different_list_items:
-                x: List[str]
-
-                def __init__(self, x: List[str]) -> None:
-                    self.x = x
+    def __init__(self, x: List[int]) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Different_list_items:
+    x: List[str]
+
+    def __init__(self, x: List[str]) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -549,26 +524,24 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertFalse(concrete.is_structural_subtype_of(cls=different_list_items))
 
     def test_matching_list_items(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: List[int]
+        source = """\
+class Concrete:
+    x: List[int]
 
-                def __init__(self, x: List[int]) -> None:
-                    self.x = x
-
-
-            class Structurally_same:
-                x: List[int]
-
-                def __init__(self, x: List[int]) -> None:
-                    self.x = x
+    def __init__(self, x: List[int]) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Structurally_same:
+    x: List[int]
+
+    def __init__(self, x: List[int]) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -585,26 +558,24 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertTrue(concrete.is_structural_subtype_of(cls=structurally_same))
 
     def test_optional_property_is_invariant(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Required:
-                x: int
+        source = """\
+class Required:
+    x: int
 
-                def __init__(self, x: int) -> None:
-                    self.x = x
-
-
-            class Optional_property:
-                x: Optional[int]
-
-                def __init__(self, x: Optional[int] = None) -> None:
-                    self.x = x
+    def __init__(self, x: int) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Optional_property:
+    x: Optional[int]
+
+    def __init__(self, x: Optional[int] = None) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -623,26 +594,24 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertFalse(optional_property.is_structural_subtype_of(cls=required))
 
     def test_required_property_is_not_substitutable_for_optional(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Required:
-                x: int
+        source = """\
+class Required:
+    x: int
 
-                def __init__(self, x: int) -> None:
-                    self.x = x
-
-
-            class Optional_property:
-                x: Optional[int]
-
-                def __init__(self, x: Optional[int] = None) -> None:
-                    self.x = x
+    def __init__(self, x: int) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Optional_property:
+    x: Optional[int]
+
+    def __init__(self, x: Optional[int] = None) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -662,26 +631,24 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertFalse(required.is_structural_subtype_of(cls=optional_property))
 
     def test_matching_optional_property(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: Optional[int]
+        source = """\
+class Concrete:
+    x: Optional[int]
 
-                def __init__(self, x: Optional[int] = None) -> None:
-                    self.x = x
-
-
-            class Structurally_same:
-                x: Optional[int]
-
-                def __init__(self, x: Optional[int] = None) -> None:
-                    self.x = x
+    def __init__(self, x: Optional[int] = None) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Structurally_same:
+    x: Optional[int]
+
+    def __init__(self, x: Optional[int] = None) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source
@@ -698,26 +665,24 @@ class TestIsStructuralSubtypeOf(unittest.TestCase):
         self.assertTrue(concrete.is_structural_subtype_of(cls=structurally_same))
 
     def test_optional_list_with_different_items_is_not_a_subtype(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Concrete:
-                x: Optional[List[int]]
+        source = """\
+class Concrete:
+    x: Optional[List[int]]
 
-                def __init__(self, x: Optional[List[int]] = None) -> None:
-                    self.x = x
-
-
-            class Different_list_items:
-                x: Optional[List[str]]
-
-                def __init__(self, x: Optional[List[str]] = None) -> None:
-                    self.x = x
+    def __init__(self, x: Optional[List[int]] = None) -> None:
+        self.x = x
 
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            """
-        )
+class Different_list_items:
+    x: Optional[List[str]]
+
+    def __init__(self, x: Optional[List[str]] = None) -> None:
+        self.x = x
+
+
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+"""
 
         symbol_table, error = tests.common.translate_source_to_intermediate(
             source=source

--- a/dev/tests/parse/test_parse.py
+++ b/dev/tests/parse/test_parse.py
@@ -6,7 +6,6 @@ import ast
 import os
 import pathlib
 import re
-import textwrap
 import unittest
 from typing import Optional, Tuple, List
 
@@ -21,23 +20,19 @@ import tests.common
 
 class Test_parsing_AST(unittest.TestCase):
     def test_valid_code(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something:
-                pass
-            """
-        )
+        source = """\
+class Something:
+    pass
+"""
 
         atok, error = parse.source_to_atok(source=source)
         assert atok is not None
         assert error is None
 
     def test_invalid_code(self) -> None:
-        source = textwrap.dedent(
-            """\
-            class Something: 12 this is wrong
-            """
-        )
+        source = """\
+class Something: 12 this is wrong
+"""
 
         _, error = parse.source_to_atok(source=source)
         assert error is not None
@@ -57,11 +52,9 @@ class Test_checking_imports(unittest.TestCase):
         return [re.sub(r"column [0-9]+", "column X", error) for error in errors]
 
     def test_import_reported(self) -> None:
-        source = textwrap.dedent(
-            """\
-            import typing
-            """
-        )
+        source = """\
+import typing
+"""
 
         atok, error = parse.source_to_atok(source=source)
         assert error is None, f"{error=}"
@@ -78,11 +71,9 @@ class Test_checking_imports(unittest.TestCase):
         )
 
     def test_from_import_as_reported(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from typing import List as Lst
-            """
-        )
+        source = """\
+from typing import List as Lst
+"""
 
         atok, error = parse.source_to_atok(source=source)
         assert error is None, f"{error=}"
@@ -102,11 +93,9 @@ class Test_checking_imports(unittest.TestCase):
         )
 
     def test_unexpected_name_from_module(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from enum import List
-            """
-        )
+        source = """\
+from enum import List
+"""
 
         atok, error = parse.source_to_atok(source=source)
         assert atok is not None
@@ -123,11 +112,9 @@ class Test_checking_imports(unittest.TestCase):
         )
 
     def test_unexpected_import_from_a_module(self) -> None:
-        source = textwrap.dedent(
-            """\
-            from something import Else
-            """
-        )
+        source = """\
+from something import Else
+"""
 
         atok, error = parse.source_to_atok(source=source)
         assert atok is not None
@@ -157,30 +144,26 @@ class Test_parsing_docstring(unittest.TestCase):
         return cls.description.document
 
     def test_empty(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """"""
+        source = '''\
+class Some_class:
+    """"""
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         document = Test_parsing_docstring.parse_and_extract_docstring(source=source)
 
         self.assertEqual(0, len(document.children))
 
     def test_simple_single_line(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """This is some documentation."""
+        source = '''\
+class Some_class:
+    """This is some documentation."""
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         document = Test_parsing_docstring.parse_and_extract_docstring(source=source)
 
@@ -188,19 +171,17 @@ class Test_parsing_docstring(unittest.TestCase):
         self.assertIsInstance(document.children[0], docutils.nodes.paragraph)
 
     def test_that_multi_line_docstring_is_not_parsed_as_a_block_quote(self) -> None:
-        source = textwrap.dedent(
-            '''\
-            class Some_class:
-                """
-                This is some documentation.
+        source = '''\
+class Some_class:
+    """
+    This is some documentation.
 
-                Another paragraph.
-                """
+    Another paragraph.
+    """
 
-            __version__ = "dummy"
-            __xml_namespace__ = "https://dummy.com"
-            '''
-        )
+__version__ = "dummy"
+__xml_namespace__ = "https://dummy.com"
+'''
 
         document = Test_parsing_docstring.parse_and_extract_docstring(source=source)
         self.assertEqual(2, len(document.children))


### PR DESCRIPTION
``textwrap.dedent`` wraps source literals in an extra call and forces the content to be indented to match the surrounding code, which makes it harder to read and edit. Instead, we write triple-quoted strings flush-left at column 0 instead, which are easier to maintain and copy/paste.