### PR TITLE
Compose the C# XML de-serialization out of readers

### DIFF
--- a/aas_core_codegen/csharp/lib/_generate_xmlization.py
+++ b/aas_core_codegen/csharp/lib/_generate_xmlization.py
@@ -1,8 +1,9 @@
 """Generate code for XML de/serialization."""
 
+import collections
 import io
 import textwrap
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Mapping, MutableMapping, Set, Final
 
 from icontract import ensure, require
 
@@ -24,6 +25,7 @@ from aas_core_codegen.csharp.common import (
     INDENT3 as III,
     INDENT4 as IIII,
     INDENT5 as IIIII,
+    INDENT6 as IIIIII,
 )
 
 
@@ -108,637 +110,125 @@ private static string TryElementName(
     )
 
 
-def _generate_read_v_element() -> Stripped:
+def _generate_element_reader_delegates() -> Stripped:
+    """
+    Generate the two delegates through which every value is read.
+
+    An :py:class:`ElementReader` reads a whole element, tags included;
+    a :py:class:`ContentReader` reads what is between the tags. ``AtElement``
+    converts the latter into the former and is the only thing that has to
+    know an element's name.
+
+    Both return a plain ``T``. A nullable return would have to be spelled
+    ``T?``, which is a value type for a ``struct`` but a nullable reference
+    for a ``class``, so it would have to be split in two (and, before C# 9,
+    can not be written for an unconstrained ``T`` at all).
+
+    ``ElementReader`` is declared covariant, so that a field holding
+    the reader of a concrete class can be passed where the reader of its
+    interface is expected -- with a method group that came for free, but
+    a field is a value and needs the variance spelled out.
+    """
     return Stripped(
         f"""\
 /// <summary>
-/// Consume a start element named <paramref name="expectedName" /> from
-/// the reader and return whether it was a self-closing (empty) element.
-/// </summary>
-private static bool ReadVElement(
-{I}Xml.XmlReader reader,
-{I}string expectedName,
-{I}out Reporting.Error? error
-{I})
-{{
-{I}if (reader.EOF) {{
-{II}error = new Reporting.Error(
-{III}$"Expected a <{{expectedName}}> element, but got an end-of-file.");
-{II}return false;
-{I}}}
-
-{I}if (reader.NodeType != Xml.XmlNodeType.Element)
-{I}{{
-{II}error = new Reporting.Error(
-{III}$"Expected a <{{expectedName}}> start element, " +
-{III}$"but got the node of type {{reader.NodeType}} " +
-{III}$"with the value {{reader.Value}}");
-{II}return false;
-{I}}}
-
-{I}string elementName = TryElementName(
-{II}reader, out error);
-{I}if (error != null)
-{I}{{
-{II}return false;
-{I}}}
-{I}if (elementName != expectedName)
-{I}{{
-{II}error = new Reporting.Error(
-{III}$"Expected a <{{expectedName}}> element, " +
-{III}$"but got an element {{elementName}}");
-{II}return false;
-{I}}}
-
-{I}bool isEmpty = reader.IsEmptyElement;
-
-{I}// We can consume now the start element.
-{I}reader.Read();
-{I}return isEmpty;
-}}"""
-    )
-
-
-def _generate_read_v_end_element() -> Stripped:
-    return Stripped(
-        f"""\
-/// <summary>
-/// Consume an end element named <paramref name="expectedName" /> from
-/// the reader.
-/// </summary>
-private static void ReadVEndElement(
-{I}Xml.XmlReader reader,
-{I}string expectedName,
-{I}out Reporting.Error? error
-{I})
-{{
-{I}if (reader.EOF) {{
-{II}error = new Reporting.Error(
-{III}$"Expected a </{{expectedName}}> element, but got an end-of-file.");
-{II}return;
-{I}}}
-
-{I}if (reader.NodeType != Xml.XmlNodeType.EndElement)
-{I}{{
-{II}error = new Reporting.Error(
-{III}$"Expected a </{{expectedName}}> end element, " +
-{III}$"but got the node of type {{reader.NodeType}} " +
-{III}$"with the value {{reader.Value}}");
-{II}return;
-{I}}}
-
-{I}string elementName = TryElementName(
-{II}reader, out error);
-{I}if (error != null)
-{I}{{
-{II}return;
-{I}}}
-{I}if (elementName != expectedName)
-{I}{{
-{II}error = new Reporting.Error(
-{III}$"Expected a </{{expectedName}}> element, " +
-{III}$"but got an end element {{elementName}}");
-{II}return;
-{I}}}
-
-{I}// We can consume now the end element.
-{I}reader.Read();
-}}"""
-    )
-
-
-def _generate_read_v_element_as_primitive_functions() -> List[Stripped]:
-    result = []  # type: List[Stripped]
-
-    for function_name, result_type, deserialization_expr in (
-        ("ReadVElementAsBoolean", "bool", "reader.ReadContentAsBoolean()"),
-        ("ReadVElementAsLong", "long", "reader.ReadContentAsLong()"),
-        ("ReadVElementAsDouble", "double", "reader.ReadContentAsDouble()"),
-    ):
-        result.append(
-            Stripped(
-                f"""\
-/// <summary>
-/// Read the content of a <c>&lt;v&gt;</c> element
-/// and parse it as {result_type}.
-/// </summary>
-private static {result_type}? {function_name}(
-{I}Xml.XmlReader reader,
-{I}string elementName,
-{I}out Reporting.Error? error
-{I})
-{{
-{I}bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-{I}if (error != null)
-{I}{{
-{II}return null;
-{I}}}
-
-{I}{result_type}? result = null;
-{I}if (!isEmptyVElement)
-{I}{{
-{II}if (reader.EOF)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}"Expected an XML content representing {result_type}, " +
-{IIII}"but reached the end-of-file");
-{III}return null;
-{II}}}
-
-{II}try
-{II}{{
-{III}result = {deserialization_expr};
-{II}}}
-{II}catch (System.Exception exception)
-{IIII}when (exception is System.FormatException
-{IIIII}|| exception is System.Xml.XmlException)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}$"The content could not be de-serialized as {result_type}: {{exception}}");
-{III}return null;
-{II}}}
-
-{II}ReadVEndElement(reader, elementName, out error);
-{II}if (error != null)
-{II}{{
-{III}return null;
-{II}}}
-{I}}}
-
-{I}if (result == null)
-{I}{{
-{II}throw new System.InvalidOperationException(
-{III}"Unexpected result null when there is no error.");
-{I}}}
-{I}return result;
-}}"""
-            )
-        )
-
-    # A self-closing <v /> represents an empty string.
-    result.append(
-        Stripped(
-            f"""\
-/// <summary>
-/// Read the content of a <c>&lt;v&gt;</c> element
-/// and parse it as string.
-/// </summary>
-private static string? ReadVElementAsString(
-{I}Xml.XmlReader reader,
-{I}string elementName,
-{I}out Reporting.Error? error
-{I})
-{{
-{I}bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-{I}if (error != null)
-{I}{{
-{II}return null;
-{I}}}
-
-{I}string result;
-{I}if (!isEmptyVElement)
-{I}{{
-{II}if (reader.EOF)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}"Expected an XML content representing string, " +
-{IIII}"but reached the end-of-file");
-{III}return null;
-{II}}}
-
-{II}try
-{II}{{
-{III}result = reader.ReadContentAsString();
-{II}}}
-{II}catch (System.FormatException exception)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}$"The content could not be de-serialized as string: {{exception}}");
-{III}return null;
-{II}}}
-
-{II}ReadVEndElement(reader, elementName, out error);
-{II}if (error != null)
-{II}{{
-{III}return null;
-{II}}}
-{I}}}
-{I}else
-{I}{{
-{II}result = "";
-{I}}}
-
-{I}return result;
-}}"""
-        )
-    )
-
-    result.append(
-        Stripped(
-            f"""\
-/// <summary>
-/// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-/// </summary>
-private static byte[]? ReadVElementAsBytes(
-{I}Xml.XmlReader reader,
-{I}string elementName,
-{I}out Reporting.Error? error
-{I})
-{{
-{I}bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-{I}if (error != null)
-{I}{{
-{II}return null;
-{I}}}
-
-{I}byte[]? result;
-{I}if (isEmptyVElement)
-{I}{{
-{II}result = new byte[0];
-{I}}}
-{I}else
-{I}{{
-{II}if (reader.EOF)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}"Expected an XML content with base64-encoded bytes, " +
-{IIII}"but reached the end-of-file");
-{III}return null;
-{II}}}
-
-{II}try
-{II}{{
-{III}result = ReadWholeContentAsBase64(reader);
-{II}}}
-{II}catch (System.FormatException exception)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}"The content could not be de-serialized as " +
-{IIII}$"base64-encoded bytes: {{exception}}");
-{III}return null;
-{II}}}
-
-{II}ReadVEndElement(reader, elementName, out error);
-{II}if (error != null)
-{II}{{
-{III}return null;
-{II}}}
-{I}}}
-
-{I}return result;
-}}"""
-        )
-    )
-
-    return result
-
-
-def _generate_parse_list_of_class_helpers() -> Stripped:
-    """Generate the generic helper to de-serialize a list of reference-type items."""
-    return Stripped(
-        f"""\
-/// <summary>
-/// Read a single list item, positioned at its start element.
-/// </summary>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private delegate T? ClassItemDeserializer<T>(
-{I}Xml.XmlReader reader,
-{I}out Reporting.Error? error
-{I}) where T : class;
-
-/// <summary>
-/// Parse a sequence of list items with <paramref name="deserializeItem" />,
-/// stopping (without consuming) at the first non-element node.
+/// Read a single element, tags included, positioned at its start tag.
 /// </summary>
 /// <remarks>
-/// This is shared by all the list-typed properties whose items are
-/// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-/// array or a class instance).
-/// </remarks>
-/// <typeparam name="T">Type of a single list item</typeparam>
-private static List<T> ParseListOfClass<T>(
-{I}Xml.XmlReader reader,
-{I}ClassItemDeserializer<T> deserializeItem,
-{I}out Reporting.Error? error
-{I}) where T : class
-{{
-{I}error = null;
-{I}List<T> result = new List<T>();
-
-{I}SkipNoneWhitespaceAndComments(reader);
-
-{I}int index = 0;
-{I}while (reader.NodeType == Xml.XmlNodeType.Element)
-{I}{{
-{II}T? item = deserializeItem(reader, out error);
-{II}if (error != null)
-{II}{{
-{III}error.PrependSegment(
-{IIII}new Reporting.IndexSegment(
-{IIIII}index));
-{III}return result;
-{II}}}
-
-{II}result.Add(
-{III}item
-{IIII}?? throw new System.InvalidOperationException(
-{IIIII}"Unexpected item null when error null"));
-
-{II}index++;
-{II}SkipNoneWhitespaceAndComments(reader);
-{I}}}
-
-{I}return result;
-}}"""
-    )
-
-
-def _generate_parse_list_of_struct_helpers() -> Stripped:
-    """Generate the generic helper to de-serialize a list of value-type items."""
-    return Stripped(
-        f"""\
-/// <summary>
-/// Read a single list item, positioned at its start element.
-/// </summary>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private delegate T? StructItemDeserializer<T>(
-{I}Xml.XmlReader reader,
-{I}out Reporting.Error? error
-{I}) where T : struct;
-
-/// <summary>
-/// Parse a sequence of list items with <paramref name="deserializeItem" />,
-/// stopping (without consuming) at the first non-element node.
-/// </summary>
-/// <remarks>
-/// This is shared by all the list-typed properties whose items are
-/// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-/// an enumeration literal).
-/// </remarks>
-/// <typeparam name="T">Type of a single list item</typeparam>
-private static List<T> ParseListOfStruct<T>(
-{I}Xml.XmlReader reader,
-{I}StructItemDeserializer<T> deserializeItem,
-{I}out Reporting.Error? error
-{I}) where T : struct
-{{
-{I}error = null;
-{I}List<T> result = new List<T>();
-
-{I}SkipNoneWhitespaceAndComments(reader);
-
-{I}int index = 0;
-{I}while (reader.NodeType == Xml.XmlNodeType.Element)
-{I}{{
-{II}T? item = deserializeItem(reader, out error);
-{II}if (error != null)
-{II}{{
-{III}error.PrependSegment(
-{IIII}new Reporting.IndexSegment(
-{IIIII}index));
-{III}return result;
-{II}}}
-
-{II}result.Add(
-{III}item
-{IIII}?? throw new System.InvalidOperationException(
-{IIIII}"Unexpected item null when error null"));
-
-{II}index++;
-{II}SkipNoneWhitespaceAndComments(reader);
-{I}}}
-
-{I}return result;
-}}"""
-    )
-
-
-def _generate_tuple_item_reader_delegate() -> Stripped:
-    """Generate the delegate and adapters shared by all the generic tuple parsers."""
-    return Stripped(
-        f"""\
-/// <summary>
-/// Read a single tuple item from the current position of the reader.
-/// </summary>
-/// <remarks>
-/// A tuple-typed property is parsed by <c>ParseTupleN</c> (see
-/// <see cref="ParseTuple2{{T0, T1}}" /> for the arity-2 case, *etc.*), one
-/// function shared by *every* tuple-typed property of a given arity,
-/// regardless of which mix of reference and value types appears at each
-/// position. If <c>ParseTupleN</c> demanded the same
-/// <c>ClassItemDeserializer&lt;T&gt;</c>/<c>StructItemDeserializer&lt;T&gt;</c>
-/// shape already used for list items (a nullable return, constrained to
-/// <c>class</c> or <c>struct</c>), its own type parameters would need that
-/// constraint fixed once per position -- which breaks the moment two
-/// different tuple-typed properties of the same arity mix reference and
-/// value types differently at the same position (<em>e.g.</em>,
-/// <c>(string, long)</c> at one property and <c>(long, string)</c> at
-/// another could not share one <c>ParseTuple2</c>).
+/// Return the value; on failure it is meaningless and
+/// <paramref name="error" /> says why. A plain <c>T</c> rather than
+/// a <c>T?</c>, so that one unconstrained delegate serves both the value
+/// and the reference types.
 ///
-/// A single unconstrained <c>T? Method(Xml.XmlReader reader, out Reporting.Error? error)</c>
-/// shape shared by both reference and value types does not work around this
-/// either: for a value type, an unconstrained <c>T?</c> erases to plain
-/// <c>T</c> (not <c>System.Nullable&lt;T&gt;</c>), so a method returning
-/// <c>long?</c> can not even be assigned to it.
-///
-/// <c>TupleItemDeserializer&lt;T&gt;</c> sidesteps the class/struct split
-/// entirely by using an <c>out</c> parameter for the value instead of a
-/// nullable return, at the cost of needing an adapter --
-/// <see cref="AsTupleItemDeserializer{{T}}(ClassItemDeserializer{{T}})" /> --
-/// to convert an existing item reader (such as a <c>ReadVElementAsString</c>
-/// call or a class's own <c>...FromElement</c> method group) into one.
+/// <typeparamref name="T" /> is covariant, so that the reader of
+/// a concrete class can be used as the reader of an item of a list of
+/// its interface. It is <c>internal</c> only because the readers of
+/// the classes are, and a field may not be more accessible than its type.
 /// </remarks>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private delegate void TupleItemDeserializer<T>(
+/// <typeparam name="T">Type of the parsed value</typeparam>
+internal delegate T ElementReader<out T>(
 {I}Xml.XmlReader reader,
-{I}out T value,
 {I}out Reporting.Error? error);
 
 /// <summary>
-/// Adapt <paramref name="deserializeItem" /> -- a reference-type item reader
-/// as used for list-typed properties -- into a <see cref="TupleItemDeserializer{{T}}" />
-/// for use in a tuple-typed property.
+/// Read the content of an element, positioned after its start tag.
 /// </summary>
 /// <remarks>
-/// See the remarks on <see cref="TupleItemDeserializer{{T}}" /> for why this
-/// adapter -- rather than a shared constraint on <c>ParseTupleN</c> itself --
-/// is necessary. This overload and its <c>StructItemDeserializer&lt;T&gt;</c>
-/// counterpart are dispatched on the parameter's delegate type alone, so a
-/// caller never has to pick between them by name; each encapsulates the
-/// "unwrap the nullable result, or propagate the error" check exactly once,
-/// mirroring how <see cref="ParseListOfClass{{T}}" />/
-/// <see cref="ParseListOfStruct{{T}}" /> encapsulate the very same check
-/// once for lists instead of repeating it at every call site.
+/// Every value is read through this one shape, so that the reading can be
+/// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+/// an element reader or a list of them into one of these, and a class's own
+/// <c>...FromSequence</c> already is one.
 /// </remarks>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-{I}ClassItemDeserializer<T> deserializeItem
-{I}) where T : class
-{{
-{I}return (
-{II}Xml.XmlReader reader,
-{II}out T value,
-{II}out Reporting.Error? error) =>
-{II}{{
-{III}T? parsed = deserializeItem(reader, out error);
-{III}if (error != null)
-{III}{{
-{IIII}value = default!;
-{IIII}return;
-{III}}}
-{III}value = parsed
-{IIII}?? throw new System.InvalidOperationException(
-{IIIII}"Unexpected result null when error is null");
-{II}}};
-}}
-
-/// <summary>
-/// Adapt <paramref name="deserializeItem" /> -- a value-type item reader
-/// as used for list-typed properties -- into a <see cref="TupleItemDeserializer{{T}}" />
-/// for use in a tuple-typed property.
-/// </summary>
-/// <remarks>
-/// See <see cref="AsTupleItemDeserializer{{T}}(ClassItemDeserializer{{T}})" />
-/// for why this adapter is necessary.
-/// </remarks>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-{I}StructItemDeserializer<T> deserializeItem
-{I}) where T : struct
-{{
-{I}return (
-{II}Xml.XmlReader reader,
-{II}out T value,
-{II}out Reporting.Error? error) =>
-{II}{{
-{III}T? parsed = deserializeItem(reader, out error);
-{III}if (error != null)
-{III}{{
-{IIII}value = default;
-{IIII}return;
-{III}}}
-{III}value = parsed
-{IIII}?? throw new System.InvalidOperationException(
-{IIIII}"Unexpected result null when error is null");
-{II}}};
-}}
-
-/// <summary>
-/// Read a single tuple item wrapped in a reference-type-valued named
-/// element such as <c>&lt;v1&gt;</c>, <c>&lt;v2&gt;</c>, *etc.*
-/// </summary>
-/// <remarks>
-/// This is the counterpart of <see cref="ClassItemDeserializer{{T}}" /> for
-/// item readers that additionally need the expected element name passed in
-/// -- such as <see cref="ReadVElementAsString" /> -- since a tuple item, unlike
-/// a list item, is wrapped in a positional element name instead of always
-/// the fixed <c>&lt;v&gt;</c>.
-/// </remarks>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private delegate T? NamedClassItemDeserializer<T>(
+/// <typeparam name="T">Type of the value</typeparam>
+private delegate T ContentReader<T>(
 {I}Xml.XmlReader reader,
-{I}string elementName,
-{I}out Reporting.Error? error
-{I}) where T : class;
+{I}bool isEmpty,
+{I}out Reporting.Error? error);"""
+    )
 
+
+def _generate_read_list_helper() -> Stripped:
+    """Generate the single generic helper to read a sequence of list items."""
+    return Stripped(
+        f"""\
 /// <summary>
-/// Read a single tuple item wrapped in a value-type-valued named element
-/// such as <c>&lt;v1&gt;</c>, <c>&lt;v2&gt;</c>, *etc.*
+/// Read a sequence of list items with <paramref name="readItem" />,
+/// stopping (without consuming) at the first non-element node.
 /// </summary>
 /// <remarks>
-/// See the remarks on <see cref="NamedClassItemDeserializer{{T}}" />.
+/// This is shared by everything of a list type, whatever its items are and
+/// however deeply it is nested, since the items are read through
+/// an <see cref="ElementReader{{T}}" /> like any other element.
 /// </remarks>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private delegate T? NamedStructItemDeserializer<T>(
+/// <typeparam name="T">Type of a single list item</typeparam>
+private static List<T> ReadList<T>(
 {I}Xml.XmlReader reader,
-{I}string elementName,
+{I}ElementReader<T> readItem,
 {I}out Reporting.Error? error
-{I}) where T : struct;
-
-/// <summary>
-/// Adapt <paramref name="deserializeItem" /> -- a reference-type item reader
-/// which additionally expects the element name, such as
-/// <see cref="ReadVElementAsString" /> -- into a
-/// <see cref="TupleItemDeserializer{{T}}" /> bound to
-/// <paramref name="elementName" />, for use in a tuple-typed property.
-/// </summary>
-/// <remarks>
-/// See the remarks on <see cref="TupleItemDeserializer{{T}}" /> for why an
-/// adapter is necessary in the first place. This overload additionally
-/// closes over <paramref name="elementName" /> (<em>e.g.</em>, <c>"v1"</c>),
-/// so that the tuple-typed property itself does not need to spell out a
-/// lambda just to bind the positional element name.
-/// </remarks>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-{I}NamedClassItemDeserializer<T> deserializeItem,
-{I}string elementName
-{I}) where T : class
+{I})
 {{
-{I}return (
-{II}Xml.XmlReader reader,
-{II}out T value,
-{II}out Reporting.Error? error) =>
-{II}{{
-{III}T? parsed = deserializeItem(reader, elementName, out error);
-{III}if (error != null)
-{III}{{
-{IIII}value = default!;
-{IIII}return;
-{III}}}
-{III}value = parsed
-{IIII}?? throw new System.InvalidOperationException(
-{IIIII}"Unexpected result null when error is null");
-{II}}};
-}}
+{I}error = null;
+{I}var result = new List<T>();
 
-/// <summary>
-/// Adapt <paramref name="deserializeItem" /> -- a value-type item reader
-/// which additionally expects the element name, such as
-/// <see cref="ReadVElementAsLong" /> -- into a
-/// <see cref="TupleItemDeserializer{{T}}" /> bound to
-/// <paramref name="elementName" />, for use in a tuple-typed property.
-/// </summary>
-/// <remarks>
-/// See <see cref="AsTupleItemDeserializer{{T}}(NamedClassItemDeserializer{{T}}, string)" />
-/// for why this adapter is necessary.
-/// </remarks>
-/// <typeparam name="T">Type of the parsed item</typeparam>
-private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-{I}NamedStructItemDeserializer<T> deserializeItem,
-{I}string elementName
-{I}) where T : struct
-{{
-{I}return (
-{II}Xml.XmlReader reader,
-{II}out T value,
-{II}out Reporting.Error? error) =>
+{I}SkipNoneWhitespaceAndComments(reader);
+
+{I}int index = 0;
+{I}while (reader.NodeType == Xml.XmlNodeType.Element)
+{I}{{
+{II}T item = readItem(reader, out error);
+{II}if (error != null)
 {II}{{
-{III}T? parsed = deserializeItem(reader, elementName, out error);
-{III}if (error != null)
-{III}{{
-{IIII}value = default;
-{IIII}return;
-{III}}}
-{III}value = parsed
-{IIII}?? throw new System.InvalidOperationException(
-{IIIII}"Unexpected result null when error is null");
-{II}}};
+{III}error.PrependSegment(
+{IIII}new Reporting.IndexSegment(
+{IIIII}index));
+{III}return result;
+{II}}}
+
+{II}result.Add(item);
+
+{II}index++;
+{II}SkipNoneWhitespaceAndComments(reader);
+{I}}}
+
+{I}return result;
 }}"""
     )
 
 
 @require(lambda arity: arity > 0)
-def _generate_parse_tuple_helper(arity: int) -> Stripped:
+def _generate_as_tuple_combinator(arity: int) -> Stripped:
     """
-    Generate a generic function to parse a tuple of the given ``arity``.
+    Generate the combinator reading a content as a tuple of the given ``arity``.
 
-    Each positional item is read by its own ``deserializeItemI`` callback,
-    which is expected to have already consumed its own start and end tags (if
-    any). We can not reuse :py:func:`_generate_parse_list_of_class_helpers`/
-    :py:func:`_generate_parse_list_of_struct_helpers` here since a tuple is
-    heterogeneous -- see :py:func:`TupleItemDeserializer` for why the item
-    delegate uses an ``out`` parameter instead of a nullable return value.
+    Each positional item is read by its own ``readItemI`` callback, which is
+    expected to have already consumed its own start and end tags (if any).
+    We can not reuse :py:func:`_generate_read_list_helper` here, since
+    a tuple is heterogeneous -- but the very same, unconstrained
+    :py:class:`ElementReader` serves both.
+
+    The content is not necessarily a property's. The result is a plain
+    ``ContentReader``, so wrapping it in ``AtElement`` makes a tuple readable
+    as an item of a list or of another tuple, arbitrarily deep.
     """
     type_params = [f"T{i}" for i in range(arity)]
     type_params_joined = ", ".join(type_params)
@@ -748,15 +238,13 @@ def _generate_parse_tuple_helper(arity: int) -> Stripped:
     else:
         tuple_type = f"({type_params_joined})"
 
-    params_joined = ",\n".join(
-        f"TupleItemDeserializer<T{i}> deserializeItem{i}" for i in range(arity)
-    )
+    params_joined = ",\n".join(f"ElementReader<T{i}> readItem{i}" for i in range(arity))
 
     item_blocks = []  # type: List[Stripped]
     for i in range(arity):
         item_block = Stripped(
             f"""\
-deserializeItem{i}(reader, out T{i} item{i}, out error);
+T{i} item{i} = readItem{i}(reader, out error);
 if (error != null)
 {{
 {I}error.PrependSegment(
@@ -783,733 +271,1107 @@ if (error != null)
 {I}{indent_but_first_line(item_vars_joined, I)}
 )"""
 
-    function_name = f"ParseTuple{arity}"
-
     return Stripped(
         f"""\
 /// <summary>
-/// Parse a tuple of {arity} item(s) from the current position
-/// of <paramref name="reader" />.
+/// Read a content as a tuple of {arity} item(s).
 /// </summary>
 /// <remarks>
-/// This is shared by all the tuple-typed properties of arity {arity}.
+/// This is shared by everything of a tuple type of arity {arity} -- be it
+/// a property, or a value nested in a list or in another tuple.
 /// </remarks>
-private static {tuple_type} {function_name}<{type_params_joined}>(
-{I}Xml.XmlReader reader,
-{I}{indent_but_first_line(params_joined, I)},
-{I}out Reporting.Error? error)
+private static ContentReader<{tuple_type}> AsTuple{arity}<{type_params_joined}>(
+{I}{indent_but_first_line(params_joined, I)}
+{I})
 {{
-{I}error = null;
+{I}return (
+{II}Xml.XmlReader reader,
+{II}bool isEmptyProperty,
+{II}out Reporting.Error? error
+{I}) =>
+{I}{{
+{II}error = null;
 
-{I}{indent_but_first_line(item_blocks_joined, I)}
+{II}if (isEmptyProperty)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}"Expected an XML content representing a tuple of {arity} item(s), " +
+{IIII}"but the element was self-closing");
+{III}return default!;
+{II}}}
 
-{I}return {indent_but_first_line(return_expr, I)};
+{II}SkipNoneWhitespaceAndComments(reader);
+
+{II}{indent_but_first_line(item_blocks_joined, II)}
+
+{II}return {indent_but_first_line(return_expr, II)};
+{I}}};
 }}"""
     )
 
 
-def _generate_read_v_element_as_enumeration(
-    enumeration: intermediate.Enumeration,
-) -> Stripped:
-    """Generate the function to de-serialize a literal from a ``<v>``."""
-    enum_name = csharp_naming.enum_name(enumeration.name)
+_CONTENT_READER_BY_PRIMITIVE = {
+    intermediate.PrimitiveType.BOOL: (
+        "ReadContentAsBoolean",
+        "bool",
+        "reader.ReadContentAsBoolean()",
+    ),
+    intermediate.PrimitiveType.INT: (
+        "ReadContentAsLong",
+        "long",
+        "reader.ReadContentAsLong()",
+    ),
+    intermediate.PrimitiveType.FLOAT: (
+        "ReadContentAsDouble",
+        "double",
+        "reader.ReadContentAsDouble()",
+    ),
+    intermediate.PrimitiveType.STR: (
+        "ReadContentAsString",
+        "string",
+        "reader.ReadContentAsString()",
+    ),
+    intermediate.PrimitiveType.BYTEARRAY: (
+        "ReadContentAsBytes",
+        "byte[]",
+        f"ReadWholeContentAsBase64(\n{II}reader)",
+    ),
+}
+
+assert all(
+    literal in _CONTENT_READER_BY_PRIMITIVE for literal in intermediate.PrimitiveType
+)
+
+# NOTE (mristin):
+# A self-closing element stands for an empty string and for empty bytes,
+# whereas the other primitives have no content to convert at all and so it is
+# an error. Where a primitive has such an empty value, it is spelled out here
+# and the reading goes through the ``...OrEmpty`` variant of the skeleton.
+_EMPTY_VALUE_BY_PRIMITIVE = {
+    intermediate.PrimitiveType.STR: '""',
+    intermediate.PrimitiveType.BYTEARRAY: "new byte[0]",
+}
+
+
+class _NeededContentReaders:
+    """Capture which of the shared content readers a model actually needs."""
+
+    def __init__(
+        self,
+        primitive_types: Set[intermediate.PrimitiveType],
+        enumerations: bool,
+        polymorphic: bool,
+        lists: bool,
+        v_elements: bool,
+    ) -> None:
+        """Initialize with the given values."""
+        self.primitive_types = primitive_types
+        self.enumerations = enumerations
+        self.polymorphic = polymorphic
+        self.lists = lists
+        self.v_elements = v_elements
+
+    @property
+    def text(self) -> bool:
+        """Check whether the skeleton reading a content as text is needed."""
+        return any(
+            a_type in self.primitive_types for a_type in _CONTENT_READER_BY_PRIMITIVE
+        )
+
+
+def _needed_content_readers(
+    symbol_table: intermediate.SymbolTable,
+) -> _NeededContentReaders:
+    """
+    Determine which shared content readers need to be generated.
+
+    Only the properties of the concrete classes matter, as they are the only
+    ones de-serialized from a sequence of XML elements. A list or a tuple
+    contributes through its *items* as well, as they are read by the very
+    same combinators, only one nesting level deeper.
+
+    This mirrors how the tuple helpers are already emitted only for
+    the arities which actually occur (see
+    :py:func:`aas_core_codegen.intermediate.tuple_arities`) -- without it,
+    a model would pay for the readers it never calls.
+    """
+    primitive_types = set()  # type: Set[intermediate.PrimitiveType]
+    enumerations = False
+    polymorphic = False
+    lists = False
+    v_elements = False
+
+    for cls in symbol_table.concrete_classes:
+        for prop in cls.properties:
+            type_anno = intermediate.beneath_optional(prop.type_annotation)
+
+            if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
+                primitive_types.add(type_anno.a_type)
+
+            elif isinstance(type_anno, intermediate.OurTypeAnnotation):
+                our_type = type_anno.our_type
+
+                if isinstance(our_type, intermediate.Enumeration):
+                    enumerations = True
+                    primitive_types.add(intermediate.PrimitiveType.STR)
+
+                elif isinstance(our_type, intermediate.ConstrainedPrimitive):
+                    primitive_types.add(our_type.constrainee)
+
+                elif isinstance(
+                    our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
+                ):
+                    if (
+                        isinstance(our_type, intermediate.AbstractClass)
+                        or len(our_type.concrete_descendants) > 0
+                    ):
+                        polymorphic = True
+
+                elif isinstance(our_type, intermediate.NamedUnion):
+                    polymorphic = True
+
+                else:
+                    assert_never(our_type)
+
+            elif isinstance(
+                type_anno,
+                (intermediate.ListTypeAnnotation, intermediate.TupleTypeAnnotation),
+            ):
+                # NOTE (mristin):
+                # A primitive or an enumeration item of a list or of a tuple
+                # is wrapped in a ``<v>`` element of its own.
+                if isinstance(type_anno, intermediate.ListTypeAnnotation):
+                    lists = True
+                    item_type_annotations = [
+                        type_anno.items
+                    ]  # type: List[intermediate.TypeAnnotationUnion]
+                else:
+                    item_type_annotations = list(type_anno.items)
+
+                for item_type_anno in item_type_annotations:
+                    item_primitive_type = intermediate.try_primitive_type(
+                        item_type_anno
+                    )
+
+                    if item_primitive_type is not None:
+                        primitive_types.add(item_primitive_type)
+                        v_elements = True
+
+                    elif isinstance(
+                        item_type_anno, intermediate.OurTypeAnnotation
+                    ) and isinstance(item_type_anno.our_type, intermediate.Enumeration):
+                        primitive_types.add(intermediate.PrimitiveType.STR)
+                        enumerations = True
+                        v_elements = True
+
+            else:
+                pass
+
+    return _NeededContentReaders(
+        primitive_types=primitive_types,
+        enumerations=enumerations,
+        polymorphic=polymorphic,
+        lists=lists,
+        v_elements=v_elements,
+    )
+
+
+def _generate_as_text_combinators(
+    needed: _NeededContentReaders,
+) -> List[Stripped]:
+    """
+    Generate the shared skeletons for reading a content as text.
+
+    The self-closing-element check, the end-of-file check and the ``try``/
+    ``catch`` around the conversion are the same for every type, so they are
+    generated here exactly once -- the type-specific part is passed in as
+    a :py:class:`ContentConverter`. The content is that of *any* element --
+    a property's, or a ``<v>`` element's of a list item or of a tuple item --
+    so nothing here may speak of a property.
+
+    There are two skeletons rather than one because a self-closing element is
+    an error for most of the types, but the empty value for a couple of them
+    (an empty string, no bytes).
+
+    The type name in the messages comes from ``typeof(T).Name`` instead of
+    being baked in by the generator, so that a call site costs no more than
+    it did when there was one hand-rolled reader per type.
+    """
+    result = []  # type: List[Stripped]
+
+    if not needed.text:
+        return result
+
+    result.append(
+        Stripped(
+            """\
+/// <summary>
+/// Convert the content at the current position of <paramref name="reader" />.
+/// </summary>
+/// <typeparam name="T">Type to convert the content to</typeparam>
+private delegate T ContentConverter<T>(Xml.XmlReader reader);"""
+        )
+    )
+
+    result.append(
+        Stripped(
+            f"""\
+/// <summary>
+/// Read the content between a start and an end tag and convert it
+/// with <paramref name="readContent" />.
+/// </summary>
+/// <remarks>
+/// This is the one skeleton for reading any content whatsoever -- of
+/// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+/// (see <see cref="AtElement{{T}}" />). Only the conversion differs, so
+/// only the conversion is passed in.
+///
+/// On failure the returned value is meaningless; the caller checks
+/// <paramref name="error" /> and bails out before ever reading it. That is
+/// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+/// split into a variant for the value and one for the reference types.
+/// </remarks>
+/// <typeparam name="T">Type of the value</typeparam>
+private static ContentReader<T> AsText<T>(
+{I}ContentConverter<T> readContent
+{I})
+{{
+{I}return (
+{II}Xml.XmlReader reader,
+{II}bool isEmpty,
+{II}out Reporting.Error? error
+{I}) =>
+{I}{{
+{II}error = null;
+
+{II}if (isEmpty)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}$"Expected an XML content representing {{typeof(T).Name}}, " +
+{IIII}"but the element was self-closing");
+{III}return default!;
+{II}}}
+
+{II}if (reader.EOF)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}$"Expected an XML content representing {{typeof(T).Name}}, " +
+{IIII}"but reached the end-of-file");
+{III}return default!;
+{II}}}
+
+{II}try
+{II}{{
+{III}return readContent(reader);
+{II}}}
+{II}catch (System.Exception exception)
+{IIII}when (exception is System.FormatException
+{IIIII}|| exception is System.Xml.XmlException)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}$"The content could not be de-serialized as {{typeof(T).Name}}: " +
+{IIII}exception.Message);
+{III}return default!;
+{II}}}
+{I}}};
+}}"""
+        )
+    )
+
+    result.append(
+        Stripped(
+            f"""\
+/// <summary>
+/// Read the content between a start and an end tag, or return
+/// <paramref name="whenEmpty" /> if the element was self-closing.
+/// </summary>
+/// <typeparam name="T">Type of the value</typeparam>
+[CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+private static ContentReader<T> AsText<T>(
+{I}ContentConverter<T> readContent,
+{I}T whenEmpty
+{I})
+{{
+{I}ContentReader<T> readText = AsText<T>(readContent);
+
+{I}return (
+{II}Xml.XmlReader reader,
+{II}bool isEmpty,
+{II}out Reporting.Error? error
+{I}) =>
+{I}{{
+{II}if (isEmpty)
+{II}{{
+{III}error = null;
+{III}return whenEmpty;
+{II}}}
+
+{II}return readText(reader, false, out error);
+{I}}};
+}}"""
+        )
+    )
+
+    return result
+
+
+def _generate_consume_end_element() -> Stripped:
+    """
+    Generate the shared helper consuming the end tag of an element.
+
+    Reading a whole element and reading a property of a sequence conclude
+    in exactly the same way, so this is shared by ``AtElement`` and by
+    the property loop of every ``...FromSequence``.
+    """
     return Stripped(
         f"""\
 /// <summary>
-/// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-/// <see cref="Aas.{enum_name}"/>.
+/// Consume the end tag matching <paramref name="elementName" />, unless
+/// <paramref name="isEmptyElement" /> tells that the element was
+/// self-closing and thus has no end tag at all.
 /// </summary>
-private static Aas.{enum_name}? ReadVElementAs{enum_name}(
+private static void ConsumeEndElement(
 {I}Xml.XmlReader reader,
 {I}string elementName,
+{I}bool isEmptyElement,
 {I}out Reporting.Error? error
 {I})
 {{
-{I}string? text = ReadVElementAsString(reader, elementName, out error);
+{I}error = null;
+
+{I}if (isEmptyElement)
+{I}{{
+{II}return;
+{I}}}
+
+{I}SkipNoneWhitespaceAndComments(reader);
+
+{I}if (reader.EOF)
+{I}{{
+{II}error = new Reporting.Error(
+{III}$"Expected a closing element </{{elementName}}>, " +
+{III}"but reached the end-of-file");
+{II}return;
+{I}}}
+
+{I}if (reader.NodeType != Xml.XmlNodeType.EndElement)
+{I}{{
+{II}error = new Reporting.Error(
+{III}$"Expected a closing element </{{elementName}}>, " +
+{III}$"but got a node of type {{reader.NodeType}} " +
+{III}$"with value {{reader.Value}}");
+{II}return;
+{I}}}
+
+{I}string endElementName = TryElementName(
+{II}reader, out error);
 {I}if (error != null)
 {I}{{
-{II}return null;
+{II}return;
 {I}}}
 
-{I}if (text == null)
-{I}{{
-{II}throw new System.InvalidOperationException(
-{III}"Text must not be null if error is null.");
-{I}}}
-
-{I}Aas.{enum_name}? result = Stringification.{enum_name}FromString(
-{II}text);
-
-{I}if (result == null)
+{I}if (endElementName != elementName)
 {I}{{
 {II}error = new Reporting.Error(
-{III}"The text could not be parsed as enumeration literal " +
-{III}$"of {enum_name}: {{result}}");
-{II}return null;
+{III}$"Expected a closing element </{{elementName}}>, " +
+{III}$"but got a closing element </{{endElementName}}>");
+{II}return;
 {I}}}
 
-{I}return result;
+{I}// Consume the end tag.
+{I}reader.Read();
 }}"""
     )
 
 
-def _generate_deserialize_primitive_property(
-    prop: intermediate.Property, cls: intermediate.ConcreteClass
-) -> Stripped:
-    """Generate the snippet to deserialize a property ``prop`` of primitive type."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
+def _generate_try_next_property() -> Stripped:
+    """
+    Generate the shared helper reading the start tag of the next property.
 
-    a_type = intermediate.try_primitive_type(type_anno)
-    assert a_type is not None, f"Unexpected type annotation: {prop.type_annotation}"
+    The framing of the property loop -- where the sequence ends, what is not
+    an element at all, what the property is called and whether it is
+    self-closing -- says nothing about the class being read, so it is
+    generated once here instead of once per class.
 
-    deserialization_expr: str
-    if a_type is intermediate.PrimitiveType.BOOL:
-        deserialization_expr = "reader.ReadContentAsBoolean()"
-    elif a_type is intermediate.PrimitiveType.INT:
-        deserialization_expr = "reader.ReadContentAsLong()"
-    elif a_type is intermediate.PrimitiveType.FLOAT:
-        deserialization_expr = "reader.ReadContentAsDouble()"
-    elif a_type is intermediate.PrimitiveType.STR:
-        deserialization_expr = "reader.ReadContentAsString()"
-    elif a_type is intermediate.PrimitiveType.BYTEARRAY:
-        deserialization_expr = f"""\
-DeserializeImplementation.ReadWholeContentAsBase64(
-{I}reader)"""
-    else:
-        assert_never(a_type)
+    Only the ``switch`` over the property names is left inline, because its
+    branches assign the local variables which the constructor is called with
+    afterwards.
+    """
+    return Stripped(
+        f"""\
+/// <summary>
+/// Read the start tag of the next property of a sequence and return whether
+/// there was one.
+/// </summary>
+/// <remarks>
+/// A sequence ends at the end tag of the enclosing element or at the end of
+/// the file, which is not a failure -- when this returns <c>false</c>,
+/// <paramref name="error" /> tells the two apart.
+///
+/// The start tag is consumed, so the reader is left at the content of
+/// the property.
+/// </remarks>
+private static bool TryNextProperty(
+{I}Xml.XmlReader reader,
+{I}out string elementName,
+{I}out bool isEmptyProperty,
+{I}out Reporting.Error? error
+{I})
+{{
+{I}error = null;
+{I}elementName = "";
+{I}isEmptyProperty = false;
 
-    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
+{I}SkipNoneWhitespaceAndComments(reader);
 
-    prop_name = csharp_naming.property_name(prop.name)
-    cls_name = csharp_naming.class_name(cls.name)
-    xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
+{I}if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+{I}{{
+{II}return false;
+{I}}}
 
-    if a_type is intermediate.PrimitiveType.STR:
-        empty_handling_body = Stripped(f'{target_var} = "";')
-    else:
-        empty_handling_body = Stripped(
-            f"""\
-error = new Reporting.Error(
-{I}"The property {prop_name} of an instance of class {cls_name} " +
-{I}"can not be de-serialized from a self-closing element " +
-{I}"since it needs content");
-error.PrependSegment(
-{I}new Reporting.NameSegment(
-{II}{xml_prop_name_literal}));
-return null;"""
+{I}if (reader.NodeType != Xml.XmlNodeType.Element)
+{I}{{
+{II}error = new Reporting.Error(
+{III}"Expected an XML start element representing a property, " +
+{III}$"but got the node of type {{reader.NodeType}} " +
+{III}$"with the value {{reader.Value}}");
+{II}return false;
+{I}}}
+
+{I}elementName = TryElementName(
+{II}reader, out error);
+{I}if (error != null)
+{I}{{
+{II}return false;
+{I}}}
+
+{I}isEmptyProperty = reader.IsEmptyElement;
+
+{I}// Consume the start tag and go to the content.
+{I}reader.Read();
+
+{I}return true;
+}}"""
+    )
+
+
+def _generate_at_element_combinator() -> Stripped:
+    """
+    Generate the combinator reading a whole element of an expected name.
+
+    An element is only its start and end tag around a content, so the content
+    is read by the very same :py:class:`ContentReader` as everything else --
+    there is no separate reader per primitive, per enumeration or per class.
+
+    The name is data, not a type: ``v`` for a list item, ``v1``, ``v2``,
+    *etc.* by position in a tuple, and its own XML name for a class. So it is
+    bound here rather than being spelled as a type argument, and the error
+    messages are phrased in terms of it -- which is why the combinator needs
+    nothing else to say what it expected.
+
+    This is the hinge of the whole composition: it turns
+    a :py:class:`ContentReader` back into an :py:class:`ElementReader`, which
+    is what a list and a tuple take for their items, and what a class is read
+    as. Any content reader can therefore be nested as deeply as the model
+    needs.
+    """
+    return Stripped(
+        f"""\
+/// <summary>
+/// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+/// so that the result reads the whole element, tags included.
+/// </summary>
+/// <typeparam name="T">Type of the parsed value</typeparam>
+private static ElementReader<T> AtElement<T>(
+{I}ContentReader<T> readContent,
+{I}string elementName
+{I})
+{{
+{I}return (
+{II}Xml.XmlReader reader,
+{II}out Reporting.Error? error
+{I}) =>
+{I}{{
+{II}string observedName = PeekElementName(
+{III}reader, out error);
+{II}if (error != null)
+{II}{{
+{III}return default!;
+{II}}}
+
+{II}if (observedName != elementName)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}$"Expected a <{{elementName}}> element, " +
+{IIII}$"but got a <{{observedName}}> element");
+{III}return default!;
+{II}}}
+
+{II}bool isEmptyElement = reader.IsEmptyElement;
+
+{II}// Consume the start tag and go to the content.
+{II}reader.Read();
+
+{II}T value = readContent(reader, isEmptyElement, out error);
+{II}if (error != null)
+{II}{{
+{III}return default!;
+{II}}}
+
+{II}ConsumeEndElement(
+{III}reader, elementName, isEmptyElement, out error);
+{II}if (error != null)
+{II}{{
+{III}return default!;
+{II}}}
+
+{II}return value;
+{I}}};
+}}"""
+    )
+
+
+def _generate_content_converters(
+    primitive_types: Set[intermediate.PrimitiveType],
+) -> List[Stripped]:
+    """Generate the conversions passed to the skeletons, one per primitive."""
+    result = []  # type: List[Stripped]
+
+    for a_type, (
+        function_name,
+        csharp_type,
+        conversion_expr,
+    ) in _CONTENT_READER_BY_PRIMITIVE.items():
+        if a_type not in primitive_types:
+            continue
+
+        result.append(
+            Stripped(
+                f"""\
+/// <summary>
+/// Convert the content at the current position of <paramref name="reader" />
+/// to {csharp_type}.
+/// </summary>
+private static {csharp_type} {function_name}(Xml.XmlReader reader)
+{{
+{I}return {conversion_expr};
+}}"""
+            )
         )
 
+    return result
+
+
+def _generate_literal_parser_delegate() -> Stripped:
+    """Generate the delegate which parses the text of an enumeration literal."""
+    return Stripped(
+        """\
+/// <summary>
+/// Parse the text of a literal of <typeparamref name="T" />.
+/// </summary>
+/// <remarks>
+/// Every <c>Stringification.*FromString</c> has this shape, so it can be
+/// passed on directly -- which is what lets an enumeration be read by one
+/// generated combinator instead of one per enumeration.
+/// </remarks>
+/// <typeparam name="T">Enumeration to parse the text as</typeparam>
+private delegate T? LiteralParser<T>(string text) where T : struct;"""
+    )
+
+
+def _generate_as_enum_combinator() -> Stripped:
+    """
+    Generate the single combinator to read a content as an enumeration literal.
+
+    The parsing of the literal is passed in as a
+    ``Stringification.*FromString`` method group, so that this is generated
+    once instead of once per enumeration.
+
+    The content is not necessarily a property's -- an enumeration nested as
+    an item of a list or of a tuple is read by this very combinator, wrapped
+    in ``AtElement``.
+    """
     return Stripped(
         f"""\
-if (isEmptyProperty)
+/// <summary>
+/// Read a content and parse it as a literal of <typeparamref name="T" />
+/// with <paramref name="parseLiteral" />.
+/// </summary>
+/// <typeparam name="T">Enumeration to parse the content as</typeparam>
+private static ContentReader<T> AsEnum<T>(
+{I}LiteralParser<T> parseLiteral
+{I}) where T : struct
 {{
-{I}{indent_but_first_line(empty_handling_body, I)}
-}}
-else
-{{
-{I}if (reader.EOF)
-{I}{{
-{II}error = new Reporting.Error(
-{III}"Expected an XML content representing " +
-{III}"the property {prop_name} of an instance of class {cls_name}, " +
-{III}"but reached the end-of-file");
-{II}return null;
-{I}}}
+{I}ContentReader<string> readText = AsText<string>(ReadContentAsString, "");
 
-{I}try
+{I}return (
+{II}Xml.XmlReader reader,
+{II}bool isEmpty,
+{II}out Reporting.Error? error
+{I}) =>
 {I}{{
-{II}{target_var} = {indent_but_first_line(deserialization_expr, I)};
-{I}}}
-{I}catch (System.Exception exception)
-{III}when (exception is System.FormatException
-{IIII}|| exception is System.Xml.XmlException)
-{I}{{
-{II}error = new Reporting.Error(
-{III}"The property {prop_name} of an instance of class {cls_name} " +
-{III}$"could not be de-serialized: {{exception.Message}}");
-{II}error.PrependSegment(
-{III}new Reporting.NameSegment(
-{IIII}{xml_prop_name_literal}));
-{II}return null;
-{I}}}
+{II}string text = readText(reader, isEmpty, out error);
+{II}if (error != null)
+{II}{{
+{III}return default;
+{II}}}
+
+{II}T? result = parseLiteral(text);
+{II}if (result == null)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}$"The content could not be de-serialized as a literal " +
+{IIII}$"of {{typeof(T).Name}}: {{text}}");
+{III}return default;
+{II}}}
+
+{II}return result.Value;
+{I}}};
 }}"""
     )
 
 
-def _generate_deserialize_enumeration_property(
-    prop: intermediate.Property, cls: intermediate.ConcreteClass
-) -> Stripped:
-    """Generate the snippet to deserialize a property ``prop`` as an enum."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
+def _generate_as_list_combinator() -> Stripped:
+    """
+    Generate the combinator to read a content as a list.
 
-    assert isinstance(type_anno, intermediate.OurTypeAnnotation)
+    This only adds the handling of a self-closing element (an empty list) on
+    top of :py:func:`_generate_read_list_helper`, so that a list reads exactly
+    like every other type -- a single call.
 
-    our_type = type_anno.our_type
-    assert isinstance(our_type, intermediate.Enumeration)
-
-    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
-    text_var = csharp_naming.variable_name(Identifier(f"text_{prop.name}"))
-
-    prop_name = csharp_naming.property_name(prop.name)
-    cls_name = csharp_naming.class_name(cls.name)
-    enum_name = csharp_naming.enum_name(our_type.name)
-    xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
-
+    The items are read by an :py:class:`ElementReader`, which is what
+    ``AtElement`` produces, so a list of anything -- a list of lists
+    included -- composes without any further combinator.
+    """
     return Stripped(
         f"""\
-if (isEmptyProperty)
+/// <summary>
+/// Read a content as a list of items, each read with
+/// <paramref name="readItem" />.
+/// </summary>
+/// <remarks>
+/// A self-closing element represents an empty list.
+/// </remarks>
+/// <typeparam name="T">Type of a single list item</typeparam>
+private static ContentReader<List<T>> AsList<T>(
+{I}ElementReader<T> readItem
+{I})
 {{
-{I}error = new Reporting.Error(
-{II}"The property {prop_name} of an instance of class {cls_name} " +
-{II}"can not be de-serialized from a self-closing element " +
-{II}"since it needs content");
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}
+{I}return (
+{II}Xml.XmlReader reader,
+{II}bool isEmpty,
+{II}out Reporting.Error? error
+{I}) =>
+{I}{{
+{II}error = null;
 
-{I}if (reader.EOF)
-{{
-{II}error = new Reporting.Error(
-{III}"Expected an XML content representing " +
-{III}"the property {prop_name} of an instance of class {cls_name}, " +
-{III}"but reached the end-of-file");
-{II}return null;
-}}
+{II}if (isEmpty)
+{II}{{
+{III}return new List<T>();
+{II}}}
 
-string {text_var};
-try
-{{
-{I}{text_var} = reader.ReadContentAsString();
-}}
-catch (System.FormatException exception)
-{{
-{I}error = new Reporting.Error(
-{II}"The property {prop_name} of an instance of class {cls_name} " +
-{II}$"could not be de-serialized as a string: {{exception}}");
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}
-
-{target_var} = Stringification.{enum_name}FromString(
-{I}{text_var});
-
-if ({target_var} == null)
-{{
-{I}error = new Reporting.Error(
-{II}"The property {prop_name} of an instance of class {cls_name} " +
-{II}"could not be de-serialized from an unexpected enumeration literal: " +
-{II}{text_var});
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
+{II}return ReadList<T>(
+{III}reader, readItem, out error);
+{I}}};
 }}"""
     )
 
 
-def _generate_deserialize_interface_property(
-    prop: intermediate.Property,
-    cls: intermediate.ConcreteClass,
-) -> Stripped:
-    """Generate the snippet to deserialize a property ``prop`` as an interface."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
+def _generate_as_element_combinator() -> Stripped:
+    """
+    Generate the combinator to read a content which is a self-describing element.
 
-    assert isinstance(type_anno, intermediate.OurTypeAnnotation)
+    A value typed as an interface or as a named union is dispatched at
+    run-time by its own discriminator element, so reading it is identical in
+    both cases apart from *which* ``...FromElement`` does the dispatching --
+    which is why this takes that function as a parameter instead of being
+    generated once per interface and once per named union.
 
-    our_type = type_anno.our_type
+    The value is not necessarily a property's -- the same combinator reads
+    the items of a list of an interface, one nesting level deeper.
+    """
+    return Stripped(
+        f"""\
+/// <summary>
+/// Read a content whose value is dispatched by its own discriminator
+/// element, such as an interface or a named union.
+/// </summary>
+/// <typeparam name="T">Type of the value</typeparam>
+private static ContentReader<T> AsElement<T>(
+{I}ElementReader<T> readFromElement
+{I})
+{{
+{I}return (
+{II}Xml.XmlReader reader,
+{II}bool isEmpty,
+{II}out Reporting.Error? error
+{I}) =>
+{I}{{
+{II}error = null;
+
+{II}if (isEmpty)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}"Expected an XML element representing the value, " +
+{IIII}"but the element was self-closing");
+{III}return default!;
+{II}}}
+
+{II}// We need to skip the whitespace here in order to be able to look ahead
+{II}// the discriminator element shortly.
+{II}SkipNoneWhitespaceAndComments(reader);
+
+{II}if (reader.EOF)
+{II}{{
+{III}error = new Reporting.Error(
+{IIII}"Expected an XML element representing the value, " +
+{IIII}"but reached the end-of-file");
+{III}return default!;
+{II}}}
+
+{II}// Try to look ahead the discriminator name;
+{II}// we need this name only for the error reporting below.
+{II}// The de-serialization function will perform more sophisticated checks.
+{II}string? discriminatorElementName = null;
+{II}if (reader.NodeType == Xml.XmlNodeType.Element)
+{II}{{
+{III}discriminatorElementName = reader.LocalName;
+{II}}}
+
+{II}T result = readFromElement(reader, out error);
+{II}if (error != null)
+{II}{{
+{III}if (discriminatorElementName != null)
+{III}{{
+{IIII}error.PrependSegment(
+{IIIII}new Reporting.NameSegment(
+{IIIIII}discriminatorElementName));
+{III}}}
+{III}return default!;
+{II}}}
+
+{II}return result;
+{I}}};
+}}"""
+    )
+
+
+# NOTE (mristin):
+# A C# primitive is not a valid part of an identifier as it is spelled
+# (``byte[]``, and the lower-case names read badly), so the primitives are
+# the only types which have to be renamed. They are keyed by the meta-model
+# primitive rather than by the C# spelling, so that the mapping is total by
+# construction.
+_PRIMITIVE_TYPE_TO_MONIKER: Final[Mapping[intermediate.PrimitiveType, str]] = {
+    intermediate.PrimitiveType.BOOL: "Bool",
+    intermediate.PrimitiveType.INT: "Long",
+    intermediate.PrimitiveType.FLOAT: "Double",
+    intermediate.PrimitiveType.STR: "String",
+    intermediate.PrimitiveType.BYTEARRAY: "Bytes",
+}
+assert all(
+    primitive_type in _PRIMITIVE_TYPE_TO_MONIKER
+    for primitive_type in intermediate.PrimitiveType
+)
+
+
+def _type_moniker(type_anno: intermediate.TypeAnnotationUnion) -> str:
+    """
+    Name the type in a way usable as a part of a C# identifier.
+
+    Everything which is not a primitive is named by
+    ``csharp_common.generate_type``, so that the name of a reader can not
+    drift apart from the type of that very reader -- spelling the names out
+    here once caused exactly that.
+    """
+    if isinstance(type_anno, intermediate.ListTypeAnnotation):
+        return f"ListOf{_type_moniker(type_anno.items)}"
+
+    if isinstance(type_anno, intermediate.TupleTypeAnnotation):
+        joined = "".join(_type_moniker(item) for item in type_anno.items)
+        return f"TupleOf{joined}"
+
+    primitive_type = intermediate.try_primitive_type(type_anno)
+    if primitive_type is not None:
+        return _PRIMITIVE_TYPE_TO_MONIKER[primitive_type]
+
+    return csharp_common.generate_type(type_anno)
+
+
+def _from_element_name(our_type: intermediate.OurType) -> str:
+    """
+    Name the function reading a whole element of ``our_type``.
+
+    Mind that this is *not* the moniker of the type: a concrete class
+    without any descendant is referred to by its interface, but reads
+    through a function named after the class itself.
+    """
+    if isinstance(our_type, intermediate.NamedUnion):
+        return f"{csharp_naming.class_name(our_type.name)}FromElement"
+
     assert isinstance(
         our_type, (intermediate.AbstractClass, intermediate.ConcreteClass)
     )
-    assert our_type.interface is not None
 
-    prop_name = csharp_naming.property_name(prop.name)
-    cls_name = csharp_naming.class_name(cls.name)
+    if (
+        isinstance(our_type, intermediate.AbstractClass)
+        or len(our_type.concrete_descendants) > 0
+    ):
+        return f"{csharp_naming.interface_name(our_type.name)}FromElement"
 
-    interface_name = csharp_naming.interface_name(our_type.interface.name)
-
-    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
-    xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
-
-    return Stripped(
-        f"""\
-if (isEmptyProperty)
-{{
-{I}error = new Reporting.Error(
-{II}$"Expected an XML element within the element {{elementName}} representing " +
-{II}"the property {prop_name} of an instance of class {cls_name}, " +
-{II}"but encountered a self-closing element {{elementName}}");
-{I}return null;
-}}
-
-// We need to skip the whitespace here in order to be able to look ahead
-// the discriminator element shortly.
-SkipNoneWhitespaceAndComments(reader);
-
-if (reader.EOF)
-{{
-{I}error = new Reporting.Error(
-{II}$"Expected an XML element within the element {{elementName}} representing " +
-{II}"the property {prop_name} of an instance of class {cls_name}, " +
-{II}"but reached the end-of-file");
-{I}return null;
-}}
-
-// Try to look ahead the discriminator name;
-// we need this name only for the error reporting below.
-// {interface_name}FromElement will perform more sophisticated
-// checks.
-string? discriminatorElementName = null;
-if (reader.NodeType == Xml.XmlNodeType.Element)
-{{
-{I}discriminatorElementName = reader.LocalName;
-}}
-
-{target_var} = {interface_name}FromElement(
-{I}reader, out error);
-
-if (error != null)
-{{
-{I}if (discriminatorElementName != null)
-{I}{{
-{II}error.PrependSegment(
-{III}new Reporting.NameSegment(
-{IIII}discriminatorElementName));
-{I}}}
-
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}"""
-    )
+    return f"{csharp_naming.class_name(our_type.name)}FromElement"
 
 
-def _generate_deserialize_named_union_property(
-    prop: intermediate.Property,
-    cls: intermediate.ConcreteClass,
+def _content_reader_name(type_anno: intermediate.TypeAnnotationUnion) -> Identifier:
+    """Name the field holding the reader of the content of ``type_anno``."""
+    return Identifier(f"Read{_type_moniker(type_anno)}")
+
+
+def _element_reader_expr(
+    type_anno: intermediate.TypeAnnotationUnion, v_name_literal: str
 ) -> Stripped:
-    """Generate the snippet to deserialize a property ``prop`` as a named union."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
+    """
+    Generate the expression reading a single element of ``type_anno``.
 
-    assert isinstance(type_anno, intermediate.OurTypeAnnotation)
-
-    our_type = type_anno.our_type
-    assert isinstance(our_type, intermediate.NamedUnion)
-
-    prop_name = csharp_naming.property_name(prop.name)
-    cls_name = csharp_naming.class_name(cls.name)
-
-    union_name = csharp_naming.class_name(our_type.name)
-
-    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
-    xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
+    This is what a list item and a tuple item are read with. A class, an
+    interface or a named union reads its own, self-describing element,
+    whereas everything else is wrapped in a ``<v>`` element whose content is
+    read by the very same reader as a property of that type.
+    """
+    if isinstance(type_anno, intermediate.OurTypeAnnotation) and isinstance(
+        type_anno.our_type,
+        (
+            intermediate.AbstractClass,
+            intermediate.ConcreteClass,
+            intermediate.NamedUnion,
+        ),
+    ):
+        return Stripped(_from_element_name(type_anno.our_type))
 
     return Stripped(
         f"""\
-if (isEmptyProperty)
-{{
-{I}error = new Reporting.Error(
-{II}$"Expected an XML element within the element {{elementName}} representing " +
-{II}"the property {prop_name} of an instance of class {cls_name}, " +
-{II}"but encountered a self-closing element {{elementName}}");
-{I}return null;
-}}
-
-// We need to skip the whitespace here in order to be able to look ahead
-// the discriminator element shortly.
-SkipNoneWhitespaceAndComments(reader);
-
-if (reader.EOF)
-{{
-{I}error = new Reporting.Error(
-{II}$"Expected an XML element within the element {{elementName}} representing " +
-{II}"the property {prop_name} of an instance of class {cls_name}, " +
-{II}"but reached the end-of-file");
-{I}return null;
-}}
-
-// Try to look ahead the discriminator name;
-// we need this name only for the error reporting below.
-// {union_name}FromElement will perform more sophisticated
-// checks.
-string? discriminatorElementName = null;
-if (reader.NodeType == Xml.XmlNodeType.Element)
-{{
-{I}discriminatorElementName = reader.LocalName;
-}}
-
-{target_var} = {union_name}FromElement(
-{I}reader, out error);
-
-if (error != null)
-{{
-{I}if (discriminatorElementName != null)
-{I}{{
-{II}error.PrependSegment(
-{III}new Reporting.NameSegment(
-{IIII}discriminatorElementName));
-{I}}}
-
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}"""
+AtElement(
+{I}{_content_reader_name(type_anno)}, {v_name_literal})"""
     )
 
 
-def _generate_deserialize_cls_property(prop: intermediate.Property) -> Stripped:
-    """Generate the snippet to deserialize a property ``prop`` as a concrete class."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
+def _content_reader_initializer(
+    type_anno: intermediate.TypeAnnotationUnion,
+) -> Stripped:
+    """Generate the expression initializing the reader of ``type_anno``."""
+    primitive_type = intermediate.try_primitive_type(type_anno)
+    if primitive_type is not None:
+        content_reader, csharp_type, _ = _CONTENT_READER_BY_PRIMITIVE[primitive_type]
+        empty_value = _EMPTY_VALUE_BY_PRIMITIVE.get(primitive_type, None)
+        arguments = content_reader
+        if empty_value is not None:
+            arguments = f"{arguments}, {empty_value}"
+        return Stripped(f"AsText<{csharp_type}>({arguments})")
 
-    assert isinstance(type_anno, intermediate.OurTypeAnnotation)
+    if isinstance(type_anno, intermediate.OurTypeAnnotation):
+        our_type = type_anno.our_type
 
-    our_type = type_anno.our_type
-    assert isinstance(our_type, intermediate.ConcreteClass)
+        if isinstance(our_type, intermediate.Enumeration):
+            enum_name = csharp_naming.enum_name(our_type.name)
+            return Stripped(
+                f"""\
+AsEnum<Aas.{enum_name}>(
+{I}Stringification.{enum_name}FromString)"""
+            )
 
-    target_cls_name = csharp_naming.class_name(our_type.name)
-
-    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
-    xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
-
-    return Stripped(
-        f"""\
-{target_var} = {target_cls_name}FromSequence(
-{I}reader, isEmptyProperty, out error);
-
-if (error != null)
-{{
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}"""
-    )
-
-
-def _generate_deserialize_list_property(prop: intermediate.Property) -> Stripped:
-    """Generate the code to de-serialize a property ``prop`` as a list."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
-
-    assert isinstance(type_anno, intermediate.ListTypeAnnotation), "Pre-condition"
-
-    deserialize_method: Stripped
-    is_v_element: bool
-    is_value_type: bool
-
-    primitive_type = intermediate.try_primitive_type(type_anno.items)
-
-    if primitive_type is not None or (
-        isinstance(type_anno.items, intermediate.OurTypeAnnotation)
-        and isinstance(type_anno.items.our_type, intermediate.Enumeration)
-    ):
-        is_v_element = True
-
-        if primitive_type is not None:
-            if primitive_type is intermediate.PrimitiveType.BOOL:
-                deserialize_method = Stripped("ReadVElementAsBoolean")
-                is_value_type = True
-            elif primitive_type is intermediate.PrimitiveType.INT:
-                deserialize_method = Stripped("ReadVElementAsLong")
-                is_value_type = True
-            elif primitive_type is intermediate.PrimitiveType.FLOAT:
-                deserialize_method = Stripped("ReadVElementAsDouble")
-                is_value_type = True
-            elif primitive_type is intermediate.PrimitiveType.STR:
-                deserialize_method = Stripped("ReadVElementAsString")
-                is_value_type = False
-            elif primitive_type is intermediate.PrimitiveType.BYTEARRAY:
-                deserialize_method = Stripped("ReadVElementAsBytes")
-                is_value_type = False
-            else:
-                assert_never(primitive_type)
-        else:
-            assert isinstance(
-                type_anno.items, intermediate.OurTypeAnnotation
-            ) and isinstance(type_anno.items.our_type, intermediate.Enumeration)
-
-            enum_name = csharp_naming.enum_name(type_anno.items.our_type.name)
-            deserialize_method = Stripped(f"ReadVElementAs{enum_name}")
-            is_value_type = True
-
-    elif isinstance(type_anno.items, intermediate.OurTypeAnnotation) and isinstance(
-        type_anno.items.our_type,
-        (intermediate.AbstractClass, intermediate.ConcreteClass),
-    ):
-        is_v_element = False
-        is_value_type = False
-
-        if (
-            isinstance(type_anno.items.our_type, intermediate.AbstractClass)
-            or len(type_anno.items.our_type.concrete_descendants) > 0
+        if isinstance(our_type, intermediate.NamedUnion) or (
+            isinstance(our_type, intermediate.AbstractClass)
+            or (
+                isinstance(our_type, intermediate.ConcreteClass)
+                and len(our_type.concrete_descendants) > 0
+            )
         ):
-            deserialize_method = Stripped(
-                f"{csharp_naming.interface_name(type_anno.items.our_type.name)}FromElement"
-            )
-        else:
-            deserialize_method = Stripped(
-                f"{csharp_naming.class_name(type_anno.items.our_type.name)}FromElement"
+            return Stripped(
+                f"""\
+AsElement<Aas.{_type_moniker(type_anno)}>(
+{I}{_from_element_name(our_type)})"""
             )
 
-    elif isinstance(type_anno.items, intermediate.OurTypeAnnotation) and isinstance(
-        type_anno.items.our_type, intermediate.NamedUnion
-    ):
         # NOTE (mristin):
-        # A named union is always dispatched by its own discriminator element,
-        # so we treat it the same as a polymorphic class item here -- kept
-        # as its own branch, separate from the class branch above, so that
-        # it can diverge independently, *e.g.* if primitive alternatives are
-        # ever allowed into a named union.
-        is_v_element = False
-        is_value_type = False
+        # A concrete class without any descendant reads its own sequence,
+        # which is already a ``ContentReader``.
+        return Stripped(f"{csharp_naming.class_name(our_type.name)}FromSequence")
 
-        deserialize_method = Stripped(
-            f"{csharp_naming.class_name(type_anno.items.our_type.name)}FromElement"
-        )
-    else:
-        raise NotImplementedError(
-            f"(mristin) We only handle XML de/serialization of lists containing atomic "
-            f"values, but you want to generate the code for a list of type {type_anno}. "
-            f"Please contact the developers if you need this feature."
-        )
-
-    xml_prop_name = prop.xml_name
-    xml_prop_name_literal = csharp_common.string_literal(xml_prop_name)
-
-    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
-
-    item_type = csharp_common.generate_type(type_anno.items)
-
-    parse_list_function = "ParseListOfStruct" if is_value_type else "ParseListOfClass"
-
-    # NOTE (mristin):
-    # A method group such as ``FooFromElement`` already matches the expected
-    # ``(Xml.XmlReader, out Reporting.Error?) -> T?`` signature of the item
-    # deserializer, so we can pass it on directly. A ``<v>`` element, on the
-    # other hand, needs its fixed local name "v" bound in a lambda.
-    item_deserializer = (
-        Stripped(
+    if isinstance(type_anno, intermediate.ListTypeAnnotation):
+        item_type = csharp_common.generate_type(type_anno.items)
+        item_reader = _element_reader_expr(type_anno.items, '"v"')
+        return Stripped(
             f"""\
-(Xml.XmlReader itemReader, out Reporting.Error? itemError) => {deserialize_method}(
-{I}itemReader, "v", out itemError)"""
+AsList<{item_type}>(
+{I}{indent_but_first_line(item_reader, I)})"""
         )
-        if is_v_element
-        else deserialize_method
+
+    assert isinstance(type_anno, intermediate.TupleTypeAnnotation)
+
+    item_types = ", ".join(
+        csharp_common.generate_type(item) for item in type_anno.items
     )
-
-    body_for_non_empty_property = Stripped(
-        f"""\
-{target_var} = {parse_list_function}<{item_type}>(
-{I}reader,
-{I}{indent_but_first_line(item_deserializer, I)},
-{I}out error);
-
-if (error != null)
-{{
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}"""
+    item_readers = ",\n".join(
+        _element_reader_expr(item, csharp_common.string_literal(f"v{i + 1}"))
+        for i, item in enumerate(type_anno.items)
     )
-
     return Stripped(
         f"""\
-{target_var} = new List<{item_type}>();
-
-if (!isEmptyProperty)
-{{
-{I}{indent_but_first_line(body_for_non_empty_property, I)}
-}}"""
+AsTuple{len(type_anno.items)}<{item_types}>(
+{I}{indent_but_first_line(item_readers, I)})"""
     )
 
 
-def _generate_deserialize_tuple_property(prop: intermediate.Property) -> Stripped:
-    """Generate the code to de-serialize a property ``prop`` as a tuple."""
-    type_anno = intermediate.beneath_optional(prop.type_annotation)
+def _generate_from_element_fields(
+    symbol_table: intermediate.SymbolTable,
+) -> List[Stripped]:
+    """
+    Generate the readers of a whole element of every concrete class.
 
-    assert isinstance(type_anno, intermediate.TupleTypeAnnotation), "Pre-condition"
+    Reading a class's element is nothing but binding its XML name to its own
+    ``...FromSequence``, which already is a :py:class:`ContentReader`. There
+    is therefore nothing to generate per class beyond that binding, and it is
+    bound once here instead of at every read.
 
-    prop_name = csharp_naming.property_name(prop.name)
-    xml_prop_name_literal = csharp_common.string_literal(prop.xml_name)
-    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
+    A class whose de-serialization is implementation-specific brings its own
+    function, so it is skipped.
+    """
+    result = []  # type: List[Stripped]
 
-    item_deserializer_exprs = []  # type: List[Stripped]
+    for cls in symbol_table.concrete_classes:
+        if cls.is_implementation_specific:
+            continue
 
-    for i, item_type_anno in enumerate(type_anno.items):
-        primitive_type = intermediate.try_primitive_type(item_type_anno)
+        name = csharp_naming.class_name(cls.name)
+        xml_name_literal = csharp_common.string_literal(naming.xml_class_name(cls.name))
 
-        if primitive_type is not None:
-            v_name_literal = csharp_common.string_literal(f"v{i + 1}")
-
-            method: str
-            if primitive_type is intermediate.PrimitiveType.BOOL:
-                method = "ReadVElementAsBoolean"
-            elif primitive_type is intermediate.PrimitiveType.INT:
-                method = "ReadVElementAsLong"
-            elif primitive_type is intermediate.PrimitiveType.FLOAT:
-                method = "ReadVElementAsDouble"
-            elif primitive_type is intermediate.PrimitiveType.STR:
-                method = "ReadVElementAsString"
-            elif primitive_type is intermediate.PrimitiveType.BYTEARRAY:
-                method = "ReadVElementAsBytes"
-            else:
-                assert_never(primitive_type)
-
-            item_deserializer_exprs.append(
-                Stripped(f"AsTupleItemDeserializer({method}, {v_name_literal})")
+        result.append(
+            Stripped(
+                f"""\
+/// <summary>
+/// Read an instance of class {name} from its XML element.
+/// </summary>
+internal static readonly ElementReader<Aas.{name}> {name}FromElement = (
+{I}AtElement<Aas.{name}>(
+{II}{name}FromSequence, {xml_name_literal}));"""
             )
-        elif isinstance(item_type_anno, intermediate.OurTypeAnnotation) and isinstance(
-            item_type_anno.our_type, intermediate.Enumeration
-        ):
-            enum_name = csharp_naming.enum_name(item_type_anno.our_type.name)
-            v_name_literal = csharp_common.string_literal(f"v{i + 1}")
+        )
 
-            item_deserializer_exprs.append(
-                Stripped(
-                    f"AsTupleItemDeserializer(ReadVElementAs{enum_name}, {v_name_literal})"
-                )
-            )
-        elif isinstance(item_type_anno, intermediate.OurTypeAnnotation) and isinstance(
-            item_type_anno.our_type,
-            (intermediate.AbstractClass, intermediate.ConcreteClass),
-        ):
-            our_type = item_type_anno.our_type
-            if (
-                isinstance(our_type, intermediate.AbstractClass)
-                or len(our_type.concrete_descendants) > 0
-            ):
-                deserialize_method_name = (
-                    f"{csharp_naming.interface_name(our_type.name)}FromElement"
-                )
-            else:
-                deserialize_method_name = (
-                    f"{csharp_naming.class_name(our_type.name)}FromElement"
-                )
+    return result
 
-            item_deserializer_exprs.append(
-                Stripped(f"AsTupleItemDeserializer({deserialize_method_name})")
-            )
 
-        elif isinstance(item_type_anno, intermediate.OurTypeAnnotation) and isinstance(
-            item_type_anno.our_type, intermediate.NamedUnion
-        ):
-            # NOTE (mristin):
-            # A named union is always dispatched by its own discriminator
-            # element, so we treat it the same as a polymorphic class item
-            # here -- kept as its own branch, separate from the class branch
-            # above, so that it can diverge independently, *e.g.* if
-            # primitive alternatives are ever allowed into a named union.
-            deserialize_method_name = (
-                f"{csharp_naming.class_name(item_type_anno.our_type.name)}FromElement"
-            )
+def _generate_content_reader_fields(
+    symbol_table: intermediate.SymbolTable,
+) -> List[Stripped]:
+    """
+    Generate the fields holding one reader per distinct property type.
 
-            item_deserializer_exprs.append(
-                Stripped(f"AsTupleItemDeserializer({deserialize_method_name})")
-            )
+    The readers are composed once, at the initialization of the class,
+    instead of at every property of every instance -- composing them at
+    the call site would allocate a delegate on every single read.
+    """
+    initializer_by_name = (
+        collections.OrderedDict()
+    )  # type: MutableMapping[Identifier, Tuple[Stripped, Stripped]]
 
+    def register(type_anno: intermediate.TypeAnnotationUnion) -> None:
+        """Register the reader of ``type_anno``, its items' readers first."""
+        # NOTE (mristin):
+        # A field initializer reads the fields it composes, so a reader has
+        # to be declared after the readers it is composed of.
+        if isinstance(type_anno, intermediate.ListTypeAnnotation):
+            item_type_annotations = [
+                type_anno.items
+            ]  # type: List[intermediate.TypeAnnotationUnion]
+        elif isinstance(type_anno, intermediate.TupleTypeAnnotation):
+            item_type_annotations = list(type_anno.items)
         else:
+            item_type_annotations = []
+
+        for item_type_anno in item_type_annotations:
             # NOTE (mristin):
-            # A tuple item can only be a primitive value, a constrained primitive,
-            # an enumeration literal, a class instance or a named union; see
-            # intermediate._translate._verify_only_simple_type_patterns.
-            raise AssertionError(
-                f"Unexpected tuple item type {item_type_anno} at index {i} "
-                f"for the property {prop.name!r}"
+            # A class reads its own element, so it needs no reader of its own.
+            if isinstance(
+                item_type_anno, intermediate.OurTypeAnnotation
+            ) and isinstance(
+                item_type_anno.our_type,
+                (
+                    intermediate.AbstractClass,
+                    intermediate.ConcreteClass,
+                    intermediate.NamedUnion,
+                ),
+            ):
+                continue
+
+            register(item_type_anno)
+
+        name = _content_reader_name(type_anno)
+        if name in initializer_by_name:
+            return
+
+        initializer_by_name[name] = (
+            csharp_common.generate_type(type_anno),
+            _content_reader_initializer(type_anno),
+        )
+
+    for cls in symbol_table.concrete_classes:
+        for prop in cls.properties:
+            register(intermediate.beneath_optional(prop.type_annotation))
+
+    result = []  # type: List[Stripped]
+    for name, (csharp_type, initializer) in initializer_by_name.items():
+        result.append(
+            Stripped(
+                f"""\
+private static readonly ContentReader<{csharp_type}> {name} = (
+{I}{indent_but_first_line(initializer, I)});"""
             )
+        )
 
-    item_deserializer_exprs_joined = ",\n".join(item_deserializer_exprs)
-
-    arity = len(type_anno.items)
-
-    return Stripped(
-        f"""\
-if (isEmptyProperty)
-{{
-{I}error = new Reporting.Error(
-{II}"The property {prop_name} can not be de-serialized " +
-{II}"from a self-closing element since it needs content");
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}
-
-SkipNoneWhitespaceAndComments(reader);
-
-{target_var} = ParseTuple{arity}(
-{I}reader,
-{I}{indent_but_first_line(item_deserializer_exprs_joined, I)},
-{I}out error);
-if (error != null)
-{{
-{I}error.PrependSegment(
-{II}new Reporting.NameSegment(
-{III}{xml_prop_name_literal}));
-{I}return null;
-}}"""
-    )
+    return result
 
 
 @require(lambda prop, cls: id(prop) in cls.property_id_set)
 def _generate_deserialize_property(
     prop: intermediate.Property, cls: intermediate.ConcreteClass
 ) -> Tuple[Optional[Stripped], Optional[Error]]:
-    """Generate the snippet to deserialize the property ``prop`` from the content."""
-    blocks = []  # type: List[Stripped]
+    """
+    Generate the snippet to deserialize the property ``prop``.
 
+    Every property kind reads through the very same call -- only the reader
+    differs, and it has been composed once into a field (see
+    :py:func:`_generate_property_reader_fields`). The failure is not handled
+    here: the error is marked with the property's own element name once,
+    right after the ``switch``, see
+    :py:func:`_generate_deserialize_impl_cls_from_sequence`.
+    """
     type_anno = intermediate.beneath_optional(prop.type_annotation)
 
-    if isinstance(type_anno, intermediate.PrimitiveTypeAnnotation):
-        blocks.append(_generate_deserialize_primitive_property(prop=prop, cls=cls))
-    elif isinstance(type_anno, intermediate.OurTypeAnnotation):
-        our_type = type_anno.our_type
-        if isinstance(our_type, intermediate.Enumeration):
-            blocks.append(
-                _generate_deserialize_enumeration_property(prop=prop, cls=cls)
-            )
-        elif isinstance(our_type, intermediate.ConstrainedPrimitive):
-            # NOTE (mristin, 2022-04-13):
-            # The constrained primitives are only verified, but not represented as
-            # separate classes in the XSD.
-            blocks.append(_generate_deserialize_primitive_property(prop=prop, cls=cls))
-        elif isinstance(
-            our_type, (intermediate.ConcreteClass, intermediate.AbstractClass)
-        ):
-            if (
-                isinstance(our_type, intermediate.AbstractClass)
-                or len(our_type.concrete_descendants) > 0
-            ):
-                blocks.append(
-                    _generate_deserialize_interface_property(prop=prop, cls=cls)
-                )
-            else:
-                blocks.append(_generate_deserialize_cls_property(prop=prop))
+    if isinstance(type_anno, intermediate.ListTypeAnnotation) and not isinstance(
+        type_anno.items, intermediate.AtomicTypeAnnotationAsTuple
+    ):
+        return None, Error(
+            prop.parsed.node,
+            f"(mristin) We only handle the XML de-serialization of lists of "
+            f"atomic values, but you want to generate the code for a list of "
+            f"type {type_anno}. Please contact the developers if you need "
+            f"this feature.",
+        )
 
-        elif isinstance(our_type, intermediate.NamedUnion):
-            blocks.append(
-                _generate_deserialize_named_union_property(prop=prop, cls=cls)
-            )
+    target_var = csharp_naming.variable_name(Identifier(f"the_{prop.name}"))
+    reader_name = _content_reader_name(type_anno)
 
-        else:
-            assert_never(our_type)
-
-    elif isinstance(type_anno, intermediate.ListTypeAnnotation):
-        blocks.append(_generate_deserialize_list_property(prop=prop))
-
-    elif isinstance(type_anno, intermediate.TupleTypeAnnotation):
-        blocks.append(_generate_deserialize_tuple_property(prop=prop))
-
-    else:
-        assert_never(type_anno)
-
-    return Stripped("\n\n".join(blocks)), None
+    return (
+        Stripped(
+            f"""\
+{target_var} = {reader_name}(
+{I}reader, isEmptyProperty, out error);"""
+        ),
+        None,
+    )
 
 
+@ensure(lambda result: (result[0] is not None) ^ (result[1] is not None))
 def _generate_deserialize_impl_cls_from_sequence(
     cls: intermediate.ConcreteClass,
 ) -> Tuple[Optional[Stripped], Optional[List[Error]]]:
@@ -1542,7 +1404,7 @@ internal static Aas.{name} {name}FromSequence(
 {{
 {I}error = null;
 {I}return new Aas.{name}();
-}}  // internal static Aas.{name}? {name}FromSequence"""
+}}  // internal static Aas.{name} {name}FromSequence"""
             ),
             None,
         )
@@ -1583,7 +1445,7 @@ if (reader.EOF)
 {II}"Expected an XML element representing " +
 {II}"a property of an instance of class {name}, " +
 {II}"but reached the end-of-file");
-{I}return null;
+{I}return default!;
 }}"""
         )
     )
@@ -1599,14 +1461,16 @@ if (reader.EOF)
 
         xml_prop_name = prop.xml_name
         xml_prop_name_literal = csharp_common.string_literal(xml_prop_name)
+
+        # NOTE (mristin):
+        # No braces are necessary, as no case declares a local of its own --
+        # every one of them is a single assignment.
         case_blocks.append(
             Stripped(
                 f"""\
 case {xml_prop_name_literal}:
-{{
 {I}{indent_but_first_line(case_body, I)}
-{I}break;
-}}"""
+{I}break;"""
             )
         )
 
@@ -1621,7 +1485,7 @@ default:
 {II}"We expected properties of the class {name}, " +
 {II}"but got an unexpected element " +
 {II}$"with the name {{elementName}}");
-{I}return null;"""
+{I}return default!;"""
         )
     )
 
@@ -1630,84 +1494,43 @@ default:
     blocks_for_non_empty.append(
         Stripped(
             f"""\
-while (true)
+while (TryNextProperty(
+{II}reader,
+{II}out string elementName,
+{II}out bool isEmptyProperty,
+{II}out error))
 {{
-{I}SkipNoneWhitespaceAndComments(reader);
-
-{I}if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-{I}{{
-{II}break;
-{I}}}
-
-{I}if (reader.NodeType != Xml.XmlNodeType.Element)
-{I}{{
-{II}error = new Reporting.Error(
-{III}"Expected an XML start element representing " +
-{III}"a property of an instance of class {name}, " +
-{III}$"but got the node of type {{reader.NodeType}} " +
-{III}$"with the value {{reader.Value}}");
-{II}return null;
-{I}}}
-
-{I}string elementName = TryElementName(
-{II}reader, out error);
-{I}if (error != null)
-{I}{{
-{II}return null;
-{I}}}
-
-{I}bool isEmptyProperty = reader.IsEmptyElement;
-
-{I}// Skip the expected element
-{I}reader.Read();
-
 {I}switch (elementName)
 {I}{{
 {II}{indent_but_first_line(switch_body, II)}
 {I}}}
 
-{I}SkipNoneWhitespaceAndComments(reader);
-
-{I}if (!isEmptyProperty)
+{I}// NOTE (mristin):
+{I}// Every property is read in this very loop, so we mark the error with
+{I}// the property's own element name here, once, instead of at every
+{I}// single case above. For a matched case, elementName *is* that name.
+{I}if (error != null)
 {I}{{
-{II}// Read the end element
-
-{II}if (reader.EOF)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}"Expected an XML end element to conclude a property of class {name} " +
-{IIII}$"with the element name {{elementName}}, " +
-{IIII}"but got the end-of-file.");
-{III}return null;
-{II}}}
-{II}if (reader.NodeType != Xml.XmlNodeType.EndElement)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}"Expected an XML end element to conclude a property of class {name} " +
-{IIII}$"with the element name {{elementName}}, " +
-{IIII}$"but got the node of type {{reader.NodeType}} " +
-{IIII}$"with the value {{reader.Value}}");
-{III}return null;
-{II}}}
-
-{II}string endElementName = TryElementName(
-{III}reader, out error);
-{II}if (error != null)
-{II}{{
-{III}return null;
-{II}}}
-
-{II}if (endElementName != elementName)
-{II}{{
-{III}error = new Reporting.Error(
-{IIII}"Expected an XML end element to conclude a property of class {name} " +
-{IIII}$"with the element name {{elementName}}, " +
-{IIII}$"but got the end element with the name {{reader.Name}}");
-{III}return null;
-{II}}}
-{II}// Skip the expected end element
-{II}reader.Read();
+{II}error.PrependSegment(
+{III}new Reporting.NameSegment(
+{IIII}elementName));
+{II}return default!;
 {I}}}
+
+{I}ConsumeEndElement(
+{II}reader, elementName, isEmptyProperty, out error);
+{I}if (error != null)
+{I}{{
+{II}return default!;
+{I}}}
+}}
+
+// NOTE (mristin):
+// The loop also ends when the next property could not be read at all,
+// which is the only way out of it that is a failure.
+if (error != null)
+{{
+{I}return default!;
 }}"""
         )
     )
@@ -1738,7 +1561,7 @@ if ({target_var} == null)
 {I}error = new Reporting.Error(
 {II}"The required property {prop_csharp} has not been given " +
 {II}"in the XML representation of an instance of class {name}");
-{I}return null;
+{I}return default!;
 }}"""
                 )
             )
@@ -1827,7 +1650,7 @@ if ({target_var} == null)
     writer.write(
         f"""\
 {description}
-internal static Aas.{name}? {name}FromSequence(
+internal static Aas.{name} {name}FromSequence(
 {I}Xml.XmlReader reader,
 {I}bool isEmptySequence,
 {I}out Reporting.Error? error)
@@ -1845,193 +1668,49 @@ internal static Aas.{name}? {name}FromSequence(
     return Stripped(writer.getvalue()), None
 
 
-def _generate_read_start_element_of_class() -> Stripped:
-    """Generate the shared helper to read the opening tag of a class instance."""
+def _generate_peek_element_name() -> Stripped:
+    """
+    Generate the shared helper looking ahead the name of the current element.
+
+    Nothing is consumed, so the caller can still decide what to do with
+    the element: ``AtElement`` checks the name against the one it expects,
+    while a de-serialization dispatching on a discriminator element uses
+    the name to pick the reader.
+    """
     return Stripped(
         f"""\
 /// <summary>
-/// Read the opening tag of an XML element representing an instance of
-/// <paramref name="className" />, without consuming its content.
+/// Look ahead the name of the element at the current position of
+/// <paramref name="reader" />, without consuming anything.
 /// </summary>
-/// <remarks>
-/// This is shared by the de-serialization of every concrete class from
-/// an XML element.
-/// </remarks>
-private static string ReadStartElementOfClass(
+private static string PeekElementName(
 {I}Xml.XmlReader reader,
-{I}string className,
-{I}out bool isEmptyElement,
 {I}out Reporting.Error? error
 {I})
 {{
 {I}error = null;
-{I}isEmptyElement = false;
 
 {I}SkipNoneWhitespaceAndComments(reader);
 
 {I}if (reader.EOF)
 {I}{{
 {II}error = new Reporting.Error(
-{III}$"Expected an XML element representing an instance of class {{className}}, " +
-{III}"but reached the end-of-file");
+{III}"Expected an XML element, but reached the end-of-file");
 {II}return "";
 {I}}}
 
 {I}if (reader.NodeType != Xml.XmlNodeType.Element)
 {I}{{
 {II}error = new Reporting.Error(
-{III}$"Expected an XML element representing an instance of class {{className}}, " +
+{III}"Expected an XML element, " +
 {III}$"but got a node of type {{reader.NodeType}} " +
 {III}$"with value {{reader.Value}}");
 {II}return "";
 {I}}}
 
-{I}string elementName = TryElementName(
+{I}return TryElementName(
 {II}reader, out error);
-{I}if (error != null)
-{I}{{
-{II}return "";
-{I}}}
-
-{I}isEmptyElement = reader.IsEmptyElement;
-{I}return elementName;
 }}"""
-    )
-
-
-def _generate_consume_close_tag() -> Stripped:
-    """Generate the shared helper to consume the closing tag of an XML element."""
-    return Stripped(
-        f"""\
-/// <summary>
-/// Consume the closing tag matching <paramref name="expectedElementName" />,
-/// unless <paramref name="isEmptyElement" /> indicates that the element was
-/// self-closing and thus has no separate closing tag to consume.
-/// </summary>
-/// <remarks>
-/// This is shared by the de-serialization of every concrete class from
-/// an XML element.
-/// </remarks>
-private static void ConsumeCloseTag(
-{I}Xml.XmlReader reader,
-{I}string expectedElementName,
-{I}bool isEmptyElement,
-{I}out Reporting.Error? error
-{I})
-{{
-{I}error = null;
-
-{I}if (isEmptyElement)
-{I}{{
-{II}return;
-{I}}}
-
-{I}SkipNoneWhitespaceAndComments(reader);
-
-{I}if (reader.EOF)
-{I}{{
-{II}error = new Reporting.Error(
-{III}$"Expected a closing element </{{expectedElementName}}>, " +
-{III}"but reached the end-of-file");
-{II}return;
-{I}}}
-
-{I}if (reader.NodeType != Xml.XmlNodeType.EndElement)
-{I}{{
-{II}error = new Reporting.Error(
-{III}$"Expected a closing element </{{expectedElementName}}>, " +
-{III}$"but got a node of type {{reader.NodeType}} " +
-{III}$"with value {{reader.Value}}");
-{II}return;
-{I}}}
-
-{I}string endElementName = TryElementName(
-{II}reader, out error);
-{I}if (error != null)
-{I}{{
-{II}return;
-{I}}}
-
-{I}if (endElementName != expectedElementName)
-{I}{{
-{II}error = new Reporting.Error(
-{III}$"Expected a closing element </{{expectedElementName}}>, " +
-{III}$"but got a closing element </{{endElementName}}>");
-{II}return;
-{I}}}
-
-{I}// Skip the end element
-{I}reader.Read();
-}}"""
-    )
-
-
-def _generate_deserialize_impl_concrete_cls_from_element(
-    cls: intermediate.ConcreteClass,
-) -> Stripped:
-    """Generate the function to de-serialize a concrete ``cls`` from an XML element."""
-    name = csharp_naming.class_name(cls.name)
-    xml_name = naming.xml_class_name(cls.name)
-    xml_name_literal = csharp_common.string_literal(xml_name)
-
-    # NOTE (mristin, 2022-06-21):
-    # We need to propagate nullability. Otherwise, InspectCode complains.
-    result_nullability = "?" if len(cls.constructor.arguments) > 0 else ""
-
-    body = Stripped(
-        f"""\
-error = null;
-
-string elementName = ReadStartElementOfClass(
-{I}reader, {csharp_common.string_literal(name)}, out bool isEmptyElement, out error);
-if (error != null)
-{{
-{I}return null;
-}}
-
-if (elementName != {xml_name_literal})
-{{
-{I}error = new Reporting.Error(
-{II}"Expected an element representing an instance of class {name} " +
-{II}$"with element name {xml_name}, but got: {{elementName}}");
-{I}return null;
-}}
-
-// Skip the element node and go to the content
-reader.Read();
-
-Aas.{name}{result_nullability} result = (
-{I}{name}FromSequence(
-{II}reader, isEmptyElement, out error));
-if (error != null)
-{{
-{I}return null;
-}}
-
-ConsumeCloseTag(
-{I}reader,
-{I}elementName,
-{I}isEmptyElement,
-{I}out error);
-if (error != null)
-{{
-{I}return null;
-}}
-
-return result;"""
-    )
-
-    return Stripped(
-        f"""\
-/// <summary>
-/// Deserialize an instance of class {name} from an XML element.
-/// </summary>
-internal static Aas.{name}? {name}FromElement(
-{I}Xml.XmlReader reader,
-{I}out Reporting.Error? error)
-{{
-{I}{indent_but_first_line(body, I)}
-}}  // internal static Aas.{name}? {name}FromElement"""
     )
 
 
@@ -2041,30 +1720,7 @@ def _generate_deserialize_impl_interface_from_element(
     """Generate the function to de-serialize an ``interface`` from an XML element."""
     name = csharp_naming.interface_name(interface.name)
 
-    blocks = [
-        Stripped(
-            f"""\
-error = null;
-
-SkipNoneWhitespaceAndComments(reader);
-
-if (reader.EOF)
-{{
-{I}error = new Reporting.Error(
-{II}"Expected an XML element, but reached end-of-file");
-{I}return null;
-}}
-
-if (reader.NodeType != Xml.XmlNodeType.Element)
-{{
-{I}error = new Reporting.Error(
-{II}"Expected an XML element, " +
-{II}$"but got a node of type {{reader.NodeType}} " +
-{II}$"with value {{reader.Value}}");
-{I}return null;
-}}"""
-        )
-    ]  # type: List[Stripped]
+    blocks = []  # type: List[Stripped]
 
     case_stmts = []  # type: List[Stripped]
     for implementer in interface.implementers:
@@ -2089,18 +1745,18 @@ case {implementer_xml_name_literal}:
 default:
 {I}error = new Reporting.Error(
 {II}$"Unexpected element with the name {{elementName}}");
-{I}return null;"""
+{I}return default!;"""
         )
     )
 
     switch_writer = io.StringIO()
     switch_writer.write(
         f"""\
-string elementName = TryElementName(
+string elementName = PeekElementName(
 {I}reader, out error);
 if (error != null)
 {{
-{I}return null;
+{I}return default!;
 }}
 
 switch (elementName)
@@ -2123,7 +1779,7 @@ switch (elementName)
 /// Deserialize an instance of {name} from an XML element.
 /// </summary>
 [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-internal static Aas.{name}? {name}FromElement(
+internal static Aas.{name} {name}FromElement(
 {I}Xml.XmlReader reader,
 {I}out Reporting.Error? error)
 {{
@@ -2146,30 +1802,7 @@ def _generate_deserialize_impl_named_union_from_element(
     """Generate the function to de-serialize a ``named_union`` from an XML element."""
     name = csharp_naming.class_name(named_union.name)
 
-    blocks = [
-        Stripped(
-            f"""\
-error = null;
-
-SkipNoneWhitespaceAndComments(reader);
-
-if (reader.EOF)
-{{
-{I}error = new Reporting.Error(
-{II}"Expected an XML element, but reached end-of-file");
-{I}return null;
-}}
-
-if (reader.NodeType != Xml.XmlNodeType.Element)
-{{
-{I}error = new Reporting.Error(
-{II}"Expected an XML element, " +
-{II}$"but got a node of type {{reader.NodeType}} " +
-{II}$"with value {{reader.Value}}");
-{I}return null;
-}}"""
-        )
-    ]  # type: List[Stripped]
+    blocks = []  # type: List[Stripped]
 
     case_stmts = []  # type: List[Stripped]
     for implementer in named_union.implementers:
@@ -2187,16 +1820,11 @@ if (reader.NodeType != Xml.XmlNodeType.Element)
                 f"""\
 case {implementer_xml_name_literal}:
 {{
-{I}Aas.{implementer_name}? instance = {implementer_name}FromElement(
+{I}Aas.{implementer_name} instance = {implementer_name}FromElement(
 {II}reader, out error);
 {I}if (error != null)
 {I}{{
-{II}return null;
-{I}}}
-{I}if (instance == null)
-{I}{{
-{II}throw new System.InvalidOperationException(
-{III}"Unexpected instance null when error null");
+{II}return default!;
 {I}}}
 {I}return Aas.{name}.{from_method_name}(instance);
 }}"""
@@ -2209,18 +1837,18 @@ case {implementer_xml_name_literal}:
 default:
 {I}error = new Reporting.Error(
 {II}$"Unexpected element with the name {{elementName}}");
-{I}return null;"""
+{I}return default!;"""
         )
     )
 
     switch_writer = io.StringIO()
     switch_writer.write(
         f"""\
-string elementName = TryElementName(
+string elementName = PeekElementName(
 {I}reader, out error);
 if (error != null)
 {{
-{I}return null;
+{I}return default!;
 }}
 
 switch (elementName)
@@ -2242,7 +1870,7 @@ switch (elementName)
 /// <summary>
 /// Deserialize an instance of {name} from an XML element.
 /// </summary>
-internal static Aas.{name}? {name}FromElement(
+internal static Aas.{name} {name}FromElement(
 {I}Xml.XmlReader reader,
 {I}out Reporting.Error? error)
 {{
@@ -2268,23 +1896,58 @@ def _generate_deserialize_impl(
         _generate_skip_whitespace_and_comments(),
         _generate_read_whole_content_as_base_64(),
         _generate_extract_element_name(),
-        _generate_read_v_element(),
-        _generate_read_v_end_element(),
-        *_generate_read_v_element_as_primitive_functions(),
-        _generate_parse_list_of_class_helpers(),
-        _generate_parse_list_of_struct_helpers(),
-        _generate_read_start_element_of_class(),
-        _generate_consume_close_tag(),
+        _generate_peek_element_name(),
+        _generate_element_reader_delegates(),
     ]  # type: List[Stripped]
+
+    needed_readers = _needed_content_readers(symbol_table)
+    from_element_fields = _generate_from_element_fields(symbol_table)
+
+    blocks.extend(_generate_as_text_combinators(needed=needed_readers))
+    blocks.extend(
+        _generate_content_converters(primitive_types=needed_readers.primitive_types)
+    )
+
+    # NOTE (mristin):
+    # A class reads its own element through ``AtElement`` as well, so this is
+    # needed as soon as there is anything at all to read.
+    if needed_readers.v_elements or len(from_element_fields) > 0:
+        blocks.append(_generate_consume_end_element())
+        blocks.append(_generate_at_element_combinator())
+
+    if any(
+        len(cls.constructor.arguments) > 0
+        for cls in symbol_table.concrete_classes
+        if not cls.is_implementation_specific
+    ):
+        blocks.append(_generate_try_next_property())
+
+    if needed_readers.enumerations:
+        blocks.append(_generate_literal_parser_delegate())
+        blocks.append(_generate_as_enum_combinator())
+
+    if needed_readers.lists:
+        blocks.append(_generate_read_list_helper())
+        blocks.append(_generate_as_list_combinator())
+
+    if needed_readers.polymorphic:
+        blocks.append(_generate_as_element_combinator())
 
     tuple_arities = intermediate.tuple_arities(symbol_table)
     if len(tuple_arities) > 0:
-        blocks.append(_generate_tuple_item_reader_delegate())
         for arity in tuple_arities:
-            blocks.append(_generate_parse_tuple_helper(arity))
+            blocks.append(_generate_as_tuple_combinator(arity))
 
-    for enumeration in symbol_table.enumerations:
-        blocks.append(_generate_read_v_element_as_enumeration(enumeration))
+    # NOTE (mristin):
+    # The readers are composed once, here, rather than at every property of
+    # every instance -- composing them at the call site would allocate
+    # a delegate on every single read.
+    #
+    # A field initializer reads the fields it composes, and a reader of
+    # a list or of a tuple of a class composes that class's reader, so
+    # the classes have to come first.
+    blocks.extend(from_element_fields)
+    blocks.extend(_generate_content_reader_fields(symbol_table))
 
     errors = []  # type: List[Error]
 
@@ -2346,11 +2009,6 @@ def _generate_deserialize_impl(
                     _generate_deserialize_impl_interface_from_element(
                         interface=cls.interface
                     )
-                )
-
-            if isinstance(cls, intermediate.ConcreteClass):
-                blocks.append(
-                    _generate_deserialize_impl_concrete_cls_from_element(cls=cls)
                 )
 
     for named_union in symbol_table.named_unions:
@@ -2434,19 +2092,16 @@ public static Aas.{name} {name}From(
 {III}"to be set at content with MoveToContent");
 {I}}}
 
-{I}Aas.{name}? result = (
-{II}DeserializeImplementation.{name}FromElement(
-{III}reader,
-{III}out Reporting.Error? error));
+{I}Aas.{name} result = DeserializeImplementation.{name}FromElement(
+{II}reader,
+{II}out Reporting.Error? error);
 {I}if (error != null)
 {I}{{
 {II}throw new Xmlization.Exception(
 {III}Reporting.GenerateRelativeXPath(error.PathSegments),
 {III}error.Cause);
 {I}}}
-{I}return result
-{II}?? throw new System.InvalidOperationException(
-{III}"Unexpected output null when error is null");
+{I}return result;
 }}"""
     )
 
@@ -2583,7 +2238,7 @@ def _generate_write_v_element_as_primitive_functions() -> List[Stripped]:
     """
     Generate the functions to write a primitive value as a named element.
 
-    These mirror :py:func:`_generate_read_v_element_as_primitive_functions`
+    These mirror the read-side content readers
     on the write side: a tuple item, unlike a list item, is wrapped in a
     positional element name (<c>v1</c>, <c>v2</c>, *etc.*) instead of always
     the fixed <c>v</c>, so we generate one write function per primitive type,
@@ -2669,9 +2324,7 @@ def _generate_tuple_item_serializer_helpers() -> Stripped:
 /// first needs to be wrapped in its own positional <c>v1</c>, <c>v2</c>,
 /// *etc.* element -- this adapter closes over the element name so that
 /// a tuple-typed property does not need to spell out that wrapping (start
-/// element/write value/end element) at every item, mirroring how
-/// <see cref="AsTupleItemDeserializer{{T}}(NamedClassItemDeserializer{{T}}, string)" />
-/// avoids the equivalent on the read side.
+/// element/write value/end element) at every item.
 /// </remarks>
 /// <typeparam name="T">Type of the item to be written</typeparam>
 private delegate void NamedElementSerializer<T>(

--- a/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/aas_core_meta.v3/expected_output/AasCore.Aas3_0/xmlization.cs
@@ -102,531 +102,203 @@ namespace AasCore.Aas3_0
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to bool.
+            /// </summary>
+            private static bool ReadContentAsBoolean(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsBoolean();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to byte[].
+            /// </summary>
+            private static byte[] ReadContentAsBytes(Xml.XmlReader reader)
+            {
+                return ReadWholeContentAsBase64(
+                    reader);
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +315,7 @@ namespace AasCore.Aas3_0
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +323,7 @@ namespace AasCore.Aas3_0
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,447 +336,735 @@ namespace AasCore.Aas3_0
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
 
             /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.ModellingKind"/>.
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
             /// </summary>
-            private static Aas.ModellingKind? ReadVElementAsModellingKind(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
                 )
             {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
                 {
-                    return null;
-                }
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
 
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
 
-                Aas.ModellingKind? result = Stringification.ModellingKindFromString(
-                    text);
+                    bool isEmptyElement = reader.IsEmptyElement;
 
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of ModellingKind: {result}");
-                    return null;
-                }
+                    // Consume the start tag and go to the content.
+                    reader.Read();
 
-                return result;
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
             }
 
             /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.QualifierKind"/>.
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
             /// </summary>
-            private static Aas.QualifierKind? ReadVElementAsQualifierKind(
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
                 Xml.XmlReader reader,
-                string elementName,
+                out string elementName,
+                out bool isEmptyProperty,
                 out Reporting.Error? error
                 )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.QualifierKind? result = Stringification.QualifierKindFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of QualifierKind: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.AssetKind"/>.
-            /// </summary>
-            private static Aas.AssetKind? ReadVElementAsAssetKind(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.AssetKind? result = Stringification.AssetKindFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of AssetKind: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.AasSubmodelElements"/>.
-            /// </summary>
-            private static Aas.AasSubmodelElements? ReadVElementAsAasSubmodelElements(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.AasSubmodelElements? result = Stringification.AasSubmodelElementsFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of AasSubmodelElements: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.EntityType"/>.
-            /// </summary>
-            private static Aas.EntityType? ReadVElementAsEntityType(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.EntityType? result = Stringification.EntityTypeFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of EntityType: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.Direction"/>.
-            /// </summary>
-            private static Aas.Direction? ReadVElementAsDirection(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.Direction? result = Stringification.DirectionFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of Direction: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.StateOfEvent"/>.
-            /// </summary>
-            private static Aas.StateOfEvent? ReadVElementAsStateOfEvent(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.StateOfEvent? result = Stringification.StateOfEventFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of StateOfEvent: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.ReferenceTypes"/>.
-            /// </summary>
-            private static Aas.ReferenceTypes? ReadVElementAsReferenceTypes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.ReferenceTypes? result = Stringification.ReferenceTypesFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of ReferenceTypes: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.KeyTypes"/>.
-            /// </summary>
-            private static Aas.KeyTypes? ReadVElementAsKeyTypes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.KeyTypes? result = Stringification.KeyTypesFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of KeyTypes: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.DataTypeDefXsd"/>.
-            /// </summary>
-            private static Aas.DataTypeDefXsd? ReadVElementAsDataTypeDefXsd(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.DataTypeDefXsd? result = Stringification.DataTypeDefXsdFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of DataTypeDefXsd: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.DataTypeIec61360"/>.
-            /// </summary>
-            private static Aas.DataTypeIec61360? ReadVElementAsDataTypeIec61360(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.DataTypeIec61360? result = Stringification.DataTypeIec61360FromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of DataTypeIec61360: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Deserialize an instance of IHasSemantics from an XML element.
-            /// </summary>
-            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IHasSemantics? IHasSemanticsFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
             {
                 error = null;
+                elementName = "";
+                isEmptyProperty = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
-                if (reader.EOF)
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
                 {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
+                    return false;
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
                 }
 
-                string elementName = TryElementName(
+                elementName = TryElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Parse the text of a literal of <typeparamref name="T" />.
+            /// </summary>
+            /// <remarks>
+            /// Every <c>Stringification.*FromString</c> has this shape, so it can be
+            /// passed on directly -- which is what lets an enumeration be read by one
+            /// generated combinator instead of one per enumeration.
+            /// </remarks>
+            /// <typeparam name="T">Enumeration to parse the text as</typeparam>
+            private delegate T? LiteralParser<T>(string text) where T : struct;
+
+            /// <summary>
+            /// Read a content and parse it as a literal of <typeparamref name="T" />
+            /// with <paramref name="parseLiteral" />.
+            /// </summary>
+            /// <typeparam name="T">Enumeration to parse the content as</typeparam>
+            private static ContentReader<T> AsEnum<T>(
+                LiteralParser<T> parseLiteral
+                ) where T : struct
+            {
+                ContentReader<string> readText = AsText<string>(ReadContentAsString, "");
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string text = readText(reader, isEmpty, out error);
+                    if (error != null)
+                    {
+                        return default;
+                    }
+
+                    T? result = parseLiteral(text);
+                    if (result == null)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as a literal " +
+                            $"of {typeof(T).Name}: {text}");
+                        return default;
+                    }
+
+                    return result.Value;
+                };
+            }
+
+            /// <summary>
+            /// Read a sequence of list items with <paramref name="readItem" />,
+            /// stopping (without consuming) at the first non-element node.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a list type, whatever its items are and
+            /// however deeply it is nested, since the items are read through
+            /// an <see cref="ElementReader{T}" /> like any other element.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static List<T> ReadList<T>(
+                Xml.XmlReader reader,
+                ElementReader<T> readItem,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                var result = new List<T>();
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                int index = 0;
+                while (reader.NodeType == Xml.XmlNodeType.Element)
+                {
+                    T item = readItem(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(item);
+
+                    index++;
+                    SkipNoneWhitespaceAndComments(reader);
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a content as a list of items, each read with
+            /// <paramref name="readItem" />.
+            /// </summary>
+            /// <remarks>
+            /// A self-closing element represents an empty list.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static ContentReader<List<T>> AsList<T>(
+                ElementReader<T> readItem
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        return new List<T>();
+                    }
+
+                    return ReadList<T>(
+                        reader, readItem, out error);
+                };
+            }
+
+            /// <summary>
+            /// Read a content whose value is dispatched by its own discriminator
+            /// element, such as an interface or a named union.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsElement<T>(
+                ElementReader<T> readFromElement
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing the value, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    // We need to skip the whitespace here in order to be able to look ahead
+                    // the discriminator element shortly.
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing the value, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    // Try to look ahead the discriminator name;
+                    // we need this name only for the error reporting below.
+                    // The de-serialization function will perform more sophisticated checks.
+                    string? discriminatorElementName = null;
+                    if (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        discriminatorElementName = reader.LocalName;
+                    }
+
+                    T result = readFromElement(reader, out error);
+                    if (error != null)
+                    {
+                        if (discriminatorElementName != null)
+                        {
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    discriminatorElementName));
+                        }
+                        return default!;
+                    }
+
+                    return result;
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class Extension from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Extension> ExtensionFromElement = (
+                AtElement<Aas.Extension>(
+                    ExtensionFromSequence, "extension"));
+
+            /// <summary>
+            /// Read an instance of class AdministrativeInformation from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.AdministrativeInformation> AdministrativeInformationFromElement = (
+                AtElement<Aas.AdministrativeInformation>(
+                    AdministrativeInformationFromSequence, "administrativeInformation"));
+
+            /// <summary>
+            /// Read an instance of class Qualifier from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Qualifier> QualifierFromElement = (
+                AtElement<Aas.Qualifier>(
+                    QualifierFromSequence, "qualifier"));
+
+            /// <summary>
+            /// Read an instance of class AssetAdministrationShell from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.AssetAdministrationShell> AssetAdministrationShellFromElement = (
+                AtElement<Aas.AssetAdministrationShell>(
+                    AssetAdministrationShellFromSequence, "assetAdministrationShell"));
+
+            /// <summary>
+            /// Read an instance of class AssetInformation from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.AssetInformation> AssetInformationFromElement = (
+                AtElement<Aas.AssetInformation>(
+                    AssetInformationFromSequence, "assetInformation"));
+
+            /// <summary>
+            /// Read an instance of class Resource from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Resource> ResourceFromElement = (
+                AtElement<Aas.Resource>(
+                    ResourceFromSequence, "resource"));
+
+            /// <summary>
+            /// Read an instance of class SpecificAssetId from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.SpecificAssetId> SpecificAssetIdFromElement = (
+                AtElement<Aas.SpecificAssetId>(
+                    SpecificAssetIdFromSequence, "specificAssetId"));
+
+            /// <summary>
+            /// Read an instance of class Submodel from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Submodel> SubmodelFromElement = (
+                AtElement<Aas.Submodel>(
+                    SubmodelFromSequence, "submodel"));
+
+            /// <summary>
+            /// Read an instance of class RelationshipElement from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.RelationshipElement> RelationshipElementFromElement = (
+                AtElement<Aas.RelationshipElement>(
+                    RelationshipElementFromSequence, "relationshipElement"));
+
+            /// <summary>
+            /// Read an instance of class SubmodelElementList from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.SubmodelElementList> SubmodelElementListFromElement = (
+                AtElement<Aas.SubmodelElementList>(
+                    SubmodelElementListFromSequence, "submodelElementList"));
+
+            /// <summary>
+            /// Read an instance of class SubmodelElementCollection from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.SubmodelElementCollection> SubmodelElementCollectionFromElement = (
+                AtElement<Aas.SubmodelElementCollection>(
+                    SubmodelElementCollectionFromSequence, "submodelElementCollection"));
+
+            /// <summary>
+            /// Read an instance of class Property from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Property> PropertyFromElement = (
+                AtElement<Aas.Property>(
+                    PropertyFromSequence, "property"));
+
+            /// <summary>
+            /// Read an instance of class MultiLanguageProperty from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.MultiLanguageProperty> MultiLanguagePropertyFromElement = (
+                AtElement<Aas.MultiLanguageProperty>(
+                    MultiLanguagePropertyFromSequence, "multiLanguageProperty"));
+
+            /// <summary>
+            /// Read an instance of class Range from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Range> RangeFromElement = (
+                AtElement<Aas.Range>(
+                    RangeFromSequence, "range"));
+
+            /// <summary>
+            /// Read an instance of class ReferenceElement from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.ReferenceElement> ReferenceElementFromElement = (
+                AtElement<Aas.ReferenceElement>(
+                    ReferenceElementFromSequence, "referenceElement"));
+
+            /// <summary>
+            /// Read an instance of class Blob from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Blob> BlobFromElement = (
+                AtElement<Aas.Blob>(
+                    BlobFromSequence, "blob"));
+
+            /// <summary>
+            /// Read an instance of class File from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.File> FileFromElement = (
+                AtElement<Aas.File>(
+                    FileFromSequence, "file"));
+
+            /// <summary>
+            /// Read an instance of class AnnotatedRelationshipElement from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.AnnotatedRelationshipElement> AnnotatedRelationshipElementFromElement = (
+                AtElement<Aas.AnnotatedRelationshipElement>(
+                    AnnotatedRelationshipElementFromSequence, "annotatedRelationshipElement"));
+
+            /// <summary>
+            /// Read an instance of class Entity from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Entity> EntityFromElement = (
+                AtElement<Aas.Entity>(
+                    EntityFromSequence, "entity"));
+
+            /// <summary>
+            /// Read an instance of class EventPayload from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.EventPayload> EventPayloadFromElement = (
+                AtElement<Aas.EventPayload>(
+                    EventPayloadFromSequence, "eventPayload"));
+
+            /// <summary>
+            /// Read an instance of class BasicEventElement from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.BasicEventElement> BasicEventElementFromElement = (
+                AtElement<Aas.BasicEventElement>(
+                    BasicEventElementFromSequence, "basicEventElement"));
+
+            /// <summary>
+            /// Read an instance of class Operation from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Operation> OperationFromElement = (
+                AtElement<Aas.Operation>(
+                    OperationFromSequence, "operation"));
+
+            /// <summary>
+            /// Read an instance of class OperationVariable from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.OperationVariable> OperationVariableFromElement = (
+                AtElement<Aas.OperationVariable>(
+                    OperationVariableFromSequence, "operationVariable"));
+
+            /// <summary>
+            /// Read an instance of class Capability from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Capability> CapabilityFromElement = (
+                AtElement<Aas.Capability>(
+                    CapabilityFromSequence, "capability"));
+
+            /// <summary>
+            /// Read an instance of class ConceptDescription from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.ConceptDescription> ConceptDescriptionFromElement = (
+                AtElement<Aas.ConceptDescription>(
+                    ConceptDescriptionFromSequence, "conceptDescription"));
+
+            /// <summary>
+            /// Read an instance of class Reference from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Reference> ReferenceFromElement = (
+                AtElement<Aas.Reference>(
+                    ReferenceFromSequence, "reference"));
+
+            /// <summary>
+            /// Read an instance of class Key from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Key> KeyFromElement = (
+                AtElement<Aas.Key>(
+                    KeyFromSequence, "key"));
+
+            /// <summary>
+            /// Read an instance of class LangStringNameType from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.LangStringNameType> LangStringNameTypeFromElement = (
+                AtElement<Aas.LangStringNameType>(
+                    LangStringNameTypeFromSequence, "langStringNameType"));
+
+            /// <summary>
+            /// Read an instance of class LangStringTextType from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.LangStringTextType> LangStringTextTypeFromElement = (
+                AtElement<Aas.LangStringTextType>(
+                    LangStringTextTypeFromSequence, "langStringTextType"));
+
+            /// <summary>
+            /// Read an instance of class Environment from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Environment> EnvironmentFromElement = (
+                AtElement<Aas.Environment>(
+                    EnvironmentFromSequence, "environment"));
+
+            /// <summary>
+            /// Read an instance of class EmbeddedDataSpecification from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.EmbeddedDataSpecification> EmbeddedDataSpecificationFromElement = (
+                AtElement<Aas.EmbeddedDataSpecification>(
+                    EmbeddedDataSpecificationFromSequence, "embeddedDataSpecification"));
+
+            /// <summary>
+            /// Read an instance of class LevelType from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.LevelType> LevelTypeFromElement = (
+                AtElement<Aas.LevelType>(
+                    LevelTypeFromSequence, "levelType"));
+
+            /// <summary>
+            /// Read an instance of class ValueReferencePair from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.ValueReferencePair> ValueReferencePairFromElement = (
+                AtElement<Aas.ValueReferencePair>(
+                    ValueReferencePairFromSequence, "valueReferencePair"));
+
+            /// <summary>
+            /// Read an instance of class ValueList from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.ValueList> ValueListFromElement = (
+                AtElement<Aas.ValueList>(
+                    ValueListFromSequence, "valueList"));
+
+            /// <summary>
+            /// Read an instance of class LangStringPreferredNameTypeIec61360 from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.LangStringPreferredNameTypeIec61360> LangStringPreferredNameTypeIec61360FromElement = (
+                AtElement<Aas.LangStringPreferredNameTypeIec61360>(
+                    LangStringPreferredNameTypeIec61360FromSequence, "langStringPreferredNameTypeIec61360"));
+
+            /// <summary>
+            /// Read an instance of class LangStringShortNameTypeIec61360 from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.LangStringShortNameTypeIec61360> LangStringShortNameTypeIec61360FromElement = (
+                AtElement<Aas.LangStringShortNameTypeIec61360>(
+                    LangStringShortNameTypeIec61360FromSequence, "langStringShortNameTypeIec61360"));
+
+            /// <summary>
+            /// Read an instance of class LangStringDefinitionTypeIec61360 from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.LangStringDefinitionTypeIec61360> LangStringDefinitionTypeIec61360FromElement = (
+                AtElement<Aas.LangStringDefinitionTypeIec61360>(
+                    LangStringDefinitionTypeIec61360FromSequence, "langStringDefinitionTypeIec61360"));
+
+            /// <summary>
+            /// Read an instance of class DataSpecificationIec61360 from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.DataSpecificationIec61360> DataSpecificationIec61360FromElement = (
+                AtElement<Aas.DataSpecificationIec61360>(
+                    DataSpecificationIec61360FromSequence, "dataSpecificationIec61360"));
+
+            private static readonly ContentReader<IReference> ReadIReference = (
+                ReferenceFromSequence);
+
+            private static readonly ContentReader<List<IReference>> ReadListOfIReference = (
+                AsList<IReference>(
+                    ReferenceFromElement));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<DataTypeDefXsd> ReadDataTypeDefXsd = (
+                AsEnum<Aas.DataTypeDefXsd>(
+                    Stringification.DataTypeDefXsdFromString));
+
+            private static readonly ContentReader<List<IEmbeddedDataSpecification>> ReadListOfIEmbeddedDataSpecification = (
+                AsList<IEmbeddedDataSpecification>(
+                    EmbeddedDataSpecificationFromElement));
+
+            private static readonly ContentReader<QualifierKind> ReadQualifierKind = (
+                AsEnum<Aas.QualifierKind>(
+                    Stringification.QualifierKindFromString));
+
+            private static readonly ContentReader<List<IExtension>> ReadListOfIExtension = (
+                AsList<IExtension>(
+                    ExtensionFromElement));
+
+            private static readonly ContentReader<List<ILangStringNameType>> ReadListOfILangStringNameType = (
+                AsList<ILangStringNameType>(
+                    LangStringNameTypeFromElement));
+
+            private static readonly ContentReader<List<ILangStringTextType>> ReadListOfILangStringTextType = (
+                AsList<ILangStringTextType>(
+                    LangStringTextTypeFromElement));
+
+            private static readonly ContentReader<IAdministrativeInformation> ReadIAdministrativeInformation = (
+                AdministrativeInformationFromSequence);
+
+            private static readonly ContentReader<IAssetInformation> ReadIAssetInformation = (
+                AssetInformationFromSequence);
+
+            private static readonly ContentReader<AssetKind> ReadAssetKind = (
+                AsEnum<Aas.AssetKind>(
+                    Stringification.AssetKindFromString));
+
+            private static readonly ContentReader<List<ISpecificAssetId>> ReadListOfISpecificAssetId = (
+                AsList<ISpecificAssetId>(
+                    SpecificAssetIdFromElement));
+
+            private static readonly ContentReader<IResource> ReadIResource = (
+                ResourceFromSequence);
+
+            private static readonly ContentReader<ModellingKind> ReadModellingKind = (
+                AsEnum<Aas.ModellingKind>(
+                    Stringification.ModellingKindFromString));
+
+            private static readonly ContentReader<List<IQualifier>> ReadListOfIQualifier = (
+                AsList<IQualifier>(
+                    QualifierFromElement));
+
+            private static readonly ContentReader<List<ISubmodelElement>> ReadListOfISubmodelElement = (
+                AsList<ISubmodelElement>(
+                    ISubmodelElementFromElement));
+
+            private static readonly ContentReader<bool> ReadBool = (
+                AsText<bool>(ReadContentAsBoolean));
+
+            private static readonly ContentReader<AasSubmodelElements> ReadAasSubmodelElements = (
+                AsEnum<Aas.AasSubmodelElements>(
+                    Stringification.AasSubmodelElementsFromString));
+
+            private static readonly ContentReader<byte[]> ReadBytes = (
+                AsText<byte[]>(ReadContentAsBytes, new byte[0]));
+
+            private static readonly ContentReader<List<IDataElement>> ReadListOfIDataElement = (
+                AsList<IDataElement>(
+                    IDataElementFromElement));
+
+            private static readonly ContentReader<EntityType> ReadEntityType = (
+                AsEnum<Aas.EntityType>(
+                    Stringification.EntityTypeFromString));
+
+            private static readonly ContentReader<Direction> ReadDirection = (
+                AsEnum<Aas.Direction>(
+                    Stringification.DirectionFromString));
+
+            private static readonly ContentReader<StateOfEvent> ReadStateOfEvent = (
+                AsEnum<Aas.StateOfEvent>(
+                    Stringification.StateOfEventFromString));
+
+            private static readonly ContentReader<List<IOperationVariable>> ReadListOfIOperationVariable = (
+                AsList<IOperationVariable>(
+                    OperationVariableFromElement));
+
+            private static readonly ContentReader<ISubmodelElement> ReadISubmodelElement = (
+                AsElement<Aas.ISubmodelElement>(
+                    ISubmodelElementFromElement));
+
+            private static readonly ContentReader<ReferenceTypes> ReadReferenceTypes = (
+                AsEnum<Aas.ReferenceTypes>(
+                    Stringification.ReferenceTypesFromString));
+
+            private static readonly ContentReader<List<IKey>> ReadListOfIKey = (
+                AsList<IKey>(
+                    KeyFromElement));
+
+            private static readonly ContentReader<KeyTypes> ReadKeyTypes = (
+                AsEnum<Aas.KeyTypes>(
+                    Stringification.KeyTypesFromString));
+
+            private static readonly ContentReader<List<IAssetAdministrationShell>> ReadListOfIAssetAdministrationShell = (
+                AsList<IAssetAdministrationShell>(
+                    AssetAdministrationShellFromElement));
+
+            private static readonly ContentReader<List<ISubmodel>> ReadListOfISubmodel = (
+                AsList<ISubmodel>(
+                    SubmodelFromElement));
+
+            private static readonly ContentReader<List<IConceptDescription>> ReadListOfIConceptDescription = (
+                AsList<IConceptDescription>(
+                    ConceptDescriptionFromElement));
+
+            private static readonly ContentReader<IDataSpecificationContent> ReadIDataSpecificationContent = (
+                AsElement<Aas.IDataSpecificationContent>(
+                    IDataSpecificationContentFromElement));
+
+            private static readonly ContentReader<List<IValueReferencePair>> ReadListOfIValueReferencePair = (
+                AsList<IValueReferencePair>(
+                    ValueReferencePairFromElement));
+
+            private static readonly ContentReader<List<ILangStringPreferredNameTypeIec61360>> ReadListOfILangStringPreferredNameTypeIec61360 = (
+                AsList<ILangStringPreferredNameTypeIec61360>(
+                    LangStringPreferredNameTypeIec61360FromElement));
+
+            private static readonly ContentReader<List<ILangStringShortNameTypeIec61360>> ReadListOfILangStringShortNameTypeIec61360 = (
+                AsList<ILangStringShortNameTypeIec61360>(
+                    LangStringShortNameTypeIec61360FromElement));
+
+            private static readonly ContentReader<DataTypeIec61360> ReadDataTypeIec61360 = (
+                AsEnum<Aas.DataTypeIec61360>(
+                    Stringification.DataTypeIec61360FromString));
+
+            private static readonly ContentReader<List<ILangStringDefinitionTypeIec61360>> ReadListOfILangStringDefinitionTypeIec61360 = (
+                AsList<ILangStringDefinitionTypeIec61360>(
+                    LangStringDefinitionTypeIec61360FromElement));
+
+            private static readonly ContentReader<IValueList> ReadIValueList = (
+                ValueListFromSequence);
+
+            private static readonly ContentReader<ILevelType> ReadILevelType = (
+                LevelTypeFromSequence);
+
+            /// <summary>
+            /// Deserialize an instance of IHasSemantics from an XML element.
+            /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            internal static Aas.IHasSemantics IHasSemanticsFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                string elementName = PeekElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1166,7 +1126,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IHasSemantics? IHasSemanticsFromElement
 
@@ -1178,7 +1138,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Extension? ExtensionFromSequence(
+            internal static Aas.Extension ExtensionFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1201,274 +1161,74 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Extension, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Extension, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "name":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theName = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Name of an instance of class Extension, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theName = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Name of an instance of class Extension " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "name"));
-                                        return null;
-                                    }
-                                }
+                                theName = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "valueType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Extension " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ValueType of an instance of class Extension, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textValueType;
-                                try
-                                {
-                                    textValueType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Extension " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                theValueType = Stringification.DataTypeDefXsdFromString(
-                                    textValueType);
-
-                                if (theValueType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Extension " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textValueType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
+                                theValueType = ReadDataTypeDefXsd(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class Extension, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class Extension " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "refersTo":
-                            {
-                                theRefersTo = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theRefersTo = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "refersTo"));
-                                        return null;
-                                    }
-                                }
+                                theRefersTo = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Extension, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Extension " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Extension " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Extension " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1477,7 +1237,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Name has not been given " +
                         "in the XML representation of an instance of class Extension");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Extension(
@@ -1492,86 +1252,18 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Extension? ExtensionFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Extension from an XML element.
-            /// </summary>
-            internal static Aas.Extension? ExtensionFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Extension", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "extension")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Extension " +
-                        $"with element name extension, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Extension? result = (
-                    ExtensionFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Extension? ExtensionFromElement
-
-            /// <summary>
             /// Deserialize an instance of IHasExtensions from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IHasExtensions? IHasExtensionsFromElement(
+            internal static Aas.IHasExtensions IHasExtensionsFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1630,7 +1322,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IHasExtensions? IHasExtensionsFromElement
 
@@ -1638,35 +1330,15 @@ namespace AasCore.Aas3_0
             /// Deserialize an instance of IReferable from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IReferable? IReferableFromElement(
+            internal static Aas.IReferable IReferableFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1725,7 +1397,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IReferable? IReferableFromElement
 
@@ -1733,35 +1405,15 @@ namespace AasCore.Aas3_0
             /// Deserialize an instance of IIdentifiable from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IIdentifiable? IIdentifiableFromElement(
+            internal static Aas.IIdentifiable IIdentifiableFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1778,7 +1430,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IIdentifiable? IIdentifiableFromElement
 
@@ -1786,35 +1438,15 @@ namespace AasCore.Aas3_0
             /// Deserialize an instance of IHasKind from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IHasKind? IHasKindFromElement(
+            internal static Aas.IHasKind IHasKindFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1825,7 +1457,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IHasKind? IHasKindFromElement
 
@@ -1833,35 +1465,15 @@ namespace AasCore.Aas3_0
             /// Deserialize an instance of IHasDataSpecification from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IHasDataSpecification? IHasDataSpecificationFromElement(
+            internal static Aas.IHasDataSpecification IHasDataSpecificationFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1923,7 +1535,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IHasDataSpecification? IHasDataSpecificationFromElement
 
@@ -1935,7 +1547,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.AdministrativeInformation? AdministrativeInformationFromSequence(
+            internal static Aas.AdministrativeInformation AdministrativeInformationFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1957,234 +1569,70 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class AdministrativeInformation, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class AdministrativeInformation, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "version":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theVersion = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Version of an instance of class AdministrativeInformation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theVersion = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Version of an instance of class AdministrativeInformation " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "version"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "revision":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theRevision = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Revision of an instance of class AdministrativeInformation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theRevision = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Revision of an instance of class AdministrativeInformation " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "revision"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "creator":
-                            {
-                                theCreator = ReferenceFromSequence(
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "creator"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "version":
+                                theVersion = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "revision":
+                                theRevision = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "creator":
+                                theCreator = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "templateId":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theTemplateId = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property TemplateId of an instance of class AdministrativeInformation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theTemplateId = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property TemplateId of an instance of class AdministrativeInformation " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "templateId"));
-                                        return null;
-                                    }
-                                }
+                                theTemplateId = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class AdministrativeInformation, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AdministrativeInformation " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AdministrativeInformation " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AdministrativeInformation " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -2197,86 +1645,18 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.AdministrativeInformation? AdministrativeInformationFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class AdministrativeInformation from an XML element.
-            /// </summary>
-            internal static Aas.AdministrativeInformation? AdministrativeInformationFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "AdministrativeInformation", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "administrativeInformation")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class AdministrativeInformation " +
-                        $"with element name administrativeInformation, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.AdministrativeInformation? result = (
-                    AdministrativeInformationFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.AdministrativeInformation? AdministrativeInformationFromElement
-
-            /// <summary>
             /// Deserialize an instance of IQualifiable from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IQualifiable? IQualifiableFromElement(
+            internal static Aas.IQualifiable IQualifiableFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -2329,7 +1709,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IQualifiable? IQualifiableFromElement
 
@@ -2341,7 +1721,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Qualifier? QualifierFromSequence(
+            internal static Aas.Qualifier QualifierFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -2365,322 +1745,78 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Qualifier, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Qualifier, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "kind":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Kind of an instance of class Qualifier " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "kind"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Kind of an instance of class Qualifier, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textKind;
-                                try
-                                {
-                                    textKind = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Kind of an instance of class Qualifier " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "kind"));
-                                    return null;
-                                }
-
-                                theKind = Stringification.QualifierKindFromString(
-                                    textKind);
-
-                                if (theKind == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Kind of an instance of class Qualifier " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textKind);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "kind"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "type":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theType = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Type of an instance of class Qualifier, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theType = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Type of an instance of class Qualifier " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "type"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "valueType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Qualifier " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ValueType of an instance of class Qualifier, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textValueType;
-                                try
-                                {
-                                    textValueType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Qualifier " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                theValueType = Stringification.DataTypeDefXsdFromString(
-                                    textValueType);
-
-                                if (theValueType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Qualifier " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textValueType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class Qualifier, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class Qualifier " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "valueId":
-                            {
-                                theValueId = ReferenceFromSequence(
+                                theSupplementalSemanticIds = ReadListOfIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "kind":
+                                theKind = ReadQualifierKind(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "type":
+                                theType = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "valueType":
+                                theValueType = ReadDataTypeDefXsd(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "value":
+                                theValue = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "valueId":
+                                theValueId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Qualifier, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Qualifier " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Qualifier " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Qualifier " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -2689,7 +1825,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Type has not been given " +
                         "in the XML representation of an instance of class Qualifier");
-                    return null;
+                    return default!;
                 }
 
                 if (theValueType == null)
@@ -2697,7 +1833,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ValueType has not been given " +
                         "in the XML representation of an instance of class Qualifier");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Qualifier(
@@ -2715,54 +1851,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Qualifier? QualifierFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Qualifier from an XML element.
-            /// </summary>
-            internal static Aas.Qualifier? QualifierFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Qualifier", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "qualifier")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Qualifier " +
-                        $"with element name qualifier, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Qualifier? result = (
-                    QualifierFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Qualifier? QualifierFromElement
-
-            /// <summary>
             /// Deserialize an instance of class AssetAdministrationShell from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -2770,7 +1858,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.AssetAdministrationShell? AssetAdministrationShellFromSequence(
+            internal static Aas.AssetAdministrationShell AssetAdministrationShellFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -2798,346 +1886,94 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class AssetAdministrationShell, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class AssetAdministrationShell, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class AssetAdministrationShell, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class AssetAdministrationShell " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class AssetAdministrationShell, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class AssetAdministrationShell " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "administration":
-                            {
-                                theAdministration = AdministrativeInformationFromSequence(
+                                theAdministration = ReadIAdministrativeInformation(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "administration"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "id":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theId = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Id of an instance of class AssetAdministrationShell, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theId = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Id of an instance of class AssetAdministrationShell " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "id"));
-                                        return null;
-                                    }
-                                }
+                                theId = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "derivedFrom":
-                            {
-                                theDerivedFrom = ReferenceFromSequence(
+                                theDerivedFrom = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "derivedFrom"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "assetInformation":
-                            {
-                                theAssetInformation = AssetInformationFromSequence(
+                                theAssetInformation = ReadIAssetInformation(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "assetInformation"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "submodels":
-                            {
-                                theSubmodels = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSubmodels = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "submodels"));
-                                        return null;
-                                    }
-                                }
+                                theSubmodels = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class AssetAdministrationShell, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AssetAdministrationShell " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AssetAdministrationShell " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AssetAdministrationShell " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -3146,7 +1982,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Id has not been given " +
                         "in the XML representation of an instance of class AssetAdministrationShell");
-                    return null;
+                    return default!;
                 }
 
                 if (theAssetInformation == null)
@@ -3154,7 +1990,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property AssetInformation has not been given " +
                         "in the XML representation of an instance of class AssetAdministrationShell");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.AssetAdministrationShell(
@@ -3176,54 +2012,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.AssetAdministrationShell? AssetAdministrationShellFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class AssetAdministrationShell from an XML element.
-            /// </summary>
-            internal static Aas.AssetAdministrationShell? AssetAdministrationShellFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "AssetAdministrationShell", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "assetAdministrationShell")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class AssetAdministrationShell " +
-                        $"with element name assetAdministrationShell, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.AssetAdministrationShell? result = (
-                    AssetAdministrationShellFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.AssetAdministrationShell? AssetAdministrationShellFromElement
-
-            /// <summary>
             /// Deserialize an instance of class AssetInformation from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -3231,7 +2019,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.AssetInformation? AssetInformationFromSequence(
+            internal static Aas.AssetInformation AssetInformationFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -3253,253 +2041,70 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class AssetInformation, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class AssetInformation, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "assetKind":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property AssetKind of an instance of class AssetInformation " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "assetKind"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property AssetKind of an instance of class AssetInformation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textAssetKind;
-                                try
-                                {
-                                    textAssetKind = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property AssetKind of an instance of class AssetInformation " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "assetKind"));
-                                    return null;
-                                }
-
-                                theAssetKind = Stringification.AssetKindFromString(
-                                    textAssetKind);
-
-                                if (theAssetKind == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property AssetKind of an instance of class AssetInformation " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textAssetKind);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "assetKind"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "globalAssetId":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theGlobalAssetId = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property GlobalAssetId of an instance of class AssetInformation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theGlobalAssetId = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property GlobalAssetId of an instance of class AssetInformation " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "globalAssetId"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "specificAssetIds":
-                            {
-                                theSpecificAssetIds = new List<ISpecificAssetId>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSpecificAssetIds = ParseListOfClass<ISpecificAssetId>(
-                                        reader,
-                                        SpecificAssetIdFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "specificAssetIds"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "assetType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theAssetType = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property AssetType of an instance of class AssetInformation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theAssetType = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property AssetType of an instance of class AssetInformation " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "assetType"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "defaultThumbnail":
-                            {
-                                theDefaultThumbnail = ResourceFromSequence(
+                                theAssetKind = ReadAssetKind(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "defaultThumbnail"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "globalAssetId":
+                                theGlobalAssetId = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "specificAssetIds":
+                                theSpecificAssetIds = ReadListOfISpecificAssetId(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "assetType":
+                                theAssetType = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "defaultThumbnail":
+                                theDefaultThumbnail = ReadIResource(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class AssetInformation, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AssetInformation " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AssetInformation " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AssetInformation " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -3508,7 +2113,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property AssetKind has not been given " +
                         "in the XML representation of an instance of class AssetInformation");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.AssetInformation(
@@ -3522,54 +2127,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.AssetInformation? AssetInformationFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class AssetInformation from an XML element.
-            /// </summary>
-            internal static Aas.AssetInformation? AssetInformationFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "AssetInformation", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "assetInformation")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class AssetInformation " +
-                        $"with element name assetInformation, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.AssetInformation? result = (
-                    AssetInformationFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.AssetInformation? AssetInformationFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Resource from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -3577,7 +2134,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Resource? ResourceFromSequence(
+            internal static Aas.Resource ResourceFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -3596,163 +2153,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Resource, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Resource, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "path":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    thePath = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Path of an instance of class Resource, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        thePath = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Path of an instance of class Resource " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "path"));
-                                        return null;
-                                    }
-                                }
+                                thePath = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "contentType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theContentType = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ContentType of an instance of class Resource, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theContentType = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property ContentType of an instance of class Resource " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "contentType"));
-                                        return null;
-                                    }
-                                }
+                                theContentType = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Resource, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Resource " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Resource " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Resource " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -3761,7 +2213,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Path has not been given " +
                         "in the XML representation of an instance of class Resource");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Resource(
@@ -3772,54 +2224,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Resource? ResourceFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Resource from an XML element.
-            /// </summary>
-            internal static Aas.Resource? ResourceFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Resource", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "resource")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Resource " +
-                        $"with element name resource, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Resource? result = (
-                    ResourceFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Resource? ResourceFromElement
-
-            /// <summary>
             /// Deserialize an instance of class SpecificAssetId from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -3827,7 +2231,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.SpecificAssetId? SpecificAssetIdFromSequence(
+            internal static Aas.SpecificAssetId SpecificAssetIdFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -3849,212 +2253,70 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class SpecificAssetId, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class SpecificAssetId, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "name":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theName = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Name of an instance of class SpecificAssetId, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theName = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Name of an instance of class SpecificAssetId " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "name"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class SpecificAssetId, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class SpecificAssetId " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "externalSubjectId":
-                            {
-                                theExternalSubjectId = ReferenceFromSequence(
+                                theSupplementalSemanticIds = ReadListOfIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "externalSubjectId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "name":
+                                theName = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "value":
+                                theValue = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "externalSubjectId":
+                                theExternalSubjectId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class SpecificAssetId, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SpecificAssetId " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SpecificAssetId " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SpecificAssetId " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -4063,7 +2325,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Name has not been given " +
                         "in the XML representation of an instance of class SpecificAssetId");
-                    return null;
+                    return default!;
                 }
 
                 if (theValue == null)
@@ -4071,7 +2333,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Value has not been given " +
                         "in the XML representation of an instance of class SpecificAssetId");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.SpecificAssetId(
@@ -4087,54 +2349,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.SpecificAssetId? SpecificAssetIdFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class SpecificAssetId from an XML element.
-            /// </summary>
-            internal static Aas.SpecificAssetId? SpecificAssetIdFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "SpecificAssetId", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "specificAssetId")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class SpecificAssetId " +
-                        $"with element name specificAssetId, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.SpecificAssetId? result = (
-                    SpecificAssetIdFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.SpecificAssetId? SpecificAssetIdFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Submodel from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -4142,7 +2356,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Submodel? SubmodelFromSequence(
+            internal static Aas.Submodel SubmodelFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -4172,429 +2386,102 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Submodel, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Submodel, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class Submodel, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class Submodel " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class Submodel, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class Submodel " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "administration":
-                            {
-                                theAdministration = AdministrativeInformationFromSequence(
+                                theAdministration = ReadIAdministrativeInformation(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "administration"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "id":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theId = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Id of an instance of class Submodel, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theId = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Id of an instance of class Submodel " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "id"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "kind":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Kind of an instance of class Submodel " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "kind"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Kind of an instance of class Submodel, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textKind;
-                                try
-                                {
-                                    textKind = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Kind of an instance of class Submodel " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "kind"));
-                                    return null;
-                                }
-
-                                theKind = Stringification.ModellingKindFromString(
-                                    textKind);
-
-                                if (theKind == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Kind of an instance of class Submodel " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textKind);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "kind"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theId = ReadString(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "kind":
+                                theKind = ReadModellingKind(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "submodelElements":
-                            {
-                                theSubmodelElements = new List<ISubmodelElement>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSubmodelElements = ParseListOfClass<ISubmodelElement>(
-                                        reader,
-                                        ISubmodelElementFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "submodelElements"));
-                                        return null;
-                                    }
-                                }
+                                theSubmodelElements = ReadListOfISubmodelElement(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Submodel, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Submodel " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Submodel " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Submodel " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -4603,7 +2490,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Id has not been given " +
                         "in the XML representation of an instance of class Submodel");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Submodel(
@@ -4625,86 +2512,18 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Submodel? SubmodelFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Submodel from an XML element.
-            /// </summary>
-            internal static Aas.Submodel? SubmodelFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Submodel", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "submodel")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Submodel " +
-                        $"with element name submodel, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Submodel? result = (
-                    SubmodelFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Submodel? SubmodelFromElement
-
-            /// <summary>
             /// Deserialize an instance of ISubmodelElement from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.ISubmodelElement? ISubmodelElementFromElement(
+            internal static Aas.ISubmodelElement ISubmodelElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -4754,7 +2573,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.ISubmodelElement? ISubmodelElementFromElement
 
@@ -4766,7 +2585,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.RelationshipElement? RelationshipElementFromSequence(
+            internal static Aas.RelationshipElement RelationshipElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -4794,331 +2613,94 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class RelationshipElement, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class RelationshipElement, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class RelationshipElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class RelationshipElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class RelationshipElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class RelationshipElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "first":
-                            {
-                                theFirst = ReferenceFromSequence(
+                                theFirst = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "first"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "second":
-                            {
-                                theSecond = ReferenceFromSequence(
+                                theSecond = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "second"));
-                                    return null;
-                                }
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class RelationshipElement, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class RelationshipElement " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class RelationshipElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class RelationshipElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -5127,7 +2709,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property First has not been given " +
                         "in the XML representation of an instance of class RelationshipElement");
-                    return null;
+                    return default!;
                 }
 
                 if (theSecond == null)
@@ -5135,7 +2717,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Second has not been given " +
                         "in the XML representation of an instance of class RelationshipElement");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.RelationshipElement(
@@ -5160,35 +2742,15 @@ namespace AasCore.Aas3_0
             /// Deserialize an instance of IRelationshipElement from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IRelationshipElement? IRelationshipElementFromElement(
+            internal static Aas.IRelationshipElement IRelationshipElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -5202,57 +2764,9 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IRelationshipElement? IRelationshipElementFromElement
-
-            /// <summary>
-            /// Deserialize an instance of class RelationshipElement from an XML element.
-            /// </summary>
-            internal static Aas.RelationshipElement? RelationshipElementFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "RelationshipElement", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "relationshipElement")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class RelationshipElement " +
-                        $"with element name relationshipElement, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.RelationshipElement? result = (
-                    RelationshipElementFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.RelationshipElement? RelationshipElementFromElement
 
             /// <summary>
             /// Deserialize an instance of class SubmodelElementList from a sequence of XML elements.
@@ -5262,7 +2776,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.SubmodelElementList? SubmodelElementListFromSequence(
+            internal static Aas.SubmodelElementList SubmodelElementListFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -5293,491 +2807,106 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class SubmodelElementList, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class SubmodelElementList, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class SubmodelElementList, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class SubmodelElementList " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class SubmodelElementList, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class SubmodelElementList " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "orderRelevant":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property OrderRelevant of an instance of class SubmodelElementList " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "orderRelevant"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property OrderRelevant of an instance of class SubmodelElementList, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theOrderRelevant = reader.ReadContentAsBoolean();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property OrderRelevant of an instance of class SubmodelElementList " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "orderRelevant"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticIdListElement":
-                            {
-                                theSemanticIdListElement = ReferenceFromSequence(
+                                theSupplementalSemanticIds = ReadListOfIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticIdListElement"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "qualifiers":
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "embeddedDataSpecifications":
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "orderRelevant":
+                                theOrderRelevant = ReadBool(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticIdListElement":
+                                theSemanticIdListElement = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "typeValueListElement":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property TypeValueListElement of an instance of class SubmodelElementList " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "typeValueListElement"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property TypeValueListElement of an instance of class SubmodelElementList, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textTypeValueListElement;
-                                try
-                                {
-                                    textTypeValueListElement = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property TypeValueListElement of an instance of class SubmodelElementList " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "typeValueListElement"));
-                                    return null;
-                                }
-
-                                theTypeValueListElement = Stringification.AasSubmodelElementsFromString(
-                                    textTypeValueListElement);
-
-                                if (theTypeValueListElement == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property TypeValueListElement of an instance of class SubmodelElementList " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textTypeValueListElement);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "typeValueListElement"));
-                                    return null;
-                                }
+                                theTypeValueListElement = ReadAasSubmodelElements(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "valueTypeListElement":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueTypeListElement of an instance of class SubmodelElementList " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueTypeListElement"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ValueTypeListElement of an instance of class SubmodelElementList, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textValueTypeListElement;
-                                try
-                                {
-                                    textValueTypeListElement = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueTypeListElement of an instance of class SubmodelElementList " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueTypeListElement"));
-                                    return null;
-                                }
-
-                                theValueTypeListElement = Stringification.DataTypeDefXsdFromString(
-                                    textValueTypeListElement);
-
-                                if (theValueTypeListElement == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueTypeListElement of an instance of class SubmodelElementList " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textValueTypeListElement);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueTypeListElement"));
-                                    return null;
-                                }
+                                theValueTypeListElement = ReadDataTypeDefXsd(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                theValue = new List<ISubmodelElement>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theValue = ParseListOfClass<ISubmodelElement>(
-                                        reader,
-                                        ISubmodelElementFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadListOfISubmodelElement(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class SubmodelElementList, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SubmodelElementList " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SubmodelElementList " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SubmodelElementList " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -5786,7 +2915,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property TypeValueListElement has not been given " +
                         "in the XML representation of an instance of class SubmodelElementList");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.SubmodelElementList(
@@ -5809,54 +2938,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.SubmodelElementList? SubmodelElementListFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class SubmodelElementList from an XML element.
-            /// </summary>
-            internal static Aas.SubmodelElementList? SubmodelElementListFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "SubmodelElementList", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "submodelElementList")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class SubmodelElementList " +
-                        $"with element name submodelElementList, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.SubmodelElementList? result = (
-                    SubmodelElementListFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.SubmodelElementList? SubmodelElementListFromElement
-
-            /// <summary>
             /// Deserialize an instance of class SubmodelElementCollection from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -5864,7 +2945,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.SubmodelElementCollection? SubmodelElementCollectionFromSequence(
+            internal static Aas.SubmodelElementCollection SubmodelElementCollectionFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -5891,324 +2972,90 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class SubmodelElementCollection, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class SubmodelElementCollection, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class SubmodelElementCollection, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class SubmodelElementCollection " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class SubmodelElementCollection, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class SubmodelElementCollection " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                theValue = new List<ISubmodelElement>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theValue = ParseListOfClass<ISubmodelElement>(
-                                        reader,
-                                        ISubmodelElementFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadListOfISubmodelElement(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class SubmodelElementCollection, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SubmodelElementCollection " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SubmodelElementCollection " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SubmodelElementCollection " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -6226,86 +3073,18 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.SubmodelElementCollection? SubmodelElementCollectionFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class SubmodelElementCollection from an XML element.
-            /// </summary>
-            internal static Aas.SubmodelElementCollection? SubmodelElementCollectionFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "SubmodelElementCollection", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "submodelElementCollection")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class SubmodelElementCollection " +
-                        $"with element name submodelElementCollection, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.SubmodelElementCollection? result = (
-                    SubmodelElementCollectionFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.SubmodelElementCollection? SubmodelElementCollectionFromElement
-
-            /// <summary>
             /// Deserialize an instance of IDataElement from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IDataElement? IDataElementFromElement(
+            internal static Aas.IDataElement IDataElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -6331,7 +3110,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IDataElement? IDataElementFromElement
 
@@ -6343,7 +3122,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Property? PropertyFromSequence(
+            internal static Aas.Property PropertyFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -6372,408 +3151,98 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Property, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Property, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class Property, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class Property " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class Property, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class Property " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "valueType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Property " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ValueType of an instance of class Property, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textValueType;
-                                try
-                                {
-                                    textValueType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Property " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                theValueType = Stringification.DataTypeDefXsdFromString(
-                                    textValueType);
-
-                                if (theValueType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Property " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textValueType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class Property, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class Property " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "valueId":
-                            {
-                                theValueId = ReferenceFromSequence(
+                                theSupplementalSemanticIds = ReadListOfIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "qualifiers":
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "embeddedDataSpecifications":
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "valueType":
+                                theValueType = ReadDataTypeDefXsd(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "value":
+                                theValue = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "valueId":
+                                theValueId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Property, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Property " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Property " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Property " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -6782,7 +3251,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ValueType has not been given " +
                         "in the XML representation of an instance of class Property");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Property(
@@ -6803,54 +3272,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Property? PropertyFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Property from an XML element.
-            /// </summary>
-            internal static Aas.Property? PropertyFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Property", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "property")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Property " +
-                        $"with element name property, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Property? result = (
-                    PropertyFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Property? PropertyFromElement
-
-            /// <summary>
             /// Deserialize an instance of class MultiLanguageProperty from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -6858,7 +3279,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.MultiLanguageProperty? MultiLanguagePropertyFromSequence(
+            internal static Aas.MultiLanguageProperty MultiLanguagePropertyFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -6886,338 +3307,94 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class MultiLanguageProperty, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class MultiLanguageProperty, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class MultiLanguageProperty, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class MultiLanguageProperty " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class MultiLanguageProperty, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class MultiLanguageProperty " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "value":
-                            {
-                                theValue = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theValue = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "valueId":
-                            {
-                                theValueId = ReferenceFromSequence(
+                                theSupplementalSemanticIds = ReadListOfIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "qualifiers":
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "embeddedDataSpecifications":
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "value":
+                                theValue = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "valueId":
+                                theValueId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class MultiLanguageProperty, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MultiLanguageProperty " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MultiLanguageProperty " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MultiLanguageProperty " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -7236,54 +3413,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.MultiLanguageProperty? MultiLanguagePropertyFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class MultiLanguageProperty from an XML element.
-            /// </summary>
-            internal static Aas.MultiLanguageProperty? MultiLanguagePropertyFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "MultiLanguageProperty", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "multiLanguageProperty")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class MultiLanguageProperty " +
-                        $"with element name multiLanguageProperty, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.MultiLanguageProperty? result = (
-                    MultiLanguagePropertyFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.MultiLanguageProperty? MultiLanguagePropertyFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Range from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -7291,7 +3420,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Range? RangeFromSequence(
+            internal static Aas.Range RangeFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -7320,430 +3449,98 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Range, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Range, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class Range, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class Range " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class Range, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class Range " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "valueType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Range " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ValueType of an instance of class Range, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textValueType;
-                                try
-                                {
-                                    textValueType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Range " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
-
-                                theValueType = Stringification.DataTypeDefXsdFromString(
-                                    textValueType);
-
-                                if (theValueType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property ValueType of an instance of class Range " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textValueType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueType"));
-                                    return null;
-                                }
+                                theValueType = ReadDataTypeDefXsd(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "min":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theMin = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Min of an instance of class Range, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theMin = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Min of an instance of class Range " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "min"));
-                                        return null;
-                                    }
-                                }
+                                theMin = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "max":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theMax = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Max of an instance of class Range, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theMax = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Max of an instance of class Range " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "max"));
-                                        return null;
-                                    }
-                                }
+                                theMax = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Range, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Range " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Range " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Range " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -7752,7 +3549,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ValueType has not been given " +
                         "in the XML representation of an instance of class Range");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Range(
@@ -7773,54 +3570,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Range? RangeFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Range from an XML element.
-            /// </summary>
-            internal static Aas.Range? RangeFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Range", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "range")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Range " +
-                        $"with element name range, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Range? result = (
-                    RangeFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Range? RangeFromElement
-
-            /// <summary>
             /// Deserialize an instance of class ReferenceElement from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -7828,7 +3577,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.ReferenceElement? ReferenceElementFromSequence(
+            internal static Aas.ReferenceElement ReferenceElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -7855,317 +3604,90 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class ReferenceElement, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class ReferenceElement, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class ReferenceElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class ReferenceElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class ReferenceElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class ReferenceElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "value":
-                            {
-                                theValue = ReferenceFromSequence(
+                                theSupplementalSemanticIds = ReadListOfIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "qualifiers":
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "embeddedDataSpecifications":
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "value":
+                                theValue = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class ReferenceElement, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ReferenceElement " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ReferenceElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ReferenceElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -8183,54 +3705,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.ReferenceElement? ReferenceElementFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class ReferenceElement from an XML element.
-            /// </summary>
-            internal static Aas.ReferenceElement? ReferenceElementFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "ReferenceElement", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "referenceElement")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class ReferenceElement " +
-                        $"with element name referenceElement, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.ReferenceElement? result = (
-                    ReferenceElementFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.ReferenceElement? ReferenceElementFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Blob from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -8238,7 +3712,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Blob? BlobFromSequence(
+            internal static Aas.Blob BlobFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -8266,383 +3740,94 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Blob, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Blob, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class Blob, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class Blob " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class Blob, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class Blob " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Value of an instance of class Blob " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class Blob, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = DeserializeImplementation.ReadWholeContentAsBase64(
-                                        reader);
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class Blob " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadBytes(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "contentType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theContentType = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ContentType of an instance of class Blob, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theContentType = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property ContentType of an instance of class Blob " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "contentType"));
-                                        return null;
-                                    }
-                                }
+                                theContentType = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Blob, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Blob " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Blob " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Blob " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -8651,7 +3836,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ContentType has not been given " +
                         "in the XML representation of an instance of class Blob");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Blob(
@@ -8671,54 +3856,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Blob? BlobFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Blob from an XML element.
-            /// </summary>
-            internal static Aas.Blob? BlobFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Blob", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "blob")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Blob " +
-                        $"with element name blob, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Blob? result = (
-                    BlobFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Blob? BlobFromElement
-
-            /// <summary>
             /// Deserialize an instance of class File from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -8726,7 +3863,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.File? FileFromSequence(
+            internal static Aas.File FileFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -8754,375 +3891,94 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class File, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class File, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class File, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class File " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class File, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class File " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class File, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class File " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "contentType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theContentType = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ContentType of an instance of class File, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theContentType = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property ContentType of an instance of class File " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "contentType"));
-                                        return null;
-                                    }
-                                }
+                                theContentType = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class File, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class File " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class File " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class File " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -9131,7 +3987,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ContentType has not been given " +
                         "in the XML representation of an instance of class File");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.File(
@@ -9151,54 +4007,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.File? FileFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class File from an XML element.
-            /// </summary>
-            internal static Aas.File? FileFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "File", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "file")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class File " +
-                        $"with element name file, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.File? result = (
-                    FileFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.File? FileFromElement
-
-            /// <summary>
             /// Deserialize an instance of class AnnotatedRelationshipElement from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -9206,7 +4014,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.AnnotatedRelationshipElement? AnnotatedRelationshipElementFromSequence(
+            internal static Aas.AnnotatedRelationshipElement AnnotatedRelationshipElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -9235,352 +4043,98 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class AnnotatedRelationshipElement, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class AnnotatedRelationshipElement, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class AnnotatedRelationshipElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class AnnotatedRelationshipElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class AnnotatedRelationshipElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class AnnotatedRelationshipElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "first":
-                            {
-                                theFirst = ReferenceFromSequence(
+                                theFirst = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "first"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "second":
-                            {
-                                theSecond = ReferenceFromSequence(
+                                theSecond = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "second"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "annotations":
-                            {
-                                theAnnotations = new List<IDataElement>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theAnnotations = ParseListOfClass<IDataElement>(
-                                        reader,
-                                        IDataElementFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "annotations"));
-                                        return null;
-                                    }
-                                }
+                                theAnnotations = ReadListOfIDataElement(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class AnnotatedRelationshipElement, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnnotatedRelationshipElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -9589,7 +4143,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property First has not been given " +
                         "in the XML representation of an instance of class AnnotatedRelationshipElement");
-                    return null;
+                    return default!;
                 }
 
                 if (theSecond == null)
@@ -9597,7 +4151,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Second has not been given " +
                         "in the XML representation of an instance of class AnnotatedRelationshipElement");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.AnnotatedRelationshipElement(
@@ -9620,54 +4174,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.AnnotatedRelationshipElement? AnnotatedRelationshipElementFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class AnnotatedRelationshipElement from an XML element.
-            /// </summary>
-            internal static Aas.AnnotatedRelationshipElement? AnnotatedRelationshipElementFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "AnnotatedRelationshipElement", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "annotatedRelationshipElement")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class AnnotatedRelationshipElement " +
-                        $"with element name annotatedRelationshipElement, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.AnnotatedRelationshipElement? result = (
-                    AnnotatedRelationshipElementFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.AnnotatedRelationshipElement? AnnotatedRelationshipElementFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Entity from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -9675,7 +4181,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Entity? EntityFromSequence(
+            internal static Aas.Entity EntityFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -9705,436 +4211,102 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Entity, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Entity, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class Entity, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class Entity " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class Entity, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class Entity " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "statements":
-                            {
-                                theStatements = new List<ISubmodelElement>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theStatements = ParseListOfClass<ISubmodelElement>(
-                                        reader,
-                                        ISubmodelElementFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "statements"));
-                                        return null;
-                                    }
-                                }
+                                theStatements = ReadListOfISubmodelElement(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "entityType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property EntityType of an instance of class Entity " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "entityType"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property EntityType of an instance of class Entity, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textEntityType;
-                                try
-                                {
-                                    textEntityType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property EntityType of an instance of class Entity " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "entityType"));
-                                    return null;
-                                }
-
-                                theEntityType = Stringification.EntityTypeFromString(
-                                    textEntityType);
-
-                                if (theEntityType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property EntityType of an instance of class Entity " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textEntityType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "entityType"));
-                                    return null;
-                                }
+                                theEntityType = ReadEntityType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "globalAssetId":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theGlobalAssetId = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property GlobalAssetId of an instance of class Entity, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theGlobalAssetId = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property GlobalAssetId of an instance of class Entity " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "globalAssetId"));
-                                        return null;
-                                    }
-                                }
+                                theGlobalAssetId = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "specificAssetIds":
-                            {
-                                theSpecificAssetIds = new List<ISpecificAssetId>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSpecificAssetIds = ParseListOfClass<ISpecificAssetId>(
-                                        reader,
-                                        SpecificAssetIdFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "specificAssetIds"));
-                                        return null;
-                                    }
-                                }
+                                theSpecificAssetIds = ReadListOfISpecificAssetId(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Entity, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Entity " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Entity " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Entity " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -10143,7 +4315,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property EntityType has not been given " +
                         "in the XML representation of an instance of class Entity");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Entity(
@@ -10165,54 +4337,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Entity? EntityFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Entity from an XML element.
-            /// </summary>
-            internal static Aas.Entity? EntityFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Entity", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "entity")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Entity " +
-                        $"with element name entity, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Entity? result = (
-                    EntityFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Entity? EntityFromElement
-
-            /// <summary>
             /// Deserialize an instance of class EventPayload from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -10220,7 +4344,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.EventPayload? EventPayloadFromSequence(
+            internal static Aas.EventPayload EventPayloadFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -10245,277 +4369,82 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class EventPayload, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class EventPayload, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "source":
-                            {
-                                theSource = ReferenceFromSequence(
+                                theSource = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "source"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "sourceSemanticId":
-                            {
-                                theSourceSemanticId = ReferenceFromSequence(
+                                theSourceSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "sourceSemanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "observableReference":
-                            {
-                                theObservableReference = ReferenceFromSequence(
+                                theObservableReference = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "observableReference"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "observableSemanticId":
-                            {
-                                theObservableSemanticId = ReferenceFromSequence(
+                                theObservableSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "observableSemanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "topic":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theTopic = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Topic of an instance of class EventPayload, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theTopic = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Topic of an instance of class EventPayload " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "topic"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "subjectId":
-                            {
-                                theSubjectId = ReferenceFromSequence(
+                                theTopic = ReadString(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "subjectId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "subjectId":
+                                theSubjectId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "timeStamp":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theTimeStamp = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property TimeStamp of an instance of class EventPayload, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theTimeStamp = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property TimeStamp of an instance of class EventPayload " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "timeStamp"));
-                                        return null;
-                                    }
-                                }
+                                theTimeStamp = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "payload":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Payload of an instance of class EventPayload " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "payload"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Payload of an instance of class EventPayload, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        thePayload = DeserializeImplementation.ReadWholeContentAsBase64(
-                                        reader);
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Payload of an instance of class EventPayload " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "payload"));
-                                        return null;
-                                    }
-                                }
+                                thePayload = ReadBytes(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class EventPayload, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class EventPayload " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class EventPayload " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class EventPayload " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -10524,7 +4453,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Source has not been given " +
                         "in the XML representation of an instance of class EventPayload");
-                    return null;
+                    return default!;
                 }
 
                 if (theObservableReference == null)
@@ -10532,7 +4461,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ObservableReference has not been given " +
                         "in the XML representation of an instance of class EventPayload");
-                    return null;
+                    return default!;
                 }
 
                 if (theTimeStamp == null)
@@ -10540,7 +4469,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property TimeStamp has not been given " +
                         "in the XML representation of an instance of class EventPayload");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.EventPayload(
@@ -10561,86 +4490,18 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.EventPayload? EventPayloadFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class EventPayload from an XML element.
-            /// </summary>
-            internal static Aas.EventPayload? EventPayloadFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "EventPayload", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "eventPayload")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class EventPayload " +
-                        $"with element name eventPayload, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.EventPayload? result = (
-                    EventPayloadFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.EventPayload? EventPayloadFromElement
-
-            /// <summary>
             /// Deserialize an instance of IEventElement from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IEventElement? IEventElementFromElement(
+            internal static Aas.IEventElement IEventElementFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -10651,7 +4512,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IEventElement? IEventElementFromElement
 
@@ -10663,7 +4524,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.BasicEventElement? BasicEventElementFromSequence(
+            internal static Aas.BasicEventElement BasicEventElementFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -10697,585 +4558,118 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class BasicEventElement, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class BasicEventElement, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
+                                theExtensions = ReadListOfIExtension(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class BasicEventElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class BasicEventElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theSemanticId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "observed":
-                            {
-                                theObserved = ReferenceFromSequence(
+                                theObserved = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "observed"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "direction":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Direction of an instance of class BasicEventElement " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "direction"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Direction of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textDirection;
-                                try
-                                {
-                                    textDirection = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Direction of an instance of class BasicEventElement " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "direction"));
-                                    return null;
-                                }
-
-                                theDirection = Stringification.DirectionFromString(
-                                    textDirection);
-
-                                if (theDirection == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Direction of an instance of class BasicEventElement " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textDirection);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "direction"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "state":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property State of an instance of class BasicEventElement " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "state"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property State of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textState;
-                                try
-                                {
-                                    textState = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property State of an instance of class BasicEventElement " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "state"));
-                                    return null;
-                                }
-
-                                theState = Stringification.StateOfEventFromString(
-                                    textState);
-
-                                if (theState == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property State of an instance of class BasicEventElement " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textState);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "state"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "messageTopic":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theMessageTopic = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property MessageTopic of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theMessageTopic = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property MessageTopic of an instance of class BasicEventElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "messageTopic"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "messageBroker":
-                            {
-                                theMessageBroker = ReferenceFromSequence(
+                                theDirection = ReadDirection(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "messageBroker"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "state":
+                                theState = ReadStateOfEvent(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "messageTopic":
+                                theMessageTopic = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "messageBroker":
+                                theMessageBroker = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "lastUpdate":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theLastUpdate = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property LastUpdate of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theLastUpdate = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property LastUpdate of an instance of class BasicEventElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "lastUpdate"));
-                                        return null;
-                                    }
-                                }
+                                theLastUpdate = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "minInterval":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theMinInterval = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property MinInterval of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theMinInterval = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property MinInterval of an instance of class BasicEventElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "minInterval"));
-                                        return null;
-                                    }
-                                }
+                                theMinInterval = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "maxInterval":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theMaxInterval = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property MaxInterval of an instance of class BasicEventElement, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theMaxInterval = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property MaxInterval of an instance of class BasicEventElement " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "maxInterval"));
-                                        return null;
-                                    }
-                                }
+                                theMaxInterval = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class BasicEventElement, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class BasicEventElement " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class BasicEventElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class BasicEventElement " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -11284,7 +4678,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Observed has not been given " +
                         "in the XML representation of an instance of class BasicEventElement");
-                    return null;
+                    return default!;
                 }
 
                 if (theDirection == null)
@@ -11292,7 +4686,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Direction has not been given " +
                         "in the XML representation of an instance of class BasicEventElement");
-                    return null;
+                    return default!;
                 }
 
                 if (theState == null)
@@ -11300,7 +4694,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property State has not been given " +
                         "in the XML representation of an instance of class BasicEventElement");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.BasicEventElement(
@@ -11330,54 +4724,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.BasicEventElement? BasicEventElementFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class BasicEventElement from an XML element.
-            /// </summary>
-            internal static Aas.BasicEventElement? BasicEventElementFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "BasicEventElement", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "basicEventElement")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class BasicEventElement " +
-                        $"with element name basicEventElement, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.BasicEventElement? result = (
-                    BasicEventElementFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.BasicEventElement? BasicEventElementFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Operation from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -11385,7 +4731,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Operation? OperationFromSequence(
+            internal static Aas.Operation OperationFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -11414,366 +4760,98 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Operation, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Operation, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class Operation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class Operation " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class Operation, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class Operation " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "inputVariables":
-                            {
-                                theInputVariables = new List<IOperationVariable>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theInputVariables = ParseListOfClass<IOperationVariable>(
-                                        reader,
-                                        OperationVariableFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "inputVariables"));
-                                        return null;
-                                    }
-                                }
+                                theInputVariables = ReadListOfIOperationVariable(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "outputVariables":
-                            {
-                                theOutputVariables = new List<IOperationVariable>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theOutputVariables = ParseListOfClass<IOperationVariable>(
-                                        reader,
-                                        OperationVariableFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "outputVariables"));
-                                        return null;
-                                    }
-                                }
+                                theOutputVariables = ReadListOfIOperationVariable(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "inoutputVariables":
-                            {
-                                theInoutputVariables = new List<IOperationVariable>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theInoutputVariables = ParseListOfClass<IOperationVariable>(
-                                        reader,
-                                        OperationVariableFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "inoutputVariables"));
-                                        return null;
-                                    }
-                                }
+                                theInoutputVariables = ReadListOfIOperationVariable(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Operation, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Operation " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Operation " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Operation " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -11793,54 +4871,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Operation? OperationFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Operation from an XML element.
-            /// </summary>
-            internal static Aas.Operation? OperationFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Operation", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "operation")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Operation " +
-                        $"with element name operation, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Operation? result = (
-                    OperationFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Operation? OperationFromElement
-
-            /// <summary>
             /// Deserialize an instance of class OperationVariable from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -11848,7 +4878,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.OperationVariable? OperationVariableFromSequence(
+            internal static Aas.OperationVariable OperationVariableFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -11866,144 +4896,54 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class OperationVariable, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class OperationVariable, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property Value of an instance of class OperationVariable, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property Value of an instance of class OperationVariable, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // ISubmodelElementFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theValue = ISubmodelElementFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
+                                theValue = ReadISubmodelElement(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class OperationVariable, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class OperationVariable " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class OperationVariable " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class OperationVariable " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -12012,7 +4952,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Value has not been given " +
                         "in the XML representation of an instance of class OperationVariable");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.OperationVariable(
@@ -12022,54 +4962,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.OperationVariable? OperationVariableFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class OperationVariable from an XML element.
-            /// </summary>
-            internal static Aas.OperationVariable? OperationVariableFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "OperationVariable", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "operationVariable")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class OperationVariable " +
-                        $"with element name operationVariable, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.OperationVariable? result = (
-                    OperationVariableFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.OperationVariable? OperationVariableFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Capability from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -12077,7 +4969,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Capability? CapabilityFromSequence(
+            internal static Aas.Capability CapabilityFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -12103,303 +4995,86 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Capability, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Capability, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class Capability, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class Capability " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class Capability, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class Capability " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "semanticId":
-                            {
-                                theSemanticId = ReferenceFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "semanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "semanticId":
+                                theSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "supplementalSemanticIds":
-                            {
-                                theSupplementalSemanticIds = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSupplementalSemanticIds = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "supplementalSemanticIds"));
-                                        return null;
-                                    }
-                                }
+                                theSupplementalSemanticIds = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "qualifiers":
-                            {
-                                theQualifiers = new List<IQualifier>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theQualifiers = ParseListOfClass<IQualifier>(
-                                        reader,
-                                        QualifierFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "qualifiers"));
-                                        return null;
-                                    }
-                                }
+                                theQualifiers = ReadListOfIQualifier(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Capability, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Capability " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Capability " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Capability " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -12416,54 +5091,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Capability? CapabilityFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Capability from an XML element.
-            /// </summary>
-            internal static Aas.Capability? CapabilityFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Capability", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "capability")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Capability " +
-                        $"with element name capability, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Capability? result = (
-                    CapabilityFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Capability? CapabilityFromElement
-
-            /// <summary>
             /// Deserialize an instance of class ConceptDescription from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -12471,7 +5098,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.ConceptDescription? ConceptDescriptionFromSequence(
+            internal static Aas.ConceptDescription ConceptDescriptionFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -12497,318 +5124,86 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class ConceptDescription, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class ConceptDescription, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "extensions":
-                            {
-                                theExtensions = new List<IExtension>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theExtensions = ParseListOfClass<IExtension>(
-                                        reader,
-                                        ExtensionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "extensions"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "category":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theCategory = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Category of an instance of class ConceptDescription, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theCategory = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Category of an instance of class ConceptDescription " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "category"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "idShort":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdShort = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property IdShort of an instance of class ConceptDescription, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdShort = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property IdShort of an instance of class ConceptDescription " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "idShort"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "displayName":
-                            {
-                                theDisplayName = new List<ILangStringNameType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDisplayName = ParseListOfClass<ILangStringNameType>(
-                                        reader,
-                                        LangStringNameTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "displayName"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "description":
-                            {
-                                theDescription = new List<ILangStringTextType>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDescription = ParseListOfClass<ILangStringTextType>(
-                                        reader,
-                                        LangStringTextTypeFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "administration":
-                            {
-                                theAdministration = AdministrativeInformationFromSequence(
+                                theExtensions = ReadListOfIExtension(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "administration"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "category":
+                                theCategory = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "idShort":
+                                theIdShort = ReadString(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "displayName":
+                                theDisplayName = ReadListOfILangStringNameType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "description":
+                                theDescription = ReadListOfILangStringTextType(
+                                    reader, isEmptyProperty, out error);
+                                break;
+                            case "administration":
+                                theAdministration = ReadIAdministrativeInformation(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "id":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theId = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Id of an instance of class ConceptDescription, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theId = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Id of an instance of class ConceptDescription " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "id"));
-                                        return null;
-                                    }
-                                }
+                                theId = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "embeddedDataSpecifications":
-                            {
-                                theEmbeddedDataSpecifications = new List<IEmbeddedDataSpecification>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theEmbeddedDataSpecifications = ParseListOfClass<IEmbeddedDataSpecification>(
-                                        reader,
-                                        EmbeddedDataSpecificationFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "embeddedDataSpecifications"));
-                                        return null;
-                                    }
-                                }
+                                theEmbeddedDataSpecifications = ReadListOfIEmbeddedDataSpecification(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "isCaseOf":
-                            {
-                                theIsCaseOf = new List<IReference>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theIsCaseOf = ParseListOfClass<IReference>(
-                                        reader,
-                                        ReferenceFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "isCaseOf"));
-                                        return null;
-                                    }
-                                }
+                                theIsCaseOf = ReadListOfIReference(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class ConceptDescription, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ConceptDescription " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ConceptDescription " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ConceptDescription " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -12817,7 +5212,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Id has not been given " +
                         "in the XML representation of an instance of class ConceptDescription");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.ConceptDescription(
@@ -12835,54 +5230,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.ConceptDescription? ConceptDescriptionFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class ConceptDescription from an XML element.
-            /// </summary>
-            internal static Aas.ConceptDescription? ConceptDescriptionFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "ConceptDescription", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "conceptDescription")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class ConceptDescription " +
-                        $"with element name conceptDescription, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.ConceptDescription? result = (
-                    ConceptDescriptionFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.ConceptDescription? ConceptDescriptionFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Reference from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -12890,7 +5237,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Reference? ReferenceFromSequence(
+            internal static Aas.Reference ReferenceFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -12910,181 +5257,62 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Reference, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Reference, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "type":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Type of an instance of class Reference " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "type"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Type of an instance of class Reference, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textType;
-                                try
-                                {
-                                    textType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Type of an instance of class Reference " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "type"));
-                                    return null;
-                                }
-
-                                theType = Stringification.ReferenceTypesFromString(
-                                    textType);
-
-                                if (theType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Type of an instance of class Reference " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "type"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "referredSemanticId":
-                            {
-                                theReferredSemanticId = ReferenceFromSequence(
+                                theType = ReadReferenceTypes(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "referredSemanticId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "referredSemanticId":
+                                theReferredSemanticId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             case "keys":
-                            {
-                                theKeys = new List<IKey>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theKeys = ParseListOfClass<IKey>(
-                                        reader,
-                                        KeyFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "keys"));
-                                        return null;
-                                    }
-                                }
+                                theKeys = ReadListOfIKey(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Reference, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Reference " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Reference " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Reference " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -13093,7 +5321,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Type has not been given " +
                         "in the XML representation of an instance of class Reference");
-                    return null;
+                    return default!;
                 }
 
                 if (theKeys == null)
@@ -13101,7 +5329,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Keys has not been given " +
                         "in the XML representation of an instance of class Reference");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Reference(
@@ -13115,54 +5343,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Reference? ReferenceFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Reference from an XML element.
-            /// </summary>
-            internal static Aas.Reference? ReferenceFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Reference", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "reference")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Reference " +
-                        $"with element name reference, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Reference? result = (
-                    ReferenceFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Reference? ReferenceFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Key from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -13170,7 +5350,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Key? KeyFromSequence(
+            internal static Aas.Key KeyFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -13189,182 +5369,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Key, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Key, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "type":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Type of an instance of class Key " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "type"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Type of an instance of class Key, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textType;
-                                try
-                                {
-                                    textType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Type of an instance of class Key " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "type"));
-                                    return null;
-                                }
-
-                                theType = Stringification.KeyTypesFromString(
-                                    textType);
-
-                                if (theType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Type of an instance of class Key " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "type"));
-                                    return null;
-                                }
+                                theType = ReadKeyTypes(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class Key, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class Key " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Key, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Key " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Key " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Key " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -13373,7 +5429,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Type has not been given " +
                         "in the XML representation of an instance of class Key");
-                    return null;
+                    return default!;
                 }
 
                 if (theValue == null)
@@ -13381,7 +5437,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Value has not been given " +
                         "in the XML representation of an instance of class Key");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Key(
@@ -13394,86 +5450,18 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Key? KeyFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Key from an XML element.
-            /// </summary>
-            internal static Aas.Key? KeyFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Key", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "key")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Key " +
-                        $"with element name key, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Key? result = (
-                    KeyFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Key? KeyFromElement
-
-            /// <summary>
             /// Deserialize an instance of IAbstractLangString from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IAbstractLangString? IAbstractLangStringFromElement(
+            internal static Aas.IAbstractLangString IAbstractLangStringFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -13496,7 +5484,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IAbstractLangString? IAbstractLangStringFromElement
 
@@ -13508,7 +5496,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.LangStringNameType? LangStringNameTypeFromSequence(
+            internal static Aas.LangStringNameType LangStringNameTypeFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -13527,163 +5515,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class LangStringNameType, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class LangStringNameType, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "language":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theLanguage = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Language of an instance of class LangStringNameType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theLanguage = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Language of an instance of class LangStringNameType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "language"));
-                                        return null;
-                                    }
-                                }
+                                theLanguage = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "text":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theText = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Text of an instance of class LangStringNameType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theText = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Text of an instance of class LangStringNameType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "text"));
-                                        return null;
-                                    }
-                                }
+                                theText = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class LangStringNameType, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringNameType " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringNameType " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringNameType " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -13692,7 +5575,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Language has not been given " +
                         "in the XML representation of an instance of class LangStringNameType");
-                    return null;
+                    return default!;
                 }
 
                 if (theText == null)
@@ -13700,7 +5583,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Text has not been given " +
                         "in the XML representation of an instance of class LangStringNameType");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.LangStringNameType(
@@ -13713,54 +5596,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.LangStringNameType? LangStringNameTypeFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class LangStringNameType from an XML element.
-            /// </summary>
-            internal static Aas.LangStringNameType? LangStringNameTypeFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "LangStringNameType", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "langStringNameType")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class LangStringNameType " +
-                        $"with element name langStringNameType, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.LangStringNameType? result = (
-                    LangStringNameTypeFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.LangStringNameType? LangStringNameTypeFromElement
-
-            /// <summary>
             /// Deserialize an instance of class LangStringTextType from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -13768,7 +5603,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.LangStringTextType? LangStringTextTypeFromSequence(
+            internal static Aas.LangStringTextType LangStringTextTypeFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -13787,163 +5622,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class LangStringTextType, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class LangStringTextType, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "language":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theLanguage = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Language of an instance of class LangStringTextType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theLanguage = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Language of an instance of class LangStringTextType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "language"));
-                                        return null;
-                                    }
-                                }
+                                theLanguage = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "text":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theText = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Text of an instance of class LangStringTextType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theText = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Text of an instance of class LangStringTextType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "text"));
-                                        return null;
-                                    }
-                                }
+                                theText = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class LangStringTextType, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringTextType " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringTextType " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringTextType " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -13952,7 +5682,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Language has not been given " +
                         "in the XML representation of an instance of class LangStringTextType");
-                    return null;
+                    return default!;
                 }
 
                 if (theText == null)
@@ -13960,7 +5690,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Text has not been given " +
                         "in the XML representation of an instance of class LangStringTextType");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.LangStringTextType(
@@ -13973,54 +5703,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.LangStringTextType? LangStringTextTypeFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class LangStringTextType from an XML element.
-            /// </summary>
-            internal static Aas.LangStringTextType? LangStringTextTypeFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "LangStringTextType", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "langStringTextType")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class LangStringTextType " +
-                        $"with element name langStringTextType, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.LangStringTextType? result = (
-                    LangStringTextTypeFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.LangStringTextType? LangStringTextTypeFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Environment from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -14028,7 +5710,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Environment? EnvironmentFromSequence(
+            internal static Aas.Environment EnvironmentFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -14048,154 +5730,62 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class Environment, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Environment, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "assetAdministrationShells":
-                            {
-                                theAssetAdministrationShells = new List<IAssetAdministrationShell>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theAssetAdministrationShells = ParseListOfClass<IAssetAdministrationShell>(
-                                        reader,
-                                        AssetAdministrationShellFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "assetAdministrationShells"));
-                                        return null;
-                                    }
-                                }
+                                theAssetAdministrationShells = ReadListOfIAssetAdministrationShell(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "submodels":
-                            {
-                                theSubmodels = new List<ISubmodel>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSubmodels = ParseListOfClass<ISubmodel>(
-                                        reader,
-                                        SubmodelFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "submodels"));
-                                        return null;
-                                    }
-                                }
+                                theSubmodels = ReadListOfISubmodel(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "conceptDescriptions":
-                            {
-                                theConceptDescriptions = new List<IConceptDescription>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theConceptDescriptions = ParseListOfClass<IConceptDescription>(
-                                        reader,
-                                        ConceptDescriptionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "conceptDescriptions"));
-                                        return null;
-                                    }
-                                }
+                                theConceptDescriptions = ReadListOfIConceptDescription(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Environment, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Environment " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Environment " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Environment " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -14206,86 +5796,18 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.Environment? EnvironmentFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Environment from an XML element.
-            /// </summary>
-            internal static Aas.Environment? EnvironmentFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Environment", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "environment")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Environment " +
-                        $"with element name environment, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Environment? result = (
-                    EnvironmentFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Environment? EnvironmentFromElement
-
-            /// <summary>
             /// Deserialize an instance of IDataSpecificationContent from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IDataSpecificationContent? IDataSpecificationContentFromElement(
+            internal static Aas.IDataSpecificationContent IDataSpecificationContentFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -14296,7 +5818,7 @@ namespace AasCore.Aas3_0
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IDataSpecificationContent? IDataSpecificationContentFromElement
 
@@ -14308,7 +5830,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromSequence(
+            internal static Aas.EmbeddedDataSpecification EmbeddedDataSpecificationFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -14327,158 +5849,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class EmbeddedDataSpecification, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class EmbeddedDataSpecification, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "dataSpecification":
-                            {
-                                theDataSpecification = ReferenceFromSequence(
+                                theDataSpecification = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataSpecification"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "dataSpecificationContent":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property DataSpecificationContent of an instance of class EmbeddedDataSpecification, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property DataSpecificationContent of an instance of class EmbeddedDataSpecification, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // IDataSpecificationContentFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theDataSpecificationContent = IDataSpecificationContentFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataSpecificationContent"));
-                                    return null;
-                                }
+                                theDataSpecificationContent = ReadIDataSpecificationContent(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class EmbeddedDataSpecification, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class EmbeddedDataSpecification " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class EmbeddedDataSpecification " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class EmbeddedDataSpecification " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -14487,7 +5909,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property DataSpecification has not been given " +
                         "in the XML representation of an instance of class EmbeddedDataSpecification");
-                    return null;
+                    return default!;
                 }
 
                 if (theDataSpecificationContent == null)
@@ -14495,7 +5917,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property DataSpecificationContent has not been given " +
                         "in the XML representation of an instance of class EmbeddedDataSpecification");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.EmbeddedDataSpecification(
@@ -14508,54 +5930,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class EmbeddedDataSpecification from an XML element.
-            /// </summary>
-            internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "EmbeddedDataSpecification", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "embeddedDataSpecification")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class EmbeddedDataSpecification " +
-                        $"with element name embeddedDataSpecification, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.EmbeddedDataSpecification? result = (
-                    EmbeddedDataSpecificationFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.EmbeddedDataSpecification? EmbeddedDataSpecificationFromElement
-
-            /// <summary>
             /// Deserialize an instance of class LevelType from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -14563,7 +5937,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.LevelType? LevelTypeFromSequence(
+            internal static Aas.LevelType LevelTypeFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -14584,263 +5958,66 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class LevelType, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class LevelType, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "min":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Min of an instance of class LevelType " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "min"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Min of an instance of class LevelType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theMin = reader.ReadContentAsBoolean();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Min of an instance of class LevelType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "min"));
-                                        return null;
-                                    }
-                                }
+                                theMin = ReadBool(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "nom":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Nom of an instance of class LevelType " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "nom"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Nom of an instance of class LevelType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theNom = reader.ReadContentAsBoolean();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Nom of an instance of class LevelType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "nom"));
-                                        return null;
-                                    }
-                                }
+                                theNom = ReadBool(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "typ":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Typ of an instance of class LevelType " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "typ"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Typ of an instance of class LevelType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theTyp = reader.ReadContentAsBoolean();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Typ of an instance of class LevelType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "typ"));
-                                        return null;
-                                    }
-                                }
+                                theTyp = ReadBool(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "max":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Max of an instance of class LevelType " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "max"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Max of an instance of class LevelType, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theMax = reader.ReadContentAsBoolean();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Max of an instance of class LevelType " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "max"));
-                                        return null;
-                                    }
-                                }
+                                theMax = ReadBool(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class LevelType, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LevelType " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LevelType " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LevelType " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -14849,7 +6026,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Min has not been given " +
                         "in the XML representation of an instance of class LevelType");
-                    return null;
+                    return default!;
                 }
 
                 if (theNom == null)
@@ -14857,7 +6034,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Nom has not been given " +
                         "in the XML representation of an instance of class LevelType");
-                    return null;
+                    return default!;
                 }
 
                 if (theTyp == null)
@@ -14865,7 +6042,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Typ has not been given " +
                         "in the XML representation of an instance of class LevelType");
-                    return null;
+                    return default!;
                 }
 
                 if (theMax == null)
@@ -14873,7 +6050,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Max has not been given " +
                         "in the XML representation of an instance of class LevelType");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.LevelType(
@@ -14892,54 +6069,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.LevelType? LevelTypeFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class LevelType from an XML element.
-            /// </summary>
-            internal static Aas.LevelType? LevelTypeFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "LevelType", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "levelType")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class LevelType " +
-                        $"with element name levelType, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.LevelType? result = (
-                    LevelTypeFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.LevelType? LevelTypeFromElement
-
-            /// <summary>
             /// Deserialize an instance of class ValueReferencePair from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -14947,7 +6076,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.ValueReferencePair? ValueReferencePairFromSequence(
+            internal static Aas.ValueReferencePair ValueReferencePairFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -14966,141 +6095,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class ValueReferencePair, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class ValueReferencePair, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class ValueReferencePair, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class ValueReferencePair " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "valueId":
-                            {
-                                theValueId = ReferenceFromSequence(
+                                theValue = ReadString(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueId"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "valueId":
+                                theValueId = ReadIReference(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class ValueReferencePair, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ValueReferencePair " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ValueReferencePair " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ValueReferencePair " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -15109,7 +6155,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Value has not been given " +
                         "in the XML representation of an instance of class ValueReferencePair");
-                    return null;
+                    return default!;
                 }
 
                 if (theValueId == null)
@@ -15117,7 +6163,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ValueId has not been given " +
                         "in the XML representation of an instance of class ValueReferencePair");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.ValueReferencePair(
@@ -15130,54 +6176,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.ValueReferencePair? ValueReferencePairFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class ValueReferencePair from an XML element.
-            /// </summary>
-            internal static Aas.ValueReferencePair? ValueReferencePairFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "ValueReferencePair", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "valueReferencePair")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class ValueReferencePair " +
-                        $"with element name valueReferencePair, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.ValueReferencePair? result = (
-                    ValueReferencePairFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.ValueReferencePair? ValueReferencePairFromElement
-
-            /// <summary>
             /// Deserialize an instance of class ValueList from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -15185,7 +6183,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.ValueList? ValueListFromSequence(
+            internal static Aas.ValueList ValueListFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -15203,112 +6201,54 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class ValueList, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class ValueList, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "valueReferencePairs":
-                            {
-                                theValueReferencePairs = new List<IValueReferencePair>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theValueReferencePairs = ParseListOfClass<IValueReferencePair>(
-                                        reader,
-                                        ValueReferencePairFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "valueReferencePairs"));
-                                        return null;
-                                    }
-                                }
+                                theValueReferencePairs = ReadListOfIValueReferencePair(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class ValueList, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ValueList " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ValueList " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ValueList " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -15317,7 +6257,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property ValueReferencePairs has not been given " +
                         "in the XML representation of an instance of class ValueList");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.ValueList(
@@ -15327,54 +6267,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.ValueList? ValueListFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class ValueList from an XML element.
-            /// </summary>
-            internal static Aas.ValueList? ValueListFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "ValueList", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "valueList")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class ValueList " +
-                        $"with element name valueList, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.ValueList? result = (
-                    ValueListFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.ValueList? ValueListFromElement
-
-            /// <summary>
             /// Deserialize an instance of class LangStringPreferredNameTypeIec61360 from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -15382,7 +6274,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.LangStringPreferredNameTypeIec61360? LangStringPreferredNameTypeIec61360FromSequence(
+            internal static Aas.LangStringPreferredNameTypeIec61360 LangStringPreferredNameTypeIec61360FromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -15401,163 +6293,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class LangStringPreferredNameTypeIec61360, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class LangStringPreferredNameTypeIec61360, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "language":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theLanguage = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Language of an instance of class LangStringPreferredNameTypeIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theLanguage = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Language of an instance of class LangStringPreferredNameTypeIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "language"));
-                                        return null;
-                                    }
-                                }
+                                theLanguage = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "text":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theText = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Text of an instance of class LangStringPreferredNameTypeIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theText = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Text of an instance of class LangStringPreferredNameTypeIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "text"));
-                                        return null;
-                                    }
-                                }
+                                theText = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class LangStringPreferredNameTypeIec61360, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringPreferredNameTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringPreferredNameTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringPreferredNameTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -15566,7 +6353,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Language has not been given " +
                         "in the XML representation of an instance of class LangStringPreferredNameTypeIec61360");
-                    return null;
+                    return default!;
                 }
 
                 if (theText == null)
@@ -15574,7 +6361,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Text has not been given " +
                         "in the XML representation of an instance of class LangStringPreferredNameTypeIec61360");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.LangStringPreferredNameTypeIec61360(
@@ -15587,54 +6374,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.LangStringPreferredNameTypeIec61360? LangStringPreferredNameTypeIec61360FromSequence
 
             /// <summary>
-            /// Deserialize an instance of class LangStringPreferredNameTypeIec61360 from an XML element.
-            /// </summary>
-            internal static Aas.LangStringPreferredNameTypeIec61360? LangStringPreferredNameTypeIec61360FromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "LangStringPreferredNameTypeIec61360", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "langStringPreferredNameTypeIec61360")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class LangStringPreferredNameTypeIec61360 " +
-                        $"with element name langStringPreferredNameTypeIec61360, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.LangStringPreferredNameTypeIec61360? result = (
-                    LangStringPreferredNameTypeIec61360FromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.LangStringPreferredNameTypeIec61360? LangStringPreferredNameTypeIec61360FromElement
-
-            /// <summary>
             /// Deserialize an instance of class LangStringShortNameTypeIec61360 from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -15642,7 +6381,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.LangStringShortNameTypeIec61360? LangStringShortNameTypeIec61360FromSequence(
+            internal static Aas.LangStringShortNameTypeIec61360 LangStringShortNameTypeIec61360FromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -15661,163 +6400,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class LangStringShortNameTypeIec61360, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class LangStringShortNameTypeIec61360, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "language":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theLanguage = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Language of an instance of class LangStringShortNameTypeIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theLanguage = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Language of an instance of class LangStringShortNameTypeIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "language"));
-                                        return null;
-                                    }
-                                }
+                                theLanguage = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "text":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theText = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Text of an instance of class LangStringShortNameTypeIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theText = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Text of an instance of class LangStringShortNameTypeIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "text"));
-                                        return null;
-                                    }
-                                }
+                                theText = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class LangStringShortNameTypeIec61360, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringShortNameTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringShortNameTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringShortNameTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -15826,7 +6460,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Language has not been given " +
                         "in the XML representation of an instance of class LangStringShortNameTypeIec61360");
-                    return null;
+                    return default!;
                 }
 
                 if (theText == null)
@@ -15834,7 +6468,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Text has not been given " +
                         "in the XML representation of an instance of class LangStringShortNameTypeIec61360");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.LangStringShortNameTypeIec61360(
@@ -15847,54 +6481,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.LangStringShortNameTypeIec61360? LangStringShortNameTypeIec61360FromSequence
 
             /// <summary>
-            /// Deserialize an instance of class LangStringShortNameTypeIec61360 from an XML element.
-            /// </summary>
-            internal static Aas.LangStringShortNameTypeIec61360? LangStringShortNameTypeIec61360FromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "LangStringShortNameTypeIec61360", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "langStringShortNameTypeIec61360")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class LangStringShortNameTypeIec61360 " +
-                        $"with element name langStringShortNameTypeIec61360, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.LangStringShortNameTypeIec61360? result = (
-                    LangStringShortNameTypeIec61360FromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.LangStringShortNameTypeIec61360? LangStringShortNameTypeIec61360FromElement
-
-            /// <summary>
             /// Deserialize an instance of class LangStringDefinitionTypeIec61360 from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -15902,7 +6488,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.LangStringDefinitionTypeIec61360? LangStringDefinitionTypeIec61360FromSequence(
+            internal static Aas.LangStringDefinitionTypeIec61360 LangStringDefinitionTypeIec61360FromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -15921,163 +6507,58 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class LangStringDefinitionTypeIec61360, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class LangStringDefinitionTypeIec61360, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "language":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theLanguage = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Language of an instance of class LangStringDefinitionTypeIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theLanguage = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Language of an instance of class LangStringDefinitionTypeIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "language"));
-                                        return null;
-                                    }
-                                }
+                                theLanguage = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "text":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theText = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Text of an instance of class LangStringDefinitionTypeIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theText = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Text of an instance of class LangStringDefinitionTypeIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "text"));
-                                        return null;
-                                    }
-                                }
+                                theText = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class LangStringDefinitionTypeIec61360, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringDefinitionTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringDefinitionTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class LangStringDefinitionTypeIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -16086,7 +6567,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Language has not been given " +
                         "in the XML representation of an instance of class LangStringDefinitionTypeIec61360");
-                    return null;
+                    return default!;
                 }
 
                 if (theText == null)
@@ -16094,7 +6575,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property Text has not been given " +
                         "in the XML representation of an instance of class LangStringDefinitionTypeIec61360");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.LangStringDefinitionTypeIec61360(
@@ -16107,54 +6588,6 @@ namespace AasCore.Aas3_0
             }  // internal static Aas.LangStringDefinitionTypeIec61360? LangStringDefinitionTypeIec61360FromSequence
 
             /// <summary>
-            /// Deserialize an instance of class LangStringDefinitionTypeIec61360 from an XML element.
-            /// </summary>
-            internal static Aas.LangStringDefinitionTypeIec61360? LangStringDefinitionTypeIec61360FromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "LangStringDefinitionTypeIec61360", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "langStringDefinitionTypeIec61360")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class LangStringDefinitionTypeIec61360 " +
-                        $"with element name langStringDefinitionTypeIec61360, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.LangStringDefinitionTypeIec61360? result = (
-                    LangStringDefinitionTypeIec61360FromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.LangStringDefinitionTypeIec61360? LangStringDefinitionTypeIec61360FromElement
-
-            /// <summary>
             /// Deserialize an instance of class DataSpecificationIec61360 from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -16162,7 +6595,7 @@ namespace AasCore.Aas3_0
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromSequence(
+            internal static Aas.DataSpecificationIec61360 DataSpecificationIec61360FromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -16191,431 +6624,98 @@ namespace AasCore.Aas3_0
                             "Expected an XML element representing " +
                             "a property of an instance of class DataSpecificationIec61360, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class DataSpecificationIec61360, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "preferredName":
-                            {
-                                thePreferredName = new List<ILangStringPreferredNameTypeIec61360>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    thePreferredName = ParseListOfClass<ILangStringPreferredNameTypeIec61360>(
-                                        reader,
-                                        LangStringPreferredNameTypeIec61360FromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "preferredName"));
-                                        return null;
-                                    }
-                                }
+                                thePreferredName = ReadListOfILangStringPreferredNameTypeIec61360(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "shortName":
-                            {
-                                theShortName = new List<ILangStringShortNameTypeIec61360>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theShortName = ParseListOfClass<ILangStringShortNameTypeIec61360>(
-                                        reader,
-                                        LangStringShortNameTypeIec61360FromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "shortName"));
-                                        return null;
-                                    }
-                                }
+                                theShortName = ReadListOfILangStringShortNameTypeIec61360(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "unit":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theUnit = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Unit of an instance of class DataSpecificationIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theUnit = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Unit of an instance of class DataSpecificationIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "unit"));
-                                        return null;
-                                    }
-                                }
+                                theUnit = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "unitId":
-                            {
-                                theUnitId = ReferenceFromSequence(
+                                theUnitId = ReadIReference(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "unitId"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "sourceOfDefinition":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSourceOfDefinition = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SourceOfDefinition of an instance of class DataSpecificationIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSourceOfDefinition = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SourceOfDefinition of an instance of class DataSpecificationIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "sourceOfDefinition"));
-                                        return null;
-                                    }
-                                }
+                                theSourceOfDefinition = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "symbol":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSymbol = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Symbol of an instance of class DataSpecificationIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSymbol = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Symbol of an instance of class DataSpecificationIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "symbol"));
-                                        return null;
-                                    }
-                                }
+                                theSymbol = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "dataType":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property DataType of an instance of class DataSpecificationIec61360 " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataType"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property DataType of an instance of class DataSpecificationIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textDataType;
-                                try
-                                {
-                                    textDataType = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property DataType of an instance of class DataSpecificationIec61360 " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataType"));
-                                    return null;
-                                }
-
-                                theDataType = Stringification.DataTypeIec61360FromString(
-                                    textDataType);
-
-                                if (theDataType == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property DataType of an instance of class DataSpecificationIec61360 " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textDataType);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "dataType"));
-                                    return null;
-                                }
+                                theDataType = ReadDataTypeIec61360(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "definition":
-                            {
-                                theDefinition = new List<ILangStringDefinitionTypeIec61360>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theDefinition = ParseListOfClass<ILangStringDefinitionTypeIec61360>(
-                                        reader,
-                                        LangStringDefinitionTypeIec61360FromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "definition"));
-                                        return null;
-                                    }
-                                }
+                                theDefinition = ReadListOfILangStringDefinitionTypeIec61360(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "valueFormat":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValueFormat = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property ValueFormat of an instance of class DataSpecificationIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValueFormat = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property ValueFormat of an instance of class DataSpecificationIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "valueFormat"));
-                                        return null;
-                                    }
-                                }
+                                theValueFormat = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "valueList":
-                            {
-                                theValueList = ValueListFromSequence(
+                                theValueList = ReadIValueList(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "valueList"));
-                                    return null;
-                                }
                                 break;
-                            }
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theValue = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class DataSpecificationIec61360, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class DataSpecificationIec61360 " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
-                                break;
-                            }
-                            case "levelType":
-                            {
-                                theLevelType = LevelTypeFromSequence(
+                                theValue = ReadString(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "levelType"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "levelType":
+                                theLevelType = ReadILevelType(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class DataSpecificationIec61360, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class DataSpecificationIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class DataSpecificationIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class DataSpecificationIec61360 " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -16624,7 +6724,7 @@ namespace AasCore.Aas3_0
                     error = new Reporting.Error(
                         "The required property PreferredName has not been given " +
                         "in the XML representation of an instance of class DataSpecificationIec61360");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.DataSpecificationIec61360(
@@ -16643,54 +6743,6 @@ namespace AasCore.Aas3_0
                     theValue,
                     theLevelType);
             }  // internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class DataSpecificationIec61360 from an XML element.
-            /// </summary>
-            internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "DataSpecificationIec61360", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "dataSpecificationIec61360")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class DataSpecificationIec61360 " +
-                        $"with element name dataSpecificationIec61360, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.DataSpecificationIec61360? result = (
-                    DataSpecificationIec61360FromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.DataSpecificationIec61360? DataSpecificationIec61360FromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -16753,19 +6805,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IHasSemantics? result = (
-                    DeserializeImplementation.IHasSemanticsFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IHasSemantics result = DeserializeImplementation.IHasSemanticsFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -16790,19 +6839,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Extension? result = (
-                    DeserializeImplementation.ExtensionFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Extension result = DeserializeImplementation.ExtensionFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -16827,19 +6873,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IHasExtensions? result = (
-                    DeserializeImplementation.IHasExtensionsFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IHasExtensions result = DeserializeImplementation.IHasExtensionsFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -16864,19 +6907,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IReferable? result = (
-                    DeserializeImplementation.IReferableFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IReferable result = DeserializeImplementation.IReferableFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -16901,19 +6941,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IIdentifiable? result = (
-                    DeserializeImplementation.IIdentifiableFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IIdentifiable result = DeserializeImplementation.IIdentifiableFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -16938,19 +6975,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IHasKind? result = (
-                    DeserializeImplementation.IHasKindFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IHasKind result = DeserializeImplementation.IHasKindFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -16975,19 +7009,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IHasDataSpecification? result = (
-                    DeserializeImplementation.IHasDataSpecificationFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IHasDataSpecification result = DeserializeImplementation.IHasDataSpecificationFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17012,19 +7043,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.AdministrativeInformation? result = (
-                    DeserializeImplementation.AdministrativeInformationFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.AdministrativeInformation result = DeserializeImplementation.AdministrativeInformationFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17049,19 +7077,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IQualifiable? result = (
-                    DeserializeImplementation.IQualifiableFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IQualifiable result = DeserializeImplementation.IQualifiableFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17086,19 +7111,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Qualifier? result = (
-                    DeserializeImplementation.QualifierFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Qualifier result = DeserializeImplementation.QualifierFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17123,19 +7145,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.AssetAdministrationShell? result = (
-                    DeserializeImplementation.AssetAdministrationShellFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.AssetAdministrationShell result = DeserializeImplementation.AssetAdministrationShellFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17160,19 +7179,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.AssetInformation? result = (
-                    DeserializeImplementation.AssetInformationFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.AssetInformation result = DeserializeImplementation.AssetInformationFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17197,19 +7213,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Resource? result = (
-                    DeserializeImplementation.ResourceFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Resource result = DeserializeImplementation.ResourceFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17234,19 +7247,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.SpecificAssetId? result = (
-                    DeserializeImplementation.SpecificAssetIdFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.SpecificAssetId result = DeserializeImplementation.SpecificAssetIdFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17271,19 +7281,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Submodel? result = (
-                    DeserializeImplementation.SubmodelFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Submodel result = DeserializeImplementation.SubmodelFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17308,19 +7315,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ISubmodelElement? result = (
-                    DeserializeImplementation.ISubmodelElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ISubmodelElement result = DeserializeImplementation.ISubmodelElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17345,19 +7349,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IRelationshipElement? result = (
-                    DeserializeImplementation.IRelationshipElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IRelationshipElement result = DeserializeImplementation.IRelationshipElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17382,19 +7383,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.RelationshipElement? result = (
-                    DeserializeImplementation.RelationshipElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.RelationshipElement result = DeserializeImplementation.RelationshipElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17419,19 +7417,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.SubmodelElementList? result = (
-                    DeserializeImplementation.SubmodelElementListFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.SubmodelElementList result = DeserializeImplementation.SubmodelElementListFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17456,19 +7451,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.SubmodelElementCollection? result = (
-                    DeserializeImplementation.SubmodelElementCollectionFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.SubmodelElementCollection result = DeserializeImplementation.SubmodelElementCollectionFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17493,19 +7485,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IDataElement? result = (
-                    DeserializeImplementation.IDataElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IDataElement result = DeserializeImplementation.IDataElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17530,19 +7519,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Property? result = (
-                    DeserializeImplementation.PropertyFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Property result = DeserializeImplementation.PropertyFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17567,19 +7553,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.MultiLanguageProperty? result = (
-                    DeserializeImplementation.MultiLanguagePropertyFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.MultiLanguageProperty result = DeserializeImplementation.MultiLanguagePropertyFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17604,19 +7587,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Range? result = (
-                    DeserializeImplementation.RangeFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Range result = DeserializeImplementation.RangeFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17641,19 +7621,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ReferenceElement? result = (
-                    DeserializeImplementation.ReferenceElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ReferenceElement result = DeserializeImplementation.ReferenceElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17678,19 +7655,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Blob? result = (
-                    DeserializeImplementation.BlobFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Blob result = DeserializeImplementation.BlobFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17715,19 +7689,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.File? result = (
-                    DeserializeImplementation.FileFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.File result = DeserializeImplementation.FileFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17752,19 +7723,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.AnnotatedRelationshipElement? result = (
-                    DeserializeImplementation.AnnotatedRelationshipElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.AnnotatedRelationshipElement result = DeserializeImplementation.AnnotatedRelationshipElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17789,19 +7757,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Entity? result = (
-                    DeserializeImplementation.EntityFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Entity result = DeserializeImplementation.EntityFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17826,19 +7791,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.EventPayload? result = (
-                    DeserializeImplementation.EventPayloadFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.EventPayload result = DeserializeImplementation.EventPayloadFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17863,19 +7825,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IEventElement? result = (
-                    DeserializeImplementation.IEventElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IEventElement result = DeserializeImplementation.IEventElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17900,19 +7859,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.BasicEventElement? result = (
-                    DeserializeImplementation.BasicEventElementFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.BasicEventElement result = DeserializeImplementation.BasicEventElementFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17937,19 +7893,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Operation? result = (
-                    DeserializeImplementation.OperationFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Operation result = DeserializeImplementation.OperationFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -17974,19 +7927,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.OperationVariable? result = (
-                    DeserializeImplementation.OperationVariableFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.OperationVariable result = DeserializeImplementation.OperationVariableFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18011,19 +7961,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Capability? result = (
-                    DeserializeImplementation.CapabilityFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Capability result = DeserializeImplementation.CapabilityFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18048,19 +7995,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ConceptDescription? result = (
-                    DeserializeImplementation.ConceptDescriptionFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ConceptDescription result = DeserializeImplementation.ConceptDescriptionFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18085,19 +8029,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Reference? result = (
-                    DeserializeImplementation.ReferenceFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Reference result = DeserializeImplementation.ReferenceFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18122,19 +8063,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Key? result = (
-                    DeserializeImplementation.KeyFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Key result = DeserializeImplementation.KeyFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18159,19 +8097,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IAbstractLangString? result = (
-                    DeserializeImplementation.IAbstractLangStringFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IAbstractLangString result = DeserializeImplementation.IAbstractLangStringFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18196,19 +8131,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.LangStringNameType? result = (
-                    DeserializeImplementation.LangStringNameTypeFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.LangStringNameType result = DeserializeImplementation.LangStringNameTypeFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18233,19 +8165,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.LangStringTextType? result = (
-                    DeserializeImplementation.LangStringTextTypeFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.LangStringTextType result = DeserializeImplementation.LangStringTextTypeFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18270,19 +8199,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Environment? result = (
-                    DeserializeImplementation.EnvironmentFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Environment result = DeserializeImplementation.EnvironmentFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18307,19 +8233,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IDataSpecificationContent? result = (
-                    DeserializeImplementation.IDataSpecificationContentFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IDataSpecificationContent result = DeserializeImplementation.IDataSpecificationContentFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18344,19 +8267,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.EmbeddedDataSpecification? result = (
-                    DeserializeImplementation.EmbeddedDataSpecificationFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.EmbeddedDataSpecification result = DeserializeImplementation.EmbeddedDataSpecificationFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18381,19 +8301,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.LevelType? result = (
-                    DeserializeImplementation.LevelTypeFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.LevelType result = DeserializeImplementation.LevelTypeFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18418,19 +8335,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ValueReferencePair? result = (
-                    DeserializeImplementation.ValueReferencePairFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ValueReferencePair result = DeserializeImplementation.ValueReferencePairFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18455,19 +8369,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ValueList? result = (
-                    DeserializeImplementation.ValueListFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ValueList result = DeserializeImplementation.ValueListFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18492,19 +8403,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.LangStringPreferredNameTypeIec61360? result = (
-                    DeserializeImplementation.LangStringPreferredNameTypeIec61360FromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.LangStringPreferredNameTypeIec61360 result = DeserializeImplementation.LangStringPreferredNameTypeIec61360FromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18529,19 +8437,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.LangStringShortNameTypeIec61360? result = (
-                    DeserializeImplementation.LangStringShortNameTypeIec61360FromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.LangStringShortNameTypeIec61360 result = DeserializeImplementation.LangStringShortNameTypeIec61360FromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18566,19 +8471,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.LangStringDefinitionTypeIec61360? result = (
-                    DeserializeImplementation.LangStringDefinitionTypeIec61360FromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.LangStringDefinitionTypeIec61360 result = DeserializeImplementation.LangStringDefinitionTypeIec61360FromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -18603,19 +8505,16 @@ namespace AasCore.Aas3_0
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.DataSpecificationIec61360? result = (
-                    DeserializeImplementation.DataSpecificationIec61360FromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.DataSpecificationIec61360 result = DeserializeImplementation.DataSpecificationIec61360FromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/constrained_primitives/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/constrained_primitives/expected_output/dummy/xmlization.cs
@@ -102,531 +102,221 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to bool.
+            /// </summary>
+            private static bool ReadContentAsBoolean(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsBoolean();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to long.
+            /// </summary>
+            private static long ReadContentAsLong(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsLong();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to double.
+            /// </summary>
+            private static double ReadContentAsDouble(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsDouble();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to byte[].
+            /// </summary>
+            private static byte[] ReadContentAsBytes(Xml.XmlReader reader)
+            {
+                return ReadWholeContentAsBase64(
+                    reader);
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +333,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +341,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,17 +354,145 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
+
+            /// <summary>
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
+                Xml.XmlReader reader,
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                {
+                    return false;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<bool> ReadBool = (
+                AsText<bool>(ReadContentAsBoolean));
+
+            private static readonly ContentReader<long> ReadLong = (
+                AsText<long>(ReadContentAsLong));
+
+            private static readonly ContentReader<double> ReadDouble = (
+                AsText<double>(ReadContentAsDouble));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<byte[]> ReadBytes = (
+                AsText<byte[]>(ReadContentAsBytes, new byte[0]));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -684,7 +502,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -706,300 +524,70 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someBool":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeBool of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBool"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeBool of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeBool = reader.ReadContentAsBoolean();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeBool of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBool"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBool = ReadBool(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someInt":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeInt of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someInt"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeInt of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeInt = reader.ReadContentAsLong();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeInt of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someInt"));
-                                        return null;
-                                    }
-                                }
+                                theSomeInt = ReadLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someFloat":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeFloat of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someFloat"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeFloat of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeFloat = reader.ReadContentAsDouble();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeFloat of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someFloat"));
-                                        return null;
-                                    }
-                                }
+                                theSomeFloat = ReadDouble(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someString":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSomeString = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeString of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeString = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeString of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someString"));
-                                        return null;
-                                    }
-                                }
+                                theSomeString = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someBytes":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeBytes of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBytes"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeBytes of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeBytes = DeserializeImplementation.ReadWholeContentAsBase64(
-                                        reader);
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeBytes of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBytes"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBytes = ReadBytes(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1008,7 +596,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBool has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeInt == null)
@@ -1016,7 +604,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeInt has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeFloat == null)
@@ -1024,7 +612,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeFloat has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeString == null)
@@ -1032,7 +620,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeString has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeBytes == null)
@@ -1040,7 +628,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBytes has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -1060,54 +648,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -1170,19 +710,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/custom_serialization_names/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/custom_serialization_names/expected_output/dummy/xmlization.cs
@@ -102,531 +102,184 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +296,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +304,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,17 +317,133 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
+
+            /// <summary>
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
+                Xml.XmlReader reader,
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                {
+                    return false;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read an instance of class QueryCondition from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.QueryCondition> QueryConditionFromElement = (
+                AtElement<Aas.QueryCondition>(
+                    QueryConditionFromSequence, "queryCondition"));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
 
             /// <summary>
             /// Deserialize an instance of class QueryCondition from a sequence of XML elements.
@@ -684,7 +453,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.QueryCondition? QueryConditionFromSequence(
+            internal static Aas.QueryCondition QueryConditionFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -703,163 +472,58 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class QueryCondition, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class QueryCondition, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "eq":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theEq = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Eq of an instance of class QueryCondition, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theEq = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Eq of an instance of class QueryCondition " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "eq"));
-                                        return null;
-                                    }
-                                }
+                                theEq = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "not-eq":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theNotEq = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property NotEq of an instance of class QueryCondition, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theNotEq = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property NotEq of an instance of class QueryCondition " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "not-eq"));
-                                        return null;
-                                    }
-                                }
+                                theNotEq = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class QueryCondition, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class QueryCondition " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class QueryCondition " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class QueryCondition " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -867,54 +531,6 @@ namespace dummy
                     theEq,
                     theNotEq);
             }  // internal static Aas.QueryCondition? QueryConditionFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class QueryCondition from an XML element.
-            /// </summary>
-            internal static Aas.QueryCondition? QueryConditionFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "QueryCondition", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "queryCondition")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class QueryCondition " +
-                        $"with element name queryCondition, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.QueryCondition? result = (
-                    QueryConditionFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.QueryCondition? QueryConditionFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -977,19 +593,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.QueryCondition? result = (
-                    DeserializeImplementation.QueryConditionFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.QueryCondition result = DeserializeImplementation.QueryConditionFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/deep_class_hierarchy/expected_output/dummy/xmlization.cs
@@ -102,531 +102,193 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to long.
+            /// </summary>
+            private static long ReadContentAsLong(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsLong();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +305,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +313,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,51 +326,251 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
 
             /// <summary>
-            /// Deserialize an instance of INode from an XML element.
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
             /// </summary>
-            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.INode? INodeFromElement(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
                 Xml.XmlReader reader,
-                out Reporting.Error? error)
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
             {
                 error = null;
+                elementName = "";
+                isEmptyProperty = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
-                if (reader.EOF)
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
                 {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
+                    return false;
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
                 }
 
-                string elementName = TryElementName(
+                elementName = TryElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read a content whose value is dispatched by its own discriminator
+            /// element, such as an interface or a named union.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsElement<T>(
+                ElementReader<T> readFromElement
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing the value, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    // We need to skip the whitespace here in order to be able to look ahead
+                    // the discriminator element shortly.
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing the value, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    // Try to look ahead the discriminator name;
+                    // we need this name only for the error reporting below.
+                    // The de-serialization function will perform more sophisticated checks.
+                    string? discriminatorElementName = null;
+                    if (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        discriminatorElementName = reader.LocalName;
+                    }
+
+                    T result = readFromElement(reader, out error);
+                    if (error != null)
+                    {
+                        if (discriminatorElementName != null)
+                        {
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    discriminatorElementName));
+                        }
+                        return default!;
+                    }
+
+                    return result;
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class Branch from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Branch> BranchFromElement = (
+                AtElement<Aas.Branch>(
+                    BranchFromSequence, "branch"));
+
+            /// <summary>
+            /// Read an instance of class Leaf from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Leaf> LeafFromElement = (
+                AtElement<Aas.Leaf>(
+                    LeafFromSequence, "leaf"));
+
+            /// <summary>
+            /// Read an instance of class Blossom from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Blossom> BlossomFromElement = (
+                AtElement<Aas.Blossom>(
+                    BlossomFromSequence, "blossom"));
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            /// <summary>
+            /// Read an instance of class Container from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Container> ContainerFromElement = (
+                AtElement<Aas.Container>(
+                    ContainerFromSequence, "container"));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<long> ReadLong = (
+                AsText<long>(ReadContentAsLong));
+
+            private static readonly ContentReader<INode> ReadINode = (
+                AsElement<Aas.INode>(
+                    INodeFromElement));
+
+            private static readonly ContentReader<IBranch> ReadIBranch = (
+                AsElement<Aas.IBranch>(
+                    IBranchFromElement));
+
+            private static readonly ContentReader<ISomething> ReadISomething = (
+                SomethingFromSequence);
+
+            /// <summary>
+            /// Deserialize an instance of INode from an XML element.
+            /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            internal static Aas.INode INodeFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                string elementName = PeekElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return default!;
                 }
 
                 switch (elementName)
@@ -725,7 +587,7 @@ namespace dummy
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.INode? INodeFromElement
 
@@ -737,7 +599,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Branch? BranchFromSequence(
+            internal static Aas.Branch BranchFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -756,163 +618,58 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Branch, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Branch, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "identifier":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdentifier = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Identifier of an instance of class Branch, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdentifier = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Identifier of an instance of class Branch " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "identifier"));
-                                        return null;
-                                    }
-                                }
+                                theIdentifier = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theDescription = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Description of an instance of class Branch, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theDescription = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Description of an instance of class Branch " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Branch, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Branch " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Branch " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Branch " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -921,7 +678,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Identifier has not been given " +
                         "in the XML representation of an instance of class Branch");
-                    return null;
+                    return default!;
                 }
 
                 if (theDescription == null)
@@ -929,7 +686,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Description has not been given " +
                         "in the XML representation of an instance of class Branch");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Branch(
@@ -945,35 +702,15 @@ namespace dummy
             /// Deserialize an instance of IBranch from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IBranch? IBranchFromElement(
+            internal static Aas.IBranch IBranchFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -990,57 +727,9 @@ namespace dummy
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IBranch? IBranchFromElement
-
-            /// <summary>
-            /// Deserialize an instance of class Branch from an XML element.
-            /// </summary>
-            internal static Aas.Branch? BranchFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Branch", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "branch")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Branch " +
-                        $"with element name branch, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Branch? result = (
-                    BranchFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Branch? BranchFromElement
 
             /// <summary>
             /// Deserialize an instance of class Leaf from a sequence of XML elements.
@@ -1050,7 +739,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Leaf? LeafFromSequence(
+            internal static Aas.Leaf LeafFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1070,206 +759,62 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Leaf, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Leaf, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "identifier":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdentifier = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Identifier of an instance of class Leaf, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdentifier = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Identifier of an instance of class Leaf " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "identifier"));
-                                        return null;
-                                    }
-                                }
+                                theIdentifier = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theDescription = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Description of an instance of class Leaf, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theDescription = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Description of an instance of class Leaf " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Value of an instance of class Leaf " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class Leaf, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsLong();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class Leaf " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Leaf, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Leaf " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Leaf " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Leaf " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1278,7 +823,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Identifier has not been given " +
                         "in the XML representation of an instance of class Leaf");
-                    return null;
+                    return default!;
                 }
 
                 if (theDescription == null)
@@ -1286,7 +831,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Description has not been given " +
                         "in the XML representation of an instance of class Leaf");
-                    return null;
+                    return default!;
                 }
 
                 if (theValue == null)
@@ -1294,7 +839,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Value has not been given " +
                         "in the XML representation of an instance of class Leaf");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Leaf(
@@ -1313,35 +858,15 @@ namespace dummy
             /// Deserialize an instance of ILeaf from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.ILeaf? ILeafFromElement(
+            internal static Aas.ILeaf ILeafFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1355,57 +880,9 @@ namespace dummy
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.ILeaf? ILeafFromElement
-
-            /// <summary>
-            /// Deserialize an instance of class Leaf from an XML element.
-            /// </summary>
-            internal static Aas.Leaf? LeafFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Leaf", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "leaf")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Leaf " +
-                        $"with element name leaf, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Leaf? result = (
-                    LeafFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Leaf? LeafFromElement
 
             /// <summary>
             /// Deserialize an instance of class Blossom from a sequence of XML elements.
@@ -1415,7 +892,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Blossom? BlossomFromSequence(
+            internal static Aas.Blossom BlossomFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1436,242 +913,66 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Blossom, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Blossom, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "identifier":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theIdentifier = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Identifier of an instance of class Blossom, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theIdentifier = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Identifier of an instance of class Blossom " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "identifier"));
-                                        return null;
-                                    }
-                                }
+                                theIdentifier = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "description":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theDescription = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Description of an instance of class Blossom, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theDescription = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Description of an instance of class Blossom " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "description"));
-                                        return null;
-                                    }
-                                }
+                                theDescription = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "value":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Value of an instance of class Blossom " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "value"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Value of an instance of class Blossom, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theValue = reader.ReadContentAsLong();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Value of an instance of class Blossom " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "value"));
-                                        return null;
-                                    }
-                                }
+                                theValue = ReadLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "details":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theDetails = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Details of an instance of class Blossom, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theDetails = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Details of an instance of class Blossom " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "details"));
-                                        return null;
-                                    }
-                                }
+                                theDetails = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Blossom, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Blossom " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Blossom " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Blossom " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1680,7 +981,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Identifier has not been given " +
                         "in the XML representation of an instance of class Blossom");
-                    return null;
+                    return default!;
                 }
 
                 if (theDescription == null)
@@ -1688,7 +989,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Description has not been given " +
                         "in the XML representation of an instance of class Blossom");
-                    return null;
+                    return default!;
                 }
 
                 if (theValue == null)
@@ -1696,7 +997,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Value has not been given " +
                         "in the XML representation of an instance of class Blossom");
-                    return null;
+                    return default!;
                 }
 
                 if (theDetails == null)
@@ -1704,7 +1005,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Details has not been given " +
                         "in the XML representation of an instance of class Blossom");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Blossom(
@@ -1723,54 +1024,6 @@ namespace dummy
             }  // internal static Aas.Blossom? BlossomFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Blossom from an XML element.
-            /// </summary>
-            internal static Aas.Blossom? BlossomFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Blossom", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "blossom")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Blossom " +
-                        $"with element name blossom, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Blossom? result = (
-                    BlossomFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Blossom? BlossomFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1778,7 +1031,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1797,197 +1050,58 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someChoice":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property SomeChoice of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property SomeChoice of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // INodeFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theSomeChoice = INodeFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someChoice"));
-                                    return null;
-                                }
+                                theSomeChoice = ReadINode(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "somethingWithoutChoice":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property SomethingWithoutChoice of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property SomethingWithoutChoice of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // IBranchFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theSomethingWithoutChoice = IBranchFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "somethingWithoutChoice"));
-                                    return null;
-                                }
+                                theSomethingWithoutChoice = ReadIBranch(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1996,7 +1110,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeChoice has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomethingWithoutChoice == null)
@@ -2004,7 +1118,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomethingWithoutChoice has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -2017,54 +1131,6 @@ namespace dummy
             }  // internal static Aas.Something? SomethingFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Container from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -2072,7 +1138,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Container? ContainerFromSequence(
+            internal static Aas.Container ContainerFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -2091,158 +1157,58 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Container, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Container, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "node":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property Node of an instance of class Container, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property Node of an instance of class Container, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // INodeFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theNode = INodeFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "node"));
-                                    return null;
-                                }
-                                break;
-                            }
-                            case "something":
-                            {
-                                theSomething = SomethingFromSequence(
+                                theNode = ReadINode(
                                     reader, isEmptyProperty, out error);
-
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "something"));
-                                    return null;
-                                }
                                 break;
-                            }
+                            case "something":
+                                theSomething = ReadISomething(
+                                    reader, isEmptyProperty, out error);
+                                break;
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Container, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Container " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Container " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Container " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -2251,7 +1217,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Node has not been given " +
                         "in the XML representation of an instance of class Container");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomething == null)
@@ -2259,7 +1225,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Something has not been given " +
                         "in the XML representation of an instance of class Container");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Container(
@@ -2270,54 +1236,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Container? ContainerFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Container from an XML element.
-            /// </summary>
-            internal static Aas.Container? ContainerFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Container", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "container")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Container " +
-                        $"with element name container, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Container? result = (
-                    ContainerFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Container? ContainerFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -2380,19 +1298,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.INode? result = (
-                    DeserializeImplementation.INodeFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.INode result = DeserializeImplementation.INodeFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -2417,19 +1332,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IBranch? result = (
-                    DeserializeImplementation.IBranchFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IBranch result = DeserializeImplementation.IBranchFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -2454,19 +1366,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Branch? result = (
-                    DeserializeImplementation.BranchFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Branch result = DeserializeImplementation.BranchFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -2491,19 +1400,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ILeaf? result = (
-                    DeserializeImplementation.ILeafFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ILeaf result = DeserializeImplementation.ILeafFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -2528,19 +1434,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Leaf? result = (
-                    DeserializeImplementation.LeafFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Leaf result = DeserializeImplementation.LeafFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -2565,19 +1468,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Blossom? result = (
-                    DeserializeImplementation.BlossomFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Blossom result = DeserializeImplementation.BlossomFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -2602,19 +1502,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -2639,19 +1536,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Container? result = (
-                    DeserializeImplementation.ContainerFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Container result = DeserializeImplementation.ContainerFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/empty_class/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/empty_class/expected_output/dummy/xmlization.cs
@@ -102,531 +102,80 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +192,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +200,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,17 +213,76 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
+
+            /// <summary>
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -691,55 +299,7 @@ namespace dummy
             {
                 error = null;
                 return new Aas.Something();
-            }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
+            }  // internal static Aas.Something SomethingFromSequence
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -802,19 +362,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/enum/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/enum/expected_output/dummy/xmlization.cs
@@ -102,531 +102,184 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +296,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +304,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,53 +317,181 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
 
             /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.Result"/>.
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
             /// </summary>
-            private static Aas.Result? ReadVElementAsResult(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
                 Xml.XmlReader reader,
-                string elementName,
+                out string elementName,
+                out bool isEmptyProperty,
                 out Reporting.Error? error
                 )
             {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
                 {
-                    return null;
+                    return false;
                 }
 
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.Result? result = Stringification.ResultFromString(
-                    text);
-
-                if (result == null)
+                if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of Result: {result}");
-                    return null;
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
                 }
 
-                return result;
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
             }
+
+            /// <summary>
+            /// Parse the text of a literal of <typeparamref name="T" />.
+            /// </summary>
+            /// <remarks>
+            /// Every <c>Stringification.*FromString</c> has this shape, so it can be
+            /// passed on directly -- which is what lets an enumeration be read by one
+            /// generated combinator instead of one per enumeration.
+            /// </remarks>
+            /// <typeparam name="T">Enumeration to parse the text as</typeparam>
+            private delegate T? LiteralParser<T>(string text) where T : struct;
+
+            /// <summary>
+            /// Read a content and parse it as a literal of <typeparamref name="T" />
+            /// with <paramref name="parseLiteral" />.
+            /// </summary>
+            /// <typeparam name="T">Enumeration to parse the content as</typeparam>
+            private static ContentReader<T> AsEnum<T>(
+                LiteralParser<T> parseLiteral
+                ) where T : struct
+            {
+                ContentReader<string> readText = AsText<string>(ReadContentAsString, "");
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string text = readText(reader, isEmpty, out error);
+                    if (error != null)
+                    {
+                        return default;
+                    }
+
+                    T? result = parseLiteral(text);
+                    if (result == null)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as a literal " +
+                            $"of {typeof(T).Name}: {text}");
+                        return default;
+                    }
+
+                    return result.Value;
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<Result> ReadResult = (
+                AsEnum<Aas.Result>(
+                    Stringification.ResultFromString));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -720,7 +501,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -738,146 +519,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someResult":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeResult of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someResult"));
-                                    return null;
-                                }
-
-                                    if (reader.EOF)
-                                {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeResult of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                }
-
-                                string textSomeResult;
-                                try
-                                {
-                                    textSomeResult = reader.ReadContentAsString();
-                                }
-                                catch (System.FormatException exception)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeResult of an instance of class Something " +
-                                        $"could not be de-serialized as a string: {exception}");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someResult"));
-                                    return null;
-                                }
-
-                                theSomeResult = Stringification.ResultFromString(
-                                    textSomeResult);
-
-                                if (theSomeResult == null)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeResult of an instance of class Something " +
-                                        "could not be de-serialized from an unexpected enumeration literal: " +
-                                        textSomeResult);
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someResult"));
-                                    return null;
-                                }
+                                theSomeResult = ReadResult(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -886,7 +575,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeResult has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -894,54 +583,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -1004,19 +645,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_classes/expected_output/dummy/xmlization.cs
@@ -102,531 +102,193 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to long.
+            /// </summary>
+            private static long ReadContentAsLong(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsLong();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +305,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +313,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,51 +326,251 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
 
             /// <summary>
-            /// Deserialize an instance of IAbstractItem from an XML element.
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
             /// </summary>
-            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IAbstractItem? IAbstractItemFromElement(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
                 Xml.XmlReader reader,
-                out Reporting.Error? error)
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
             {
                 error = null;
+                elementName = "";
+                isEmptyProperty = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
-                if (reader.EOF)
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
                 {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
+                    return false;
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
                 }
 
-                string elementName = TryElementName(
+                elementName = TryElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read a sequence of list items with <paramref name="readItem" />,
+            /// stopping (without consuming) at the first non-element node.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a list type, whatever its items are and
+            /// however deeply it is nested, since the items are read through
+            /// an <see cref="ElementReader{T}" /> like any other element.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static List<T> ReadList<T>(
+                Xml.XmlReader reader,
+                ElementReader<T> readItem,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                var result = new List<T>();
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                int index = 0;
+                while (reader.NodeType == Xml.XmlNodeType.Element)
+                {
+                    T item = readItem(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(item);
+
+                    index++;
+                    SkipNoneWhitespaceAndComments(reader);
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a content as a list of items, each read with
+            /// <paramref name="readItem" />.
+            /// </summary>
+            /// <remarks>
+            /// A self-closing element represents an empty list.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static ContentReader<List<T>> AsList<T>(
+                ElementReader<T> readItem
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        return new List<T>();
+                    }
+
+                    return ReadList<T>(
+                        reader, readItem, out error);
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class SomeItem from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.SomeItem> SomeItemFromElement = (
+                AtElement<Aas.SomeItem>(
+                    SomeItemFromSequence, "someItem"));
+
+            /// <summary>
+            /// Read an instance of class AnotherItem from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.AnotherItem> AnotherItemFromElement = (
+                AtElement<Aas.AnotherItem>(
+                    AnotherItemFromSequence, "anotherItem"));
+
+            /// <summary>
+            /// Read an instance of class Simple from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Simple> SimpleFromElement = (
+                AtElement<Aas.Simple>(
+                    SimpleFromSequence, "simple"));
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<long> ReadLong = (
+                AsText<long>(ReadContentAsLong));
+
+            private static readonly ContentReader<List<IAbstractItem>> ReadListOfIAbstractItem = (
+                AsList<IAbstractItem>(
+                    IAbstractItemFromElement));
+
+            private static readonly ContentReader<List<ISimple>> ReadListOfISimple = (
+                AsList<ISimple>(
+                    SimpleFromElement));
+
+            /// <summary>
+            /// Deserialize an instance of IAbstractItem from an XML element.
+            /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            internal static Aas.IAbstractItem IAbstractItemFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                string elementName = PeekElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return default!;
                 }
 
                 switch (elementName)
@@ -722,7 +584,7 @@ namespace dummy
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IAbstractItem? IAbstractItemFromElement
 
@@ -734,7 +596,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.SomeItem? SomeItemFromSequence(
+            internal static Aas.SomeItem SomeItemFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -752,127 +614,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class SomeItem, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class SomeItem, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "name":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theName = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Name of an instance of class SomeItem, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theName = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Name of an instance of class SomeItem " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "name"));
-                                        return null;
-                                    }
-                                }
+                                theName = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class SomeItem, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SomeItem " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SomeItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SomeItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -881,7 +670,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Name has not been given " +
                         "in the XML representation of an instance of class SomeItem");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.SomeItem(
@@ -891,54 +680,6 @@ namespace dummy
             }  // internal static Aas.SomeItem? SomeItemFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class SomeItem from an XML element.
-            /// </summary>
-            internal static Aas.SomeItem? SomeItemFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "SomeItem", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "someItem")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class SomeItem " +
-                        $"with element name someItem, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.SomeItem? result = (
-                    SomeItemFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.SomeItem? SomeItemFromElement
-
-            /// <summary>
             /// Deserialize an instance of class AnotherItem from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -946,7 +687,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.AnotherItem? AnotherItemFromSequence(
+            internal static Aas.AnotherItem AnotherItemFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -964,134 +705,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class AnotherItem, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class AnotherItem, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "serialNumber":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SerialNumber of an instance of class AnotherItem " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "serialNumber"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SerialNumber of an instance of class AnotherItem, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSerialNumber = reader.ReadContentAsLong();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SerialNumber of an instance of class AnotherItem " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "serialNumber"));
-                                        return null;
-                                    }
-                                }
+                                theSerialNumber = ReadLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class AnotherItem, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnotherItem " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnotherItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnotherItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1100,7 +761,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SerialNumber has not been given " +
                         "in the XML representation of an instance of class AnotherItem");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.AnotherItem(
@@ -1110,54 +771,6 @@ namespace dummy
             }  // internal static Aas.AnotherItem? AnotherItemFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class AnotherItem from an XML element.
-            /// </summary>
-            internal static Aas.AnotherItem? AnotherItemFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "AnotherItem", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "anotherItem")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class AnotherItem " +
-                        $"with element name anotherItem, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.AnotherItem? result = (
-                    AnotherItemFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.AnotherItem? AnotherItemFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Simple from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1165,7 +778,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Simple? SimpleFromSequence(
+            internal static Aas.Simple SimpleFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1183,127 +796,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Simple, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Simple, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "name":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theName = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Name of an instance of class Simple, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theName = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Name of an instance of class Simple " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "name"));
-                                        return null;
-                                    }
-                                }
+                                theName = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Simple, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Simple " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Simple " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Simple " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1312,7 +852,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Name has not been given " +
                         "in the XML representation of an instance of class Simple");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Simple(
@@ -1322,54 +862,6 @@ namespace dummy
             }  // internal static Aas.Simple? SimpleFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Simple from an XML element.
-            /// </summary>
-            internal static Aas.Simple? SimpleFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Simple", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "simple")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Simple " +
-                        $"with element name simple, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Simple? result = (
-                    SimpleFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Simple? SimpleFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1377,7 +869,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1396,133 +888,58 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someItems":
-                            {
-                                theSomeItems = new List<IAbstractItem>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeItems = ParseListOfClass<IAbstractItem>(
-                                        reader,
-                                        IAbstractItemFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someItems"));
-                                        return null;
-                                    }
-                                }
+                                theSomeItems = ReadListOfIAbstractItem(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someSimples":
-                            {
-                                theSomeSimples = new List<ISimple>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeSimples = ParseListOfClass<ISimple>(
-                                        reader,
-                                        SimpleFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someSimples"));
-                                        return null;
-                                    }
-                                }
+                                theSomeSimples = ReadListOfISimple(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1531,7 +948,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeItems has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeSimples == null)
@@ -1539,7 +956,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeSimples has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -1550,54 +967,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -1660,19 +1029,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IAbstractItem? result = (
-                    DeserializeImplementation.IAbstractItemFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IAbstractItem result = DeserializeImplementation.IAbstractItemFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -1697,19 +1063,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.SomeItem? result = (
-                    DeserializeImplementation.SomeItemFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.SomeItem result = DeserializeImplementation.SomeItemFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -1734,19 +1097,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.AnotherItem? result = (
-                    DeserializeImplementation.AnotherItemFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.AnotherItem result = DeserializeImplementation.AnotherItemFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -1771,19 +1131,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Simple? result = (
-                    DeserializeImplementation.SimpleFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Simple result = DeserializeImplementation.SimpleFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -1808,19 +1165,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/list_of_constrained_primitives/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_constrained_primitives/expected_output/dummy/xmlization.cs
@@ -102,531 +102,184 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +296,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +304,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,17 +317,210 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
+
+            /// <summary>
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
+                Xml.XmlReader reader,
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                {
+                    return false;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read a sequence of list items with <paramref name="readItem" />,
+            /// stopping (without consuming) at the first non-element node.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a list type, whatever its items are and
+            /// however deeply it is nested, since the items are read through
+            /// an <see cref="ElementReader{T}" /> like any other element.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static List<T> ReadList<T>(
+                Xml.XmlReader reader,
+                ElementReader<T> readItem,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                var result = new List<T>();
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                int index = 0;
+                while (reader.NodeType == Xml.XmlNodeType.Element)
+                {
+                    T item = readItem(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(item);
+
+                    index++;
+                    SkipNoneWhitespaceAndComments(reader);
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a content as a list of items, each read with
+            /// <paramref name="readItem" />.
+            /// </summary>
+            /// <remarks>
+            /// A self-closing element represents an empty list.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static ContentReader<List<T>> AsList<T>(
+                ElementReader<T> readItem
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        return new List<T>();
+                    }
+
+                    return ReadList<T>(
+                        reader, readItem, out error);
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<List<string>> ReadListOfString = (
+                AsList<string>(
+                    AtElement(
+                        ReadString, "v")));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -684,7 +530,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -702,113 +548,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someNames":
-                            {
-                                theSomeNames = new List<string>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeNames = ParseListOfClass<string>(
-                                        reader,
-                                        (Xml.XmlReader itemReader, out Reporting.Error? itemError) => ReadVElementAsString(
-                                            itemReader, "v", out itemError),
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someNames"));
-                                        return null;
-                                    }
-                                }
+                                theSomeNames = ReadListOfString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -817,7 +604,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeNames has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -825,54 +612,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -935,19 +674,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/list_of_enums/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_enums/expected_output/dummy/xmlization.cs
@@ -102,531 +102,184 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +296,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +304,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,53 +317,258 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
 
             /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.Result"/>.
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
             /// </summary>
-            private static Aas.Result? ReadVElementAsResult(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
                 Xml.XmlReader reader,
-                string elementName,
+                out string elementName,
+                out bool isEmptyProperty,
                 out Reporting.Error? error
                 )
             {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
                 {
-                    return null;
+                    return false;
                 }
 
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.Result? result = Stringification.ResultFromString(
-                    text);
-
-                if (result == null)
+                if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of Result: {result}");
-                    return null;
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Parse the text of a literal of <typeparamref name="T" />.
+            /// </summary>
+            /// <remarks>
+            /// Every <c>Stringification.*FromString</c> has this shape, so it can be
+            /// passed on directly -- which is what lets an enumeration be read by one
+            /// generated combinator instead of one per enumeration.
+            /// </remarks>
+            /// <typeparam name="T">Enumeration to parse the text as</typeparam>
+            private delegate T? LiteralParser<T>(string text) where T : struct;
+
+            /// <summary>
+            /// Read a content and parse it as a literal of <typeparamref name="T" />
+            /// with <paramref name="parseLiteral" />.
+            /// </summary>
+            /// <typeparam name="T">Enumeration to parse the content as</typeparam>
+            private static ContentReader<T> AsEnum<T>(
+                LiteralParser<T> parseLiteral
+                ) where T : struct
+            {
+                ContentReader<string> readText = AsText<string>(ReadContentAsString, "");
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string text = readText(reader, isEmpty, out error);
+                    if (error != null)
+                    {
+                        return default;
+                    }
+
+                    T? result = parseLiteral(text);
+                    if (result == null)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as a literal " +
+                            $"of {typeof(T).Name}: {text}");
+                        return default;
+                    }
+
+                    return result.Value;
+                };
+            }
+
+            /// <summary>
+            /// Read a sequence of list items with <paramref name="readItem" />,
+            /// stopping (without consuming) at the first non-element node.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a list type, whatever its items are and
+            /// however deeply it is nested, since the items are read through
+            /// an <see cref="ElementReader{T}" /> like any other element.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static List<T> ReadList<T>(
+                Xml.XmlReader reader,
+                ElementReader<T> readItem,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                var result = new List<T>();
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                int index = 0;
+                while (reader.NodeType == Xml.XmlNodeType.Element)
+                {
+                    T item = readItem(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(item);
+
+                    index++;
+                    SkipNoneWhitespaceAndComments(reader);
                 }
 
                 return result;
             }
+
+            /// <summary>
+            /// Read a content as a list of items, each read with
+            /// <paramref name="readItem" />.
+            /// </summary>
+            /// <remarks>
+            /// A self-closing element represents an empty list.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static ContentReader<List<T>> AsList<T>(
+                ElementReader<T> readItem
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        return new List<T>();
+                    }
+
+                    return ReadList<T>(
+                        reader, readItem, out error);
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<Result> ReadResult = (
+                AsEnum<Aas.Result>(
+                    Stringification.ResultFromString));
+
+            private static readonly ContentReader<List<Result>> ReadListOfResult = (
+                AsList<Result>(
+                    AtElement(
+                        ReadResult, "v")));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -720,7 +578,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -738,113 +596,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someResults":
-                            {
-                                theSomeResults = new List<Result>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeResults = ParseListOfStruct<Result>(
-                                        reader,
-                                        (Xml.XmlReader itemReader, out Reporting.Error? itemError) => ReadVElementAsResult(
-                                            itemReader, "v", out itemError),
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someResults"));
-                                        return null;
-                                    }
-                                }
+                                theSomeResults = ReadListOfResult(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -853,7 +652,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeResults has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -861,54 +660,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -971,19 +722,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/list_of_primitives/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/list_of_primitives/expected_output/dummy/xmlization.cs
@@ -102,531 +102,221 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to bool.
+            /// </summary>
+            private static bool ReadContentAsBoolean(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsBoolean();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to long.
+            /// </summary>
+            private static long ReadContentAsLong(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsLong();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to double.
+            /// </summary>
+            private static double ReadContentAsDouble(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsDouble();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to byte[].
+            /// </summary>
+            private static byte[] ReadContentAsBytes(Xml.XmlReader reader)
+            {
+                return ReadWholeContentAsBase64(
+                    reader);
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +333,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +341,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,17 +354,242 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
+
+            /// <summary>
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
+                Xml.XmlReader reader,
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                {
+                    return false;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read a sequence of list items with <paramref name="readItem" />,
+            /// stopping (without consuming) at the first non-element node.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a list type, whatever its items are and
+            /// however deeply it is nested, since the items are read through
+            /// an <see cref="ElementReader{T}" /> like any other element.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static List<T> ReadList<T>(
+                Xml.XmlReader reader,
+                ElementReader<T> readItem,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                var result = new List<T>();
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                int index = 0;
+                while (reader.NodeType == Xml.XmlNodeType.Element)
+                {
+                    T item = readItem(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(item);
+
+                    index++;
+                    SkipNoneWhitespaceAndComments(reader);
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a content as a list of items, each read with
+            /// <paramref name="readItem" />.
+            /// </summary>
+            /// <remarks>
+            /// A self-closing element represents an empty list.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static ContentReader<List<T>> AsList<T>(
+                ElementReader<T> readItem
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        return new List<T>();
+                    }
+
+                    return ReadList<T>(
+                        reader, readItem, out error);
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<bool> ReadBool = (
+                AsText<bool>(ReadContentAsBoolean));
+
+            private static readonly ContentReader<List<bool>> ReadListOfBool = (
+                AsList<bool>(
+                    AtElement(
+                        ReadBool, "v")));
+
+            private static readonly ContentReader<long> ReadLong = (
+                AsText<long>(ReadContentAsLong));
+
+            private static readonly ContentReader<List<long>> ReadListOfLong = (
+                AsList<long>(
+                    AtElement(
+                        ReadLong, "v")));
+
+            private static readonly ContentReader<double> ReadDouble = (
+                AsText<double>(ReadContentAsDouble));
+
+            private static readonly ContentReader<List<double>> ReadListOfDouble = (
+                AsList<double>(
+                    AtElement(
+                        ReadDouble, "v")));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<List<string>> ReadListOfString = (
+                AsList<string>(
+                    AtElement(
+                        ReadString, "v")));
+
+            private static readonly ContentReader<byte[]> ReadBytes = (
+                AsText<byte[]>(ReadContentAsBytes, new byte[0]));
+
+            private static readonly ContentReader<List<byte[]>> ReadListOfBytes = (
+                AsList<byte[]>(
+                    AtElement(
+                        ReadBytes, "v")));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -684,7 +599,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -706,201 +621,70 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someBools":
-                            {
-                                theSomeBools = new List<bool>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeBools = ParseListOfStruct<bool>(
-                                        reader,
-                                        (Xml.XmlReader itemReader, out Reporting.Error? itemError) => ReadVElementAsBoolean(
-                                            itemReader, "v", out itemError),
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBools"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBools = ReadListOfBool(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someInts":
-                            {
-                                theSomeInts = new List<long>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeInts = ParseListOfStruct<long>(
-                                        reader,
-                                        (Xml.XmlReader itemReader, out Reporting.Error? itemError) => ReadVElementAsLong(
-                                            itemReader, "v", out itemError),
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someInts"));
-                                        return null;
-                                    }
-                                }
+                                theSomeInts = ReadListOfLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someFloats":
-                            {
-                                theSomeFloats = new List<double>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeFloats = ParseListOfStruct<double>(
-                                        reader,
-                                        (Xml.XmlReader itemReader, out Reporting.Error? itemError) => ReadVElementAsDouble(
-                                            itemReader, "v", out itemError),
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someFloats"));
-                                        return null;
-                                    }
-                                }
+                                theSomeFloats = ReadListOfDouble(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someStrings":
-                            {
-                                theSomeStrings = new List<string>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeStrings = ParseListOfClass<string>(
-                                        reader,
-                                        (Xml.XmlReader itemReader, out Reporting.Error? itemError) => ReadVElementAsString(
-                                            itemReader, "v", out itemError),
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someStrings"));
-                                        return null;
-                                    }
-                                }
+                                theSomeStrings = ReadListOfString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someBytes":
-                            {
-                                theSomeBytes = new List<byte[]>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theSomeBytes = ParseListOfClass<byte[]>(
-                                        reader,
-                                        (Xml.XmlReader itemReader, out Reporting.Error? itemError) => ReadVElementAsBytes(
-                                            itemReader, "v", out itemError),
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBytes"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBytes = ReadListOfBytes(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -909,7 +693,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBools has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeInts == null)
@@ -917,7 +701,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeInts has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeFloats == null)
@@ -925,7 +709,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeFloats has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeStrings == null)
@@ -933,7 +717,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeStrings has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeBytes == null)
@@ -941,7 +725,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBytes has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -961,54 +745,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -1071,19 +807,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/primitive_types/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/primitive_types/expected_output/dummy/xmlization.cs
@@ -102,531 +102,221 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to bool.
+            /// </summary>
+            private static bool ReadContentAsBoolean(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsBoolean();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to long.
+            /// </summary>
+            private static long ReadContentAsLong(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsLong();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to double.
+            /// </summary>
+            private static double ReadContentAsDouble(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsDouble();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to byte[].
+            /// </summary>
+            private static byte[] ReadContentAsBytes(Xml.XmlReader reader)
+            {
+                return ReadWholeContentAsBase64(
+                    reader);
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +333,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +341,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,17 +354,145 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
+
+            /// <summary>
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
+                Xml.XmlReader reader,
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                {
+                    return false;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<bool> ReadBool = (
+                AsText<bool>(ReadContentAsBoolean));
+
+            private static readonly ContentReader<long> ReadLong = (
+                AsText<long>(ReadContentAsLong));
+
+            private static readonly ContentReader<double> ReadDouble = (
+                AsText<double>(ReadContentAsDouble));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<byte[]> ReadBytes = (
+                AsText<byte[]>(ReadContentAsBytes, new byte[0]));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -684,7 +502,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -706,300 +524,70 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someBool":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeBool of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBool"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeBool of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeBool = reader.ReadContentAsBoolean();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeBool of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBool"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBool = ReadBool(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someInt":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeInt of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someInt"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeInt of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeInt = reader.ReadContentAsLong();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeInt of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someInt"));
-                                        return null;
-                                    }
-                                }
+                                theSomeInt = ReadLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someFloat":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeFloat of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someFloat"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeFloat of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeFloat = reader.ReadContentAsDouble();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeFloat of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someFloat"));
-                                        return null;
-                                    }
-                                }
+                                theSomeFloat = ReadDouble(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someString":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSomeString = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeString of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeString = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeString of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someString"));
-                                        return null;
-                                    }
-                                }
+                                theSomeString = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someBytes":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SomeBytes of an instance of class Something " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "someBytes"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeBytes of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeBytes = DeserializeImplementation.ReadWholeContentAsBase64(
-                                        reader);
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeBytes of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBytes"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBytes = ReadBytes(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1008,7 +596,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBool has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeInt == null)
@@ -1016,7 +604,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeInt has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeFloat == null)
@@ -1024,7 +612,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeFloat has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeString == null)
@@ -1032,7 +620,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeString has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeBytes == null)
@@ -1040,7 +628,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBytes has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -1060,54 +648,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -1170,19 +710,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/problematic_keywords/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/problematic_keywords/expected_output/dummy/xmlization.cs
@@ -102,531 +102,184 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +296,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +304,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,17 +317,133 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
+
+            /// <summary>
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
+            /// </summary>
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
+                string elementName
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
+            }
+
+            /// <summary>
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
+            /// </summary>
+            /// <remarks>
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
+            /// </remarks>
+            private static bool TryNextProperty(
+                Xml.XmlReader reader,
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                elementName = "";
+                isEmptyProperty = false;
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
+                {
+                    return false;
+                }
+
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
 
             /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
@@ -684,7 +453,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -705,235 +474,66 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "interface":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theInterface = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Interface of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theInterface = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Interface of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "interface"));
-                                        return null;
-                                    }
-                                }
+                                theInterface = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "type":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theType = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Type of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theType = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Type of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "type"));
-                                        return null;
-                                    }
-                                }
+                                theType = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "range":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theRange = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Range of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theRange = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Range of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "range"));
-                                        return null;
-                                    }
-                                }
+                                theRange = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "void":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theVoid = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Void of an instance of class Something, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theVoid = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Void of an instance of class Something " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "void"));
-                                        return null;
-                                    }
-                                }
+                                theVoid = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -942,7 +542,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Interface has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theType == null)
@@ -950,7 +550,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Type has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theRange == null)
@@ -958,7 +558,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Range has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theVoid == null)
@@ -966,7 +566,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Void has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -983,54 +583,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -1093,19 +645,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 

--- a/dev/test_data/main/csharp/expected/tuples/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/tuples/expected_output/dummy/xmlization.cs
@@ -102,531 +102,193 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to long.
+            /// </summary>
+            private static long ReadContentAsLong(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsLong();
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +305,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +313,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,424 +326,399 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
 
             /// <summary>
-            /// Read a single tuple item from the current position of the reader.
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
             /// </summary>
-            /// <remarks>
-            /// A tuple-typed property is parsed by <c>ParseTupleN</c> (see
-            /// <see cref="ParseTuple2{T0, T1}" /> for the arity-2 case, *etc.*), one
-            /// function shared by *every* tuple-typed property of a given arity,
-            /// regardless of which mix of reference and value types appears at each
-            /// position. If <c>ParseTupleN</c> demanded the same
-            /// <c>ClassItemDeserializer&lt;T&gt;</c>/<c>StructItemDeserializer&lt;T&gt;</c>
-            /// shape already used for list items (a nullable return, constrained to
-            /// <c>class</c> or <c>struct</c>), its own type parameters would need that
-            /// constraint fixed once per position -- which breaks the moment two
-            /// different tuple-typed properties of the same arity mix reference and
-            /// value types differently at the same position (<em>e.g.</em>,
-            /// <c>(string, long)</c> at one property and <c>(long, string)</c> at
-            /// another could not share one <c>ParseTuple2</c>).
-            ///
-            /// A single unconstrained <c>T? Method(Xml.XmlReader reader, out Reporting.Error? error)</c>
-            /// shape shared by both reference and value types does not work around this
-            /// either: for a value type, an unconstrained <c>T?</c> erases to plain
-            /// <c>T</c> (not <c>System.Nullable&lt;T&gt;</c>), so a method returning
-            /// <c>long?</c> can not even be assigned to it.
-            ///
-            /// <c>TupleItemDeserializer&lt;T&gt;</c> sidesteps the class/struct split
-            /// entirely by using an <c>out</c> parameter for the value instead of a
-            /// nullable return, at the cost of needing an adapter --
-            /// <see cref="AsTupleItemDeserializer{T}(ClassItemDeserializer{T})" /> --
-            /// to convert an existing item reader (such as a <c>ReadVElementAsString</c>
-            /// call or a class's own <c>...FromElement</c> method group) into one.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate void TupleItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out T value,
-                out Reporting.Error? error);
-
-            /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a reference-type item reader
-            /// as used for list-typed properties -- into a <see cref="TupleItemDeserializer{T}" />
-            /// for use in a tuple-typed property.
-            /// </summary>
-            /// <remarks>
-            /// See the remarks on <see cref="TupleItemDeserializer{T}" /> for why this
-            /// adapter -- rather than a shared constraint on <c>ParseTupleN</c> itself --
-            /// is necessary. This overload and its <c>StructItemDeserializer&lt;T&gt;</c>
-            /// counterpart are dispatched on the parameter's delegate type alone, so a
-            /// caller never has to pick between them by name; each encapsulates the
-            /// "unwrap the nullable result, or propagate the error" check exactly once,
-            /// mirroring how <see cref="ParseListOfClass{T}" />/
-            /// <see cref="ParseListOfStruct{T}" /> encapsulate the very same check
-            /// once for lists instead of repeating it at every call site.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                ClassItemDeserializer<T> deserializeItem
-                ) where T : class
-            {
-                return (
-                    Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
-                    {
-                        T? parsed = deserializeItem(reader, out error);
-                        if (error != null)
-                        {
-                            value = default!;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
-            }
-
-            /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a value-type item reader
-            /// as used for list-typed properties -- into a <see cref="TupleItemDeserializer{T}" />
-            /// for use in a tuple-typed property.
-            /// </summary>
-            /// <remarks>
-            /// See <see cref="AsTupleItemDeserializer{T}(ClassItemDeserializer{T})" />
-            /// for why this adapter is necessary.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                StructItemDeserializer<T> deserializeItem
-                ) where T : struct
-            {
-                return (
-                    Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
-                    {
-                        T? parsed = deserializeItem(reader, out error);
-                        if (error != null)
-                        {
-                            value = default;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
-            }
-
-            /// <summary>
-            /// Read a single tuple item wrapped in a reference-type-valued named
-            /// element such as <c>&lt;v1&gt;</c>, <c>&lt;v2&gt;</c>, *etc.*
-            /// </summary>
-            /// <remarks>
-            /// This is the counterpart of <see cref="ClassItemDeserializer{T}" /> for
-            /// item readers that additionally need the expected element name passed in
-            /// -- such as <see cref="ReadVElementAsString" /> -- since a tuple item, unlike
-            /// a list item, is wrapped in a positional element name instead of always
-            /// the fixed <c>&lt;v&gt;</c>.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? NamedClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Read a single tuple item wrapped in a value-type-valued named element
-            /// such as <c>&lt;v1&gt;</c>, <c>&lt;v2&gt;</c>, *etc.*
-            /// </summary>
-            /// <remarks>
-            /// See the remarks on <see cref="NamedClassItemDeserializer{T}" />.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? NamedStructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a reference-type item reader
-            /// which additionally expects the element name, such as
-            /// <see cref="ReadVElementAsString" /> -- into a
-            /// <see cref="TupleItemDeserializer{T}" /> bound to
-            /// <paramref name="elementName" />, for use in a tuple-typed property.
-            /// </summary>
-            /// <remarks>
-            /// See the remarks on <see cref="TupleItemDeserializer{T}" /> for why an
-            /// adapter is necessary in the first place. This overload additionally
-            /// closes over <paramref name="elementName" /> (<em>e.g.</em>, <c>"v1"</c>),
-            /// so that the tuple-typed property itself does not need to spell out a
-            /// lambda just to bind the positional element name.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                NamedClassItemDeserializer<T> deserializeItem,
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
                 string elementName
-                ) where T : class
+                )
             {
                 return (
                     Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
                     {
-                        T? parsed = deserializeItem(reader, elementName, out error);
-                        if (error != null)
-                        {
-                            value = default!;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
-            }
+                        return default!;
+                    }
 
-            /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a value-type item reader
-            /// which additionally expects the element name, such as
-            /// <see cref="ReadVElementAsLong" /> -- into a
-            /// <see cref="TupleItemDeserializer{T}" /> bound to
-            /// <paramref name="elementName" />, for use in a tuple-typed property.
-            /// </summary>
-            /// <remarks>
-            /// See <see cref="AsTupleItemDeserializer{T}(NamedClassItemDeserializer{T}, string)" />
-            /// for why this adapter is necessary.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                NamedStructItemDeserializer<T> deserializeItem,
-                string elementName
-                ) where T : struct
-            {
-                return (
-                    Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
+                    if (observedName != elementName)
                     {
-                        T? parsed = deserializeItem(reader, elementName, out error);
-                        if (error != null)
-                        {
-                            value = default;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
             }
 
             /// <summary>
-            /// Parse a tuple of 2 item(s) from the current position
-            /// of <paramref name="reader" />.
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
             /// </summary>
             /// <remarks>
-            /// This is shared by all the tuple-typed properties of arity 2.
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
             /// </remarks>
-            private static (T0, T1) ParseTuple2<T0, T1>(
+            private static bool TryNextProperty(
                 Xml.XmlReader reader,
-                TupleItemDeserializer<T0> deserializeItem0,
-                TupleItemDeserializer<T1> deserializeItem1,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                deserializeItem0(reader, out T0 item0, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            0));
-                    return default!;
-                }
-                SkipNoneWhitespaceAndComments(reader);
-
-                deserializeItem1(reader, out T1 item1, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            1));
-                    return default!;
-                }
-
-                return (
-                    item0,
-                    item1
-                );
-            }
-
-            /// <summary>
-            /// Parse a tuple of 6 item(s) from the current position
-            /// of <paramref name="reader" />.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the tuple-typed properties of arity 6.
-            /// </remarks>
-            private static (T0, T1, T2, T3, T4, T5) ParseTuple6<T0, T1, T2, T3, T4, T5>(
-                Xml.XmlReader reader,
-                TupleItemDeserializer<T0> deserializeItem0,
-                TupleItemDeserializer<T1> deserializeItem1,
-                TupleItemDeserializer<T2> deserializeItem2,
-                TupleItemDeserializer<T3> deserializeItem3,
-                TupleItemDeserializer<T4> deserializeItem4,
-                TupleItemDeserializer<T5> deserializeItem5,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                deserializeItem0(reader, out T0 item0, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            0));
-                    return default!;
-                }
-                SkipNoneWhitespaceAndComments(reader);
-
-                deserializeItem1(reader, out T1 item1, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            1));
-                    return default!;
-                }
-                SkipNoneWhitespaceAndComments(reader);
-
-                deserializeItem2(reader, out T2 item2, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            2));
-                    return default!;
-                }
-                SkipNoneWhitespaceAndComments(reader);
-
-                deserializeItem3(reader, out T3 item3, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            3));
-                    return default!;
-                }
-                SkipNoneWhitespaceAndComments(reader);
-
-                deserializeItem4(reader, out T4 item4, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            4));
-                    return default!;
-                }
-                SkipNoneWhitespaceAndComments(reader);
-
-                deserializeItem5(reader, out T5 item5, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            5));
-                    return default!;
-                }
-
-                return (
-                    item0,
-                    item1,
-                    item2,
-                    item3,
-                    item4,
-                    item5
-                );
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> and parse its content as a literal of
-            /// <see cref="Aas.Result"/>.
-            /// </summary>
-            private static Aas.Result? ReadVElementAsResult(
-                Xml.XmlReader reader,
-                string elementName,
+                out string elementName,
+                out bool isEmptyProperty,
                 out Reporting.Error? error
                 )
             {
-                string? text = ReadVElementAsString(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (text == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Text must not be null if error is null.");
-                }
-
-                Aas.Result? result = Stringification.ResultFromString(
-                    text);
-
-                if (result == null)
-                {
-                    error = new Reporting.Error(
-                        "The text could not be parsed as enumeration literal " +
-                        $"of Result: {result}");
-                    return null;
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Deserialize an instance of IAbstractItem from an XML element.
-            /// </summary>
-            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IAbstractItem? IAbstractItemFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
                 error = null;
+                elementName = "";
+                isEmptyProperty = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
-                if (reader.EOF)
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
                 {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
+                    return false;
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
                 }
 
-                string elementName = TryElementName(
+                elementName = TryElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
+            }
+
+            /// <summary>
+            /// Parse the text of a literal of <typeparamref name="T" />.
+            /// </summary>
+            /// <remarks>
+            /// Every <c>Stringification.*FromString</c> has this shape, so it can be
+            /// passed on directly -- which is what lets an enumeration be read by one
+            /// generated combinator instead of one per enumeration.
+            /// </remarks>
+            /// <typeparam name="T">Enumeration to parse the text as</typeparam>
+            private delegate T? LiteralParser<T>(string text) where T : struct;
+
+            /// <summary>
+            /// Read a content and parse it as a literal of <typeparamref name="T" />
+            /// with <paramref name="parseLiteral" />.
+            /// </summary>
+            /// <typeparam name="T">Enumeration to parse the content as</typeparam>
+            private static ContentReader<T> AsEnum<T>(
+                LiteralParser<T> parseLiteral
+                ) where T : struct
+            {
+                ContentReader<string> readText = AsText<string>(ReadContentAsString, "");
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string text = readText(reader, isEmpty, out error);
+                    if (error != null)
+                    {
+                        return default;
+                    }
+
+                    T? result = parseLiteral(text);
+                    if (result == null)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as a literal " +
+                            $"of {typeof(T).Name}: {text}");
+                        return default;
+                    }
+
+                    return result.Value;
+                };
+            }
+
+            /// <summary>
+            /// Read a content as a tuple of 2 item(s).
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a tuple type of arity 2 -- be it
+            /// a property, or a value nested in a list or in another tuple.
+            /// </remarks>
+            private static ContentReader<(T0, T1)> AsTuple2<T0, T1>(
+                ElementReader<T0> readItem0,
+                ElementReader<T1> readItem1
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmptyProperty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmptyProperty)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML content representing a tuple of 2 item(s), " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T0 item0 = readItem0(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                0));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T1 item1 = readItem1(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                1));
+                        return default!;
+                    }
+
+                    return (
+                        item0,
+                        item1
+                    );
+                };
+            }
+
+            /// <summary>
+            /// Read a content as a tuple of 6 item(s).
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a tuple type of arity 6 -- be it
+            /// a property, or a value nested in a list or in another tuple.
+            /// </remarks>
+            private static ContentReader<(T0, T1, T2, T3, T4, T5)> AsTuple6<T0, T1, T2, T3, T4, T5>(
+                ElementReader<T0> readItem0,
+                ElementReader<T1> readItem1,
+                ElementReader<T2> readItem2,
+                ElementReader<T3> readItem3,
+                ElementReader<T4> readItem4,
+                ElementReader<T5> readItem5
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmptyProperty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmptyProperty)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML content representing a tuple of 6 item(s), " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T0 item0 = readItem0(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                0));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T1 item1 = readItem1(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                1));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T2 item2 = readItem2(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                2));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T3 item3 = readItem3(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                3));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T4 item4 = readItem4(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                4));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T5 item5 = readItem5(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                5));
+                        return default!;
+                    }
+
+                    return (
+                        item0,
+                        item1,
+                        item2,
+                        item3,
+                        item4,
+                        item5
+                    );
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class SomeItem from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.SomeItem> SomeItemFromElement = (
+                AtElement<Aas.SomeItem>(
+                    SomeItemFromSequence, "someItem"));
+
+            /// <summary>
+            /// Read an instance of class AnotherItem from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.AnotherItem> AnotherItemFromElement = (
+                AtElement<Aas.AnotherItem>(
+                    AnotherItemFromSequence, "anotherItem"));
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<long> ReadLong = (
+                AsText<long>(ReadContentAsLong));
+
+            private static readonly ContentReader<(string, long)> ReadTupleOfStringLong = (
+                AsTuple2<string, long>(
+                    AtElement(
+                        ReadString, "v1"),
+                    AtElement(
+                        ReadLong, "v2")));
+
+            private static readonly ContentReader<(IAbstractItem, IAbstractItem)> ReadTupleOfIAbstractItemIAbstractItem = (
+                AsTuple2<IAbstractItem, IAbstractItem>(
+                    IAbstractItemFromElement,
+                    IAbstractItemFromElement));
+
+            private static readonly ContentReader<Result> ReadResult = (
+                AsEnum<Aas.Result>(
+                    Stringification.ResultFromString));
+
+            private static readonly ContentReader<(long, ISomeItem, IAbstractItem, ISomeItem, long, Result)> ReadTupleOfLongISomeItemIAbstractItemISomeItemLongResult = (
+                AsTuple6<long, ISomeItem, IAbstractItem, ISomeItem, long, Result>(
+                    AtElement(
+                        ReadLong, "v1"),
+                    SomeItemFromElement,
+                    IAbstractItemFromElement,
+                    SomeItemFromElement,
+                    AtElement(
+                        ReadLong, "v5"),
+                    AtElement(
+                        ReadResult, "v6")));
+
+            /// <summary>
+            /// Deserialize an instance of IAbstractItem from an XML element.
+            /// </summary>
+            [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
+            internal static Aas.IAbstractItem IAbstractItemFromElement(
+                Xml.XmlReader reader,
+                out Reporting.Error? error)
+            {
+                string elementName = PeekElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1095,7 +732,7 @@ namespace dummy
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IAbstractItem? IAbstractItemFromElement
 
@@ -1107,7 +744,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.SomeItem? SomeItemFromSequence(
+            internal static Aas.SomeItem SomeItemFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1125,127 +762,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class SomeItem, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class SomeItem, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "name":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theName = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property Name of an instance of class SomeItem, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theName = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property Name of an instance of class SomeItem " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "name"));
-                                        return null;
-                                    }
-                                }
+                                theName = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class SomeItem, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SomeItem " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SomeItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class SomeItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1254,7 +818,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Name has not been given " +
                         "in the XML representation of an instance of class SomeItem");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.SomeItem(
@@ -1264,54 +828,6 @@ namespace dummy
             }  // internal static Aas.SomeItem? SomeItemFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class SomeItem from an XML element.
-            /// </summary>
-            internal static Aas.SomeItem? SomeItemFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "SomeItem", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "someItem")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class SomeItem " +
-                        $"with element name someItem, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.SomeItem? result = (
-                    SomeItemFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.SomeItem? SomeItemFromElement
-
-            /// <summary>
             /// Deserialize an instance of class AnotherItem from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1319,7 +835,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.AnotherItem? AnotherItemFromSequence(
+            internal static Aas.AnotherItem AnotherItemFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1337,134 +853,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class AnotherItem, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class AnotherItem, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "serialNumber":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property SerialNumber of an instance of class AnotherItem " +
-                                        "can not be de-serialized from a self-closing element " +
-                                        "since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "serialNumber"));
-                                    return null;
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SerialNumber of an instance of class AnotherItem, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSerialNumber = reader.ReadContentAsLong();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SerialNumber of an instance of class AnotherItem " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "serialNumber"));
-                                        return null;
-                                    }
-                                }
+                                theSerialNumber = ReadLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class AnotherItem, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnotherItem " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnotherItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class AnotherItem " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1473,7 +909,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SerialNumber has not been given " +
                         "in the XML representation of an instance of class AnotherItem");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.AnotherItem(
@@ -1483,54 +919,6 @@ namespace dummy
             }  // internal static Aas.AnotherItem? AnotherItemFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class AnotherItem from an XML element.
-            /// </summary>
-            internal static Aas.AnotherItem? AnotherItemFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "AnotherItem", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "anotherItem")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class AnotherItem " +
-                        $"with element name anotherItem, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.AnotherItem? result = (
-                    AnotherItemFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.AnotherItem? AnotherItemFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1538,7 +926,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1558,182 +946,62 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "pair":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Pair can not be de-serialized " +
-                                        "from a self-closing element since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "pair"));
-                                    return null;
-                                }
-
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                thePair = ParseTuple2(
-                                    reader,
-                                    AsTupleItemDeserializer(ReadVElementAsString, "v1"),
-                                    AsTupleItemDeserializer(ReadVElementAsLong, "v2"),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "pair"));
-                                    return null;
-                                }
+                                thePair = ReadTupleOfStringLong(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "items":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Items can not be de-serialized " +
-                                        "from a self-closing element since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "items"));
-                                    return null;
-                                }
-
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                theItems = ParseTuple2(
-                                    reader,
-                                    AsTupleItemDeserializer(IAbstractItemFromElement),
-                                    AsTupleItemDeserializer(IAbstractItemFromElement),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "items"));
-                                    return null;
-                                }
+                                theItems = ReadTupleOfIAbstractItemIAbstractItem(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "tricky":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property Tricky can not be de-serialized " +
-                                        "from a self-closing element since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "tricky"));
-                                    return null;
-                                }
-
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                theTricky = ParseTuple6(
-                                    reader,
-                                    AsTupleItemDeserializer(ReadVElementAsLong, "v1"),
-                                    AsTupleItemDeserializer(SomeItemFromElement),
-                                    AsTupleItemDeserializer(IAbstractItemFromElement),
-                                    AsTupleItemDeserializer(SomeItemFromElement),
-                                    AsTupleItemDeserializer(ReadVElementAsLong, "v5"),
-                                    AsTupleItemDeserializer(ReadVElementAsResult, "v6"),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "tricky"));
-                                    return null;
-                                }
+                                theTricky = ReadTupleOfLongISomeItemIAbstractItemISomeItemLongResult(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1742,7 +1010,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Pair has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theItems == null)
@@ -1750,7 +1018,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Items has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theTricky == null)
@@ -1758,7 +1026,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property Tricky has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -1772,54 +1040,6 @@ namespace dummy
                          ?? throw new System.InvalidOperationException(
                             "Unexpected null, had to be handled before"));
             }  // internal static Aas.Something? SomethingFromSequence
-
-            /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
         }  // internal static class DeserializeImplementation
 
         /// <summary>
@@ -1882,19 +1102,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IAbstractItem? result = (
-                    DeserializeImplementation.IAbstractItemFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IAbstractItem result = DeserializeImplementation.IAbstractItemFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -1919,19 +1136,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.SomeItem? result = (
-                    DeserializeImplementation.SomeItemFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.SomeItem result = DeserializeImplementation.SomeItemFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -1956,19 +1170,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.AnotherItem? result = (
-                    DeserializeImplementation.AnotherItemFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.AnotherItem result = DeserializeImplementation.AnotherItemFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -1993,19 +1204,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 
@@ -2140,9 +1348,7 @@ namespace dummy
             /// first needs to be wrapped in its own positional <c>v1</c>, <c>v2</c>,
             /// *etc.* element -- this adapter closes over the element name so that
             /// a tuple-typed property does not need to spell out that wrapping (start
-            /// element/write value/end element) at every item, mirroring how
-            /// <see cref="AsTupleItemDeserializer{T}(NamedClassItemDeserializer{T}, string)" />
-            /// avoids the equivalent on the read side.
+            /// element/write value/end element) at every item.
             /// </remarks>
             /// <typeparam name="T">Type of the item to be written</typeparam>
             private delegate void NamedElementSerializer<T>(

--- a/dev/test_data/main/csharp/expected/unions/expected_output/dummy/xmlization.cs
+++ b/dev/test_data/main/csharp/expected/unions/expected_output/dummy/xmlization.cs
@@ -102,531 +102,184 @@ namespace dummy
             }
 
             /// <summary>
-            /// Consume a start element named <paramref name="expectedName" /> from
-            /// the reader and return whether it was a self-closing (empty) element.
+            /// Look ahead the name of the element at the current position of
+            /// <paramref name="reader" />, without consuming anything.
             /// </summary>
-            private static bool ReadVElement(
+            private static string PeekElementName(
                 Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, but got an end-of-file.");
-                    return false;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> start element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return false;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return false;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a <{expectedName}> element, " +
-                        $"but got an element {elementName}");
-                    return false;
-                }
-
-                bool isEmpty = reader.IsEmptyElement;
-
-                // We can consume now the start element.
-                reader.Read();
-                return isEmpty;
-            }
-
-            /// <summary>
-            /// Consume an end element named <paramref name="expectedName" /> from
-            /// the reader.
-            /// </summary>
-            private static void ReadVEndElement(
-                Xml.XmlReader reader,
-                string expectedName,
-                out Reporting.Error? error
-                )
-            {
-                if (reader.EOF) {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, but got an end-of-file.");
-                    return;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> end element, " +
-                        $"but got the node of type {reader.NodeType} " +
-                        $"with the value {reader.Value}");
-                    return;
-                }
-
-                string elementName = TryElementName(
-                    reader, out error);
-                if (error != null)
-                {
-                    return;
-                }
-                if (elementName != expectedName)
-                {
-                    error = new Reporting.Error(
-                        $"Expected a </{expectedName}> element, " +
-                        $"but got an end element {elementName}");
-                    return;
-                }
-
-                // We can consume now the end element.
-                reader.Read();
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as bool.
-            /// </summary>
-            private static bool? ReadVElementAsBoolean(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                bool? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing bool, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsBoolean();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as bool: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as long.
-            /// </summary>
-            private static long? ReadVElementAsLong(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                long? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing long, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsLong();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as long: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as double.
-            /// </summary>
-            private static double? ReadVElementAsDouble(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                double? result = null;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing double, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsDouble();
-                    }
-                    catch (System.Exception exception)
-                            when (exception is System.FormatException
-                                || exception is System.Xml.XmlException)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as double: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                if (result == null)
-                {
-                    throw new System.InvalidOperationException(
-                        "Unexpected result null when there is no error.");
-                }
-                return result;
-            }
-
-            /// <summary>
-            /// Read the content of a <c>&lt;v&gt;</c> element
-            /// and parse it as string.
-            /// </summary>
-            private static string? ReadVElementAsString(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                string result;
-                if (!isEmptyVElement)
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content representing string, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = reader.ReadContentAsString();
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            $"The content could not be de-serialized as string: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-                else
-                {
-                    result = "";
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a <c>&lt;v&gt;</c> element as base64-encoded bytes.
-            /// </summary>
-            private static byte[]? ReadVElementAsBytes(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                )
-            {
-                bool isEmptyVElement = ReadVElement(reader, elementName, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                byte[]? result;
-                if (isEmptyVElement)
-                {
-                    result = new byte[0];
-                }
-                else
-                {
-                    if (reader.EOF)
-                    {
-                        error = new Reporting.Error(
-                            "Expected an XML content with base64-encoded bytes, " +
-                            "but reached the end-of-file");
-                        return null;
-                    }
-
-                    try
-                    {
-                        result = ReadWholeContentAsBase64(reader);
-                    }
-                    catch (System.FormatException exception)
-                    {
-                        error = new Reporting.Error(
-                            "The content could not be de-serialized as " +
-                            $"base64-encoded bytes: {exception}");
-                        return null;
-                    }
-
-                    ReadVEndElement(reader, elementName, out error);
-                    if (error != null)
-                    {
-                        return null;
-                    }
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? ClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a reference type (<em>e.g.</em>, a string, a byte
-            /// array or a class instance).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfClass<T>(
-                Xml.XmlReader reader,
-                ClassItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : class
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read a single list item, positioned at its start element.
-            /// </summary>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? StructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Parse a sequence of list items with <paramref name="deserializeItem" />,
-            /// stopping (without consuming) at the first non-element node.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the list-typed properties whose items are
-            /// de-serialized into a value type (<em>e.g.</em>, a bool, a number or
-            /// an enumeration literal).
-            /// </remarks>
-            /// <typeparam name="T">Type of a single list item</typeparam>
-            private static List<T> ParseListOfStruct<T>(
-                Xml.XmlReader reader,
-                StructItemDeserializer<T> deserializeItem,
-                out Reporting.Error? error
-                ) where T : struct
-            {
-                error = null;
-                List<T> result = new List<T>();
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                int index = 0;
-                while (reader.NodeType == Xml.XmlNodeType.Element)
-                {
-                    T? item = deserializeItem(reader, out error);
-                    if (error != null)
-                    {
-                        error.PrependSegment(
-                            new Reporting.IndexSegment(
-                                index));
-                        return result;
-                    }
-
-                    result.Add(
-                        item
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected item null when error null"));
-
-                    index++;
-                    SkipNoneWhitespaceAndComments(reader);
-                }
-
-                return result;
-            }
-
-            /// <summary>
-            /// Read the opening tag of an XML element representing an instance of
-            /// <paramref name="className" />, without consuming its content.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
-            /// </remarks>
-            private static string ReadStartElementOfClass(
-                Xml.XmlReader reader,
-                string className,
-                out bool isEmptyElement,
                 out Reporting.Error? error
                 )
             {
                 error = null;
-                isEmptyElement = false;
 
                 SkipNoneWhitespaceAndComments(reader);
 
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
-                        "but reached the end-of-file");
+                        "Expected an XML element, but reached the end-of-file");
                     return "";
                 }
 
                 if (reader.NodeType != Xml.XmlNodeType.Element)
                 {
                     error = new Reporting.Error(
-                        $"Expected an XML element representing an instance of class {className}, " +
+                        "Expected an XML element, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return "";
                 }
 
-                string elementName = TryElementName(
+                return TryElementName(
                     reader, out error);
-                if (error != null)
-                {
-                    return "";
-                }
-
-                isEmptyElement = reader.IsEmptyElement;
-                return elementName;
             }
 
             /// <summary>
-            /// Consume the closing tag matching <paramref name="expectedElementName" />,
-            /// unless <paramref name="isEmptyElement" /> indicates that the element was
-            /// self-closing and thus has no separate closing tag to consume.
+            /// Read a single element, tags included, positioned at its start tag.
             /// </summary>
             /// <remarks>
-            /// This is shared by the de-serialization of every concrete class from
-            /// an XML element.
+            /// Return the value; on failure it is meaningless and
+            /// <paramref name="error" /> says why. A plain <c>T</c> rather than
+            /// a <c>T?</c>, so that one unconstrained delegate serves both the value
+            /// and the reference types.
+            ///
+            /// <typeparamref name="T" /> is covariant, so that the reader of
+            /// a concrete class can be used as the reader of an item of a list of
+            /// its interface. It is <c>internal</c> only because the readers of
+            /// the classes are, and a field may not be more accessible than its type.
             /// </remarks>
-            private static void ConsumeCloseTag(
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            internal delegate T ElementReader<out T>(
                 Xml.XmlReader reader,
-                string expectedElementName,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Read the content of an element, positioned after its start tag.
+            /// </summary>
+            /// <remarks>
+            /// Every value is read through this one shape, so that the reading can be
+            /// composed: an <c>As*</c> combinator turns a conversion, a literal parser,
+            /// an element reader or a list of them into one of these, and a class's own
+            /// <c>...FromSequence</c> already is one.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private delegate T ContentReader<T>(
+                Xml.XmlReader reader,
+                bool isEmpty,
+                out Reporting.Error? error);
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />.
+            /// </summary>
+            /// <typeparam name="T">Type to convert the content to</typeparam>
+            private delegate T ContentConverter<T>(Xml.XmlReader reader);
+
+            /// <summary>
+            /// Read the content between a start and an end tag and convert it
+            /// with <paramref name="readContent" />.
+            /// </summary>
+            /// <remarks>
+            /// This is the one skeleton for reading any content whatsoever -- of
+            /// a property, or of a <c>&lt;v&gt;</c> element of a list or a tuple item
+            /// (see <see cref="AtElement{T}" />). Only the conversion differs, so
+            /// only the conversion is passed in.
+            ///
+            /// On failure the returned value is meaningless; the caller checks
+            /// <paramref name="error" /> and bails out before ever reading it. That is
+            /// what lets this return a plain <c>T</c> -- a <c>T?</c> would have to be
+            /// split into a variant for the value and one for the reference types.
+            /// </remarks>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected an XML content representing {typeof(T).Name}, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    try
+                    {
+                        return readContent(reader);
+                    }
+                    catch (System.Exception exception)
+                            when (exception is System.FormatException
+                                || exception is System.Xml.XmlException)
+                    {
+                        error = new Reporting.Error(
+                            $"The content could not be de-serialized as {typeof(T).Name}: " +
+                            exception.Message);
+                        return default!;
+                    }
+                };
+            }
+
+            /// <summary>
+            /// Read the content between a start and an end tag, or return
+            /// <paramref name="whenEmpty" /> if the element was self-closing.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            [CodeAnalysis.SuppressMessage("ReSharper", "UnusedMember.Local")]
+            private static ContentReader<T> AsText<T>(
+                ContentConverter<T> readContent,
+                T whenEmpty
+                )
+            {
+                ContentReader<T> readText = AsText<T>(readContent);
+
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    if (isEmpty)
+                    {
+                        error = null;
+                        return whenEmpty;
+                    }
+
+                    return readText(reader, false, out error);
+                };
+            }
+
+            /// <summary>
+            /// Convert the content at the current position of <paramref name="reader" />
+            /// to string.
+            /// </summary>
+            private static string ReadContentAsString(Xml.XmlReader reader)
+            {
+                return reader.ReadContentAsString();
+            }
+
+            /// <summary>
+            /// Consume the end tag matching <paramref name="elementName" />, unless
+            /// <paramref name="isEmptyElement" /> tells that the element was
+            /// self-closing and thus has no end tag at all.
+            /// </summary>
+            private static void ConsumeEndElement(
+                Xml.XmlReader reader,
+                string elementName,
                 bool isEmptyElement,
                 out Reporting.Error? error
                 )
@@ -643,7 +296,7 @@ namespace dummy
                 if (reader.EOF)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         "but reached the end-of-file");
                     return;
                 }
@@ -651,7 +304,7 @@ namespace dummy
                 if (reader.NodeType != Xml.XmlNodeType.EndElement)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a node of type {reader.NodeType} " +
                         $"with value {reader.Value}");
                     return;
@@ -664,278 +317,428 @@ namespace dummy
                     return;
                 }
 
-                if (endElementName != expectedElementName)
+                if (endElementName != elementName)
                 {
                     error = new Reporting.Error(
-                        $"Expected a closing element </{expectedElementName}>, " +
+                        $"Expected a closing element </{elementName}>, " +
                         $"but got a closing element </{endElementName}>");
                     return;
                 }
 
-                // Skip the end element
+                // Consume the end tag.
                 reader.Read();
             }
 
             /// <summary>
-            /// Read a single tuple item from the current position of the reader.
+            /// Bind <paramref name="elementName" /> to <paramref name="readContent" />,
+            /// so that the result reads the whole element, tags included.
             /// </summary>
-            /// <remarks>
-            /// A tuple-typed property is parsed by <c>ParseTupleN</c> (see
-            /// <see cref="ParseTuple2{T0, T1}" /> for the arity-2 case, *etc.*), one
-            /// function shared by *every* tuple-typed property of a given arity,
-            /// regardless of which mix of reference and value types appears at each
-            /// position. If <c>ParseTupleN</c> demanded the same
-            /// <c>ClassItemDeserializer&lt;T&gt;</c>/<c>StructItemDeserializer&lt;T&gt;</c>
-            /// shape already used for list items (a nullable return, constrained to
-            /// <c>class</c> or <c>struct</c>), its own type parameters would need that
-            /// constraint fixed once per position -- which breaks the moment two
-            /// different tuple-typed properties of the same arity mix reference and
-            /// value types differently at the same position (<em>e.g.</em>,
-            /// <c>(string, long)</c> at one property and <c>(long, string)</c> at
-            /// another could not share one <c>ParseTuple2</c>).
-            ///
-            /// A single unconstrained <c>T? Method(Xml.XmlReader reader, out Reporting.Error? error)</c>
-            /// shape shared by both reference and value types does not work around this
-            /// either: for a value type, an unconstrained <c>T?</c> erases to plain
-            /// <c>T</c> (not <c>System.Nullable&lt;T&gt;</c>), so a method returning
-            /// <c>long?</c> can not even be assigned to it.
-            ///
-            /// <c>TupleItemDeserializer&lt;T&gt;</c> sidesteps the class/struct split
-            /// entirely by using an <c>out</c> parameter for the value instead of a
-            /// nullable return, at the cost of needing an adapter --
-            /// <see cref="AsTupleItemDeserializer{T}(ClassItemDeserializer{T})" /> --
-            /// to convert an existing item reader (such as a <c>ReadVElementAsString</c>
-            /// call or a class's own <c>...FromElement</c> method group) into one.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate void TupleItemDeserializer<T>(
-                Xml.XmlReader reader,
-                out T value,
-                out Reporting.Error? error);
-
-            /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a reference-type item reader
-            /// as used for list-typed properties -- into a <see cref="TupleItemDeserializer{T}" />
-            /// for use in a tuple-typed property.
-            /// </summary>
-            /// <remarks>
-            /// See the remarks on <see cref="TupleItemDeserializer{T}" /> for why this
-            /// adapter -- rather than a shared constraint on <c>ParseTupleN</c> itself --
-            /// is necessary. This overload and its <c>StructItemDeserializer&lt;T&gt;</c>
-            /// counterpart are dispatched on the parameter's delegate type alone, so a
-            /// caller never has to pick between them by name; each encapsulates the
-            /// "unwrap the nullable result, or propagate the error" check exactly once,
-            /// mirroring how <see cref="ParseListOfClass{T}" />/
-            /// <see cref="ParseListOfStruct{T}" /> encapsulate the very same check
-            /// once for lists instead of repeating it at every call site.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                ClassItemDeserializer<T> deserializeItem
-                ) where T : class
-            {
-                return (
-                    Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
-                    {
-                        T? parsed = deserializeItem(reader, out error);
-                        if (error != null)
-                        {
-                            value = default!;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
-            }
-
-            /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a value-type item reader
-            /// as used for list-typed properties -- into a <see cref="TupleItemDeserializer{T}" />
-            /// for use in a tuple-typed property.
-            /// </summary>
-            /// <remarks>
-            /// See <see cref="AsTupleItemDeserializer{T}(ClassItemDeserializer{T})" />
-            /// for why this adapter is necessary.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                StructItemDeserializer<T> deserializeItem
-                ) where T : struct
-            {
-                return (
-                    Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
-                    {
-                        T? parsed = deserializeItem(reader, out error);
-                        if (error != null)
-                        {
-                            value = default;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
-            }
-
-            /// <summary>
-            /// Read a single tuple item wrapped in a reference-type-valued named
-            /// element such as <c>&lt;v1&gt;</c>, <c>&lt;v2&gt;</c>, *etc.*
-            /// </summary>
-            /// <remarks>
-            /// This is the counterpart of <see cref="ClassItemDeserializer{T}" /> for
-            /// item readers that additionally need the expected element name passed in
-            /// -- such as <see cref="ReadVElementAsString" /> -- since a tuple item, unlike
-            /// a list item, is wrapped in a positional element name instead of always
-            /// the fixed <c>&lt;v&gt;</c>.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? NamedClassItemDeserializer<T>(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                ) where T : class;
-
-            /// <summary>
-            /// Read a single tuple item wrapped in a value-type-valued named element
-            /// such as <c>&lt;v1&gt;</c>, <c>&lt;v2&gt;</c>, *etc.*
-            /// </summary>
-            /// <remarks>
-            /// See the remarks on <see cref="NamedClassItemDeserializer{T}" />.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private delegate T? NamedStructItemDeserializer<T>(
-                Xml.XmlReader reader,
-                string elementName,
-                out Reporting.Error? error
-                ) where T : struct;
-
-            /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a reference-type item reader
-            /// which additionally expects the element name, such as
-            /// <see cref="ReadVElementAsString" /> -- into a
-            /// <see cref="TupleItemDeserializer{T}" /> bound to
-            /// <paramref name="elementName" />, for use in a tuple-typed property.
-            /// </summary>
-            /// <remarks>
-            /// See the remarks on <see cref="TupleItemDeserializer{T}" /> for why an
-            /// adapter is necessary in the first place. This overload additionally
-            /// closes over <paramref name="elementName" /> (<em>e.g.</em>, <c>"v1"</c>),
-            /// so that the tuple-typed property itself does not need to spell out a
-            /// lambda just to bind the positional element name.
-            /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                NamedClassItemDeserializer<T> deserializeItem,
+            /// <typeparam name="T">Type of the parsed value</typeparam>
+            private static ElementReader<T> AtElement<T>(
+                ContentReader<T> readContent,
                 string elementName
-                ) where T : class
+                )
             {
                 return (
                     Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
+                    out Reporting.Error? error
+                ) =>
+                {
+                    string observedName = PeekElementName(
+                        reader, out error);
+                    if (error != null)
                     {
-                        T? parsed = deserializeItem(reader, elementName, out error);
-                        if (error != null)
-                        {
-                            value = default!;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
+                        return default!;
+                    }
+
+                    if (observedName != elementName)
+                    {
+                        error = new Reporting.Error(
+                            $"Expected a <{elementName}> element, " +
+                            $"but got a <{observedName}> element");
+                        return default!;
+                    }
+
+                    bool isEmptyElement = reader.IsEmptyElement;
+
+                    // Consume the start tag and go to the content.
+                    reader.Read();
+
+                    T value = readContent(reader, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    ConsumeEndElement(
+                        reader, elementName, isEmptyElement, out error);
+                    if (error != null)
+                    {
+                        return default!;
+                    }
+
+                    return value;
+                };
             }
 
             /// <summary>
-            /// Adapt <paramref name="deserializeItem" /> -- a value-type item reader
-            /// which additionally expects the element name, such as
-            /// <see cref="ReadVElementAsLong" /> -- into a
-            /// <see cref="TupleItemDeserializer{T}" /> bound to
-            /// <paramref name="elementName" />, for use in a tuple-typed property.
+            /// Read the start tag of the next property of a sequence and return whether
+            /// there was one.
             /// </summary>
             /// <remarks>
-            /// See <see cref="AsTupleItemDeserializer{T}(NamedClassItemDeserializer{T}, string)" />
-            /// for why this adapter is necessary.
+            /// A sequence ends at the end tag of the enclosing element or at the end of
+            /// the file, which is not a failure -- when this returns <c>false</c>,
+            /// <paramref name="error" /> tells the two apart.
+            ///
+            /// The start tag is consumed, so the reader is left at the content of
+            /// the property.
             /// </remarks>
-            /// <typeparam name="T">Type of the parsed item</typeparam>
-            private static TupleItemDeserializer<T> AsTupleItemDeserializer<T>(
-                NamedStructItemDeserializer<T> deserializeItem,
-                string elementName
-                ) where T : struct
-            {
-                return (
-                    Xml.XmlReader reader,
-                    out T value,
-                    out Reporting.Error? error) =>
-                    {
-                        T? parsed = deserializeItem(reader, elementName, out error);
-                        if (error != null)
-                        {
-                            value = default;
-                            return;
-                        }
-                        value = parsed
-                            ?? throw new System.InvalidOperationException(
-                                "Unexpected result null when error is null");
-                    };
-            }
-
-            /// <summary>
-            /// Parse a tuple of 3 item(s) from the current position
-            /// of <paramref name="reader" />.
-            /// </summary>
-            /// <remarks>
-            /// This is shared by all the tuple-typed properties of arity 3.
-            /// </remarks>
-            private static (T0, T1, T2) ParseTuple3<T0, T1, T2>(
+            private static bool TryNextProperty(
                 Xml.XmlReader reader,
-                TupleItemDeserializer<T0> deserializeItem0,
-                TupleItemDeserializer<T1> deserializeItem1,
-                TupleItemDeserializer<T2> deserializeItem2,
-                out Reporting.Error? error)
+                out string elementName,
+                out bool isEmptyProperty,
+                out Reporting.Error? error
+                )
             {
                 error = null;
+                elementName = "";
+                isEmptyProperty = false;
 
-                deserializeItem0(reader, out T0 item0, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            0));
-                    return default!;
-                }
                 SkipNoneWhitespaceAndComments(reader);
 
-                deserializeItem1(reader, out T1 item1, out error);
-                if (error != null)
+                if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
                 {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            1));
-                    return default!;
-                }
-                SkipNoneWhitespaceAndComments(reader);
-
-                deserializeItem2(reader, out T2 item2, out error);
-                if (error != null)
-                {
-                    error.PrependSegment(
-                        new Reporting.IndexSegment(
-                            2));
-                    return default!;
+                    return false;
                 }
 
-                return (
-                    item0,
-                    item1,
-                    item2
-                );
+                if (reader.NodeType != Xml.XmlNodeType.Element)
+                {
+                    error = new Reporting.Error(
+                        "Expected an XML start element representing a property, " +
+                        $"but got the node of type {reader.NodeType} " +
+                        $"with the value {reader.Value}");
+                    return false;
+                }
+
+                elementName = TryElementName(
+                    reader, out error);
+                if (error != null)
+                {
+                    return false;
+                }
+
+                isEmptyProperty = reader.IsEmptyElement;
+
+                // Consume the start tag and go to the content.
+                reader.Read();
+
+                return true;
             }
+
+            /// <summary>
+            /// Read a sequence of list items with <paramref name="readItem" />,
+            /// stopping (without consuming) at the first non-element node.
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a list type, whatever its items are and
+            /// however deeply it is nested, since the items are read through
+            /// an <see cref="ElementReader{T}" /> like any other element.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static List<T> ReadList<T>(
+                Xml.XmlReader reader,
+                ElementReader<T> readItem,
+                out Reporting.Error? error
+                )
+            {
+                error = null;
+                var result = new List<T>();
+
+                SkipNoneWhitespaceAndComments(reader);
+
+                int index = 0;
+                while (reader.NodeType == Xml.XmlNodeType.Element)
+                {
+                    T item = readItem(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                index));
+                        return result;
+                    }
+
+                    result.Add(item);
+
+                    index++;
+                    SkipNoneWhitespaceAndComments(reader);
+                }
+
+                return result;
+            }
+
+            /// <summary>
+            /// Read a content as a list of items, each read with
+            /// <paramref name="readItem" />.
+            /// </summary>
+            /// <remarks>
+            /// A self-closing element represents an empty list.
+            /// </remarks>
+            /// <typeparam name="T">Type of a single list item</typeparam>
+            private static ContentReader<List<T>> AsList<T>(
+                ElementReader<T> readItem
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        return new List<T>();
+                    }
+
+                    return ReadList<T>(
+                        reader, readItem, out error);
+                };
+            }
+
+            /// <summary>
+            /// Read a content whose value is dispatched by its own discriminator
+            /// element, such as an interface or a named union.
+            /// </summary>
+            /// <typeparam name="T">Type of the value</typeparam>
+            private static ContentReader<T> AsElement<T>(
+                ElementReader<T> readFromElement
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmpty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmpty)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing the value, " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    // We need to skip the whitespace here in order to be able to look ahead
+                    // the discriminator element shortly.
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    if (reader.EOF)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML element representing the value, " +
+                            "but reached the end-of-file");
+                        return default!;
+                    }
+
+                    // Try to look ahead the discriminator name;
+                    // we need this name only for the error reporting below.
+                    // The de-serialization function will perform more sophisticated checks.
+                    string? discriminatorElementName = null;
+                    if (reader.NodeType == Xml.XmlNodeType.Element)
+                    {
+                        discriminatorElementName = reader.LocalName;
+                    }
+
+                    T result = readFromElement(reader, out error);
+                    if (error != null)
+                    {
+                        if (discriminatorElementName != null)
+                        {
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    discriminatorElementName));
+                        }
+                        return default!;
+                    }
+
+                    return result;
+                };
+            }
+
+            /// <summary>
+            /// Read a content as a tuple of 3 item(s).
+            /// </summary>
+            /// <remarks>
+            /// This is shared by everything of a tuple type of arity 3 -- be it
+            /// a property, or a value nested in a list or in another tuple.
+            /// </remarks>
+            private static ContentReader<(T0, T1, T2)> AsTuple3<T0, T1, T2>(
+                ElementReader<T0> readItem0,
+                ElementReader<T1> readItem1,
+                ElementReader<T2> readItem2
+                )
+            {
+                return (
+                    Xml.XmlReader reader,
+                    bool isEmptyProperty,
+                    out Reporting.Error? error
+                ) =>
+                {
+                    error = null;
+
+                    if (isEmptyProperty)
+                    {
+                        error = new Reporting.Error(
+                            "Expected an XML content representing a tuple of 3 item(s), " +
+                            "but the element was self-closing");
+                        return default!;
+                    }
+
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T0 item0 = readItem0(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                0));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T1 item1 = readItem1(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                1));
+                        return default!;
+                    }
+                    SkipNoneWhitespaceAndComments(reader);
+
+                    T2 item2 = readItem2(reader, out error);
+                    if (error != null)
+                    {
+                        error.PrependSegment(
+                            new Reporting.IndexSegment(
+                                2));
+                        return default!;
+                    }
+
+                    return (
+                        item0,
+                        item1,
+                        item2
+                    );
+                };
+            }
+
+            /// <summary>
+            /// Read an instance of class StructuralFirst from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.StructuralFirst> StructuralFirstFromElement = (
+                AtElement<Aas.StructuralFirst>(
+                    StructuralFirstFromSequence, "structuralFirst"));
+
+            /// <summary>
+            /// Read an instance of class StructuralSecond from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.StructuralSecond> StructuralSecondFromElement = (
+                AtElement<Aas.StructuralSecond>(
+                    StructuralSecondFromSequence, "structuralSecond"));
+
+            /// <summary>
+            /// Read an instance of class MixedAbstractDescendantOne from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.MixedAbstractDescendantOne> MixedAbstractDescendantOneFromElement = (
+                AtElement<Aas.MixedAbstractDescendantOne>(
+                    MixedAbstractDescendantOneFromSequence, "mixedAbstractDescendantOne"));
+
+            /// <summary>
+            /// Read an instance of class MixedAbstractDescendantTwo from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.MixedAbstractDescendantTwo> MixedAbstractDescendantTwoFromElement = (
+                AtElement<Aas.MixedAbstractDescendantTwo>(
+                    MixedAbstractDescendantTwoFromSequence, "mixedAbstractDescendantTwo"));
+
+            /// <summary>
+            /// Read an instance of class MixedConcreteWithDescendants from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.MixedConcreteWithDescendants> MixedConcreteWithDescendantsFromElement = (
+                AtElement<Aas.MixedConcreteWithDescendants>(
+                    MixedConcreteWithDescendantsFromSequence, "mixedConcreteWithDescendants"));
+
+            /// <summary>
+            /// Read an instance of class MixedConcreteWithDescendantsChild from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.MixedConcreteWithDescendantsChild> MixedConcreteWithDescendantsChildFromElement = (
+                AtElement<Aas.MixedConcreteWithDescendantsChild>(
+                    MixedConcreteWithDescendantsChildFromSequence, "mixedConcreteWithDescendantsChild"));
+
+            /// <summary>
+            /// Read an instance of class MixedConcreteLeaf from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.MixedConcreteLeaf> MixedConcreteLeafFromElement = (
+                AtElement<Aas.MixedConcreteLeaf>(
+                    MixedConcreteLeafFromSequence, "mixedConcreteLeaf"));
+
+            /// <summary>
+            /// Read an instance of class ModelTypedFirst from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.ModelTypedFirst> ModelTypedFirstFromElement = (
+                AtElement<Aas.ModelTypedFirst>(
+                    ModelTypedFirstFromSequence, "modelTypedFirst"));
+
+            /// <summary>
+            /// Read an instance of class ModelTypedSecond from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.ModelTypedSecond> ModelTypedSecondFromElement = (
+                AtElement<Aas.ModelTypedSecond>(
+                    ModelTypedSecondFromSequence, "modelTypedSecond"));
+
+            /// <summary>
+            /// Read an instance of class Something from its XML element.
+            /// </summary>
+            internal static readonly ElementReader<Aas.Something> SomethingFromElement = (
+                AtElement<Aas.Something>(
+                    SomethingFromSequence, "something"));
+
+            private static readonly ContentReader<string> ReadString = (
+                AsText<string>(ReadContentAsString, ""));
+
+            private static readonly ContentReader<StructuralUnion> ReadStructuralUnion = (
+                AsElement<Aas.StructuralUnion>(
+                    StructuralUnionFromElement));
+
+            private static readonly ContentReader<MixedUnion> ReadMixedUnion = (
+                AsElement<Aas.MixedUnion>(
+                    MixedUnionFromElement));
+
+            private static readonly ContentReader<ModelTypedUnion> ReadModelTypedUnion = (
+                AsElement<Aas.ModelTypedUnion>(
+                    ModelTypedUnionFromElement));
+
+            private static readonly ContentReader<List<StructuralUnion>> ReadListOfStructuralUnion = (
+                AsList<StructuralUnion>(
+                    StructuralUnionFromElement));
+
+            private static readonly ContentReader<List<MixedUnion>> ReadListOfMixedUnion = (
+                AsList<MixedUnion>(
+                    MixedUnionFromElement));
+
+            private static readonly ContentReader<List<ModelTypedUnion>> ReadListOfModelTypedUnion = (
+                AsList<ModelTypedUnion>(
+                    ModelTypedUnionFromElement));
+
+            private static readonly ContentReader<(StructuralUnion, MixedUnion, ModelTypedUnion)> ReadTupleOfStructuralUnionMixedUnionModelTypedUnion = (
+                AsTuple3<StructuralUnion, MixedUnion, ModelTypedUnion>(
+                    StructuralUnionFromElement,
+                    MixedUnionFromElement,
+                    ModelTypedUnionFromElement));
 
             /// <summary>
             /// Deserialize an instance of class StructuralFirst from a sequence of XML elements.
@@ -945,7 +748,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.StructuralFirst? StructuralFirstFromSequence(
+            internal static Aas.StructuralFirst StructuralFirstFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -963,127 +766,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class StructuralFirst, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class StructuralFirst, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "uniqueToFirst":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theUniqueToFirst = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property UniqueToFirst of an instance of class StructuralFirst, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theUniqueToFirst = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property UniqueToFirst of an instance of class StructuralFirst " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "uniqueToFirst"));
-                                        return null;
-                                    }
-                                }
+                                theUniqueToFirst = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class StructuralFirst, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class StructuralFirst " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class StructuralFirst " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class StructuralFirst " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1092,7 +822,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property UniqueToFirst has not been given " +
                         "in the XML representation of an instance of class StructuralFirst");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.StructuralFirst(
@@ -1102,54 +832,6 @@ namespace dummy
             }  // internal static Aas.StructuralFirst? StructuralFirstFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class StructuralFirst from an XML element.
-            /// </summary>
-            internal static Aas.StructuralFirst? StructuralFirstFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "StructuralFirst", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "structuralFirst")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class StructuralFirst " +
-                        $"with element name structuralFirst, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.StructuralFirst? result = (
-                    StructuralFirstFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.StructuralFirst? StructuralFirstFromElement
-
-            /// <summary>
             /// Deserialize an instance of class StructuralSecond from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1157,7 +839,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.StructuralSecond? StructuralSecondFromSequence(
+            internal static Aas.StructuralSecond StructuralSecondFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1175,127 +857,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class StructuralSecond, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class StructuralSecond, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "uniqueToSecond":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theUniqueToSecond = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property UniqueToSecond of an instance of class StructuralSecond, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theUniqueToSecond = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property UniqueToSecond of an instance of class StructuralSecond " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "uniqueToSecond"));
-                                        return null;
-                                    }
-                                }
+                                theUniqueToSecond = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class StructuralSecond, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class StructuralSecond " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class StructuralSecond " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class StructuralSecond " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1304,7 +913,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property UniqueToSecond has not been given " +
                         "in the XML representation of an instance of class StructuralSecond");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.StructuralSecond(
@@ -1314,86 +923,18 @@ namespace dummy
             }  // internal static Aas.StructuralSecond? StructuralSecondFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class StructuralSecond from an XML element.
-            /// </summary>
-            internal static Aas.StructuralSecond? StructuralSecondFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "StructuralSecond", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "structuralSecond")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class StructuralSecond " +
-                        $"with element name structuralSecond, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.StructuralSecond? result = (
-                    StructuralSecondFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.StructuralSecond? StructuralSecondFromElement
-
-            /// <summary>
             /// Deserialize an instance of IMixedAbstractMember from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IMixedAbstractMember? IMixedAbstractMemberFromElement(
+            internal static Aas.IMixedAbstractMember IMixedAbstractMemberFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -1407,7 +948,7 @@ namespace dummy
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IMixedAbstractMember? IMixedAbstractMemberFromElement
 
@@ -1419,7 +960,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.MixedAbstractDescendantOne? MixedAbstractDescendantOneFromSequence(
+            internal static Aas.MixedAbstractDescendantOne MixedAbstractDescendantOneFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1437,127 +978,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class MixedAbstractDescendantOne, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class MixedAbstractDescendantOne, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "uniqueToAbstractDescendantOne":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theUniqueToAbstractDescendantOne = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property UniqueToAbstractDescendantOne of an instance of class MixedAbstractDescendantOne, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theUniqueToAbstractDescendantOne = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property UniqueToAbstractDescendantOne of an instance of class MixedAbstractDescendantOne " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "uniqueToAbstractDescendantOne"));
-                                        return null;
-                                    }
-                                }
+                                theUniqueToAbstractDescendantOne = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class MixedAbstractDescendantOne, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedAbstractDescendantOne " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedAbstractDescendantOne " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedAbstractDescendantOne " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1566,7 +1034,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property UniqueToAbstractDescendantOne has not been given " +
                         "in the XML representation of an instance of class MixedAbstractDescendantOne");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.MixedAbstractDescendantOne(
@@ -1576,54 +1044,6 @@ namespace dummy
             }  // internal static Aas.MixedAbstractDescendantOne? MixedAbstractDescendantOneFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class MixedAbstractDescendantOne from an XML element.
-            /// </summary>
-            internal static Aas.MixedAbstractDescendantOne? MixedAbstractDescendantOneFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "MixedAbstractDescendantOne", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "mixedAbstractDescendantOne")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class MixedAbstractDescendantOne " +
-                        $"with element name mixedAbstractDescendantOne, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.MixedAbstractDescendantOne? result = (
-                    MixedAbstractDescendantOneFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.MixedAbstractDescendantOne? MixedAbstractDescendantOneFromElement
-
-            /// <summary>
             /// Deserialize an instance of class MixedAbstractDescendantTwo from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1631,7 +1051,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.MixedAbstractDescendantTwo? MixedAbstractDescendantTwoFromSequence(
+            internal static Aas.MixedAbstractDescendantTwo MixedAbstractDescendantTwoFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1649,127 +1069,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class MixedAbstractDescendantTwo, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class MixedAbstractDescendantTwo, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "uniqueToAbstractDescendantTwo":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theUniqueToAbstractDescendantTwo = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property UniqueToAbstractDescendantTwo of an instance of class MixedAbstractDescendantTwo, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theUniqueToAbstractDescendantTwo = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property UniqueToAbstractDescendantTwo of an instance of class MixedAbstractDescendantTwo " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "uniqueToAbstractDescendantTwo"));
-                                        return null;
-                                    }
-                                }
+                                theUniqueToAbstractDescendantTwo = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class MixedAbstractDescendantTwo, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedAbstractDescendantTwo " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedAbstractDescendantTwo " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedAbstractDescendantTwo " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1778,7 +1125,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property UniqueToAbstractDescendantTwo has not been given " +
                         "in the XML representation of an instance of class MixedAbstractDescendantTwo");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.MixedAbstractDescendantTwo(
@@ -1788,54 +1135,6 @@ namespace dummy
             }  // internal static Aas.MixedAbstractDescendantTwo? MixedAbstractDescendantTwoFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class MixedAbstractDescendantTwo from an XML element.
-            /// </summary>
-            internal static Aas.MixedAbstractDescendantTwo? MixedAbstractDescendantTwoFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "MixedAbstractDescendantTwo", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "mixedAbstractDescendantTwo")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class MixedAbstractDescendantTwo " +
-                        $"with element name mixedAbstractDescendantTwo, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.MixedAbstractDescendantTwo? result = (
-                    MixedAbstractDescendantTwoFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.MixedAbstractDescendantTwo? MixedAbstractDescendantTwoFromElement
-
-            /// <summary>
             /// Deserialize an instance of class MixedConcreteWithDescendants from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -1843,7 +1142,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.MixedConcreteWithDescendants? MixedConcreteWithDescendantsFromSequence(
+            internal static Aas.MixedConcreteWithDescendants MixedConcreteWithDescendantsFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -1861,127 +1160,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class MixedConcreteWithDescendants, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class MixedConcreteWithDescendants, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someBaseProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSomeBaseProperty = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeBaseProperty of an instance of class MixedConcreteWithDescendants, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeBaseProperty = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeBaseProperty of an instance of class MixedConcreteWithDescendants " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBaseProperty"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBaseProperty = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class MixedConcreteWithDescendants, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteWithDescendants " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteWithDescendants " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteWithDescendants " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -1990,7 +1216,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBaseProperty has not been given " +
                         "in the XML representation of an instance of class MixedConcreteWithDescendants");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.MixedConcreteWithDescendants(
@@ -2003,35 +1229,15 @@ namespace dummy
             /// Deserialize an instance of IMixedConcreteWithDescendants from an XML element.
             /// </summary>
             [CodeAnalysis.SuppressMessage("ReSharper", "InconsistentNaming")]
-            internal static Aas.IMixedConcreteWithDescendants? IMixedConcreteWithDescendantsFromElement(
+            internal static Aas.IMixedConcreteWithDescendants IMixedConcreteWithDescendantsFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
@@ -2045,57 +1251,9 @@ namespace dummy
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.IMixedConcreteWithDescendants? IMixedConcreteWithDescendantsFromElement
-
-            /// <summary>
-            /// Deserialize an instance of class MixedConcreteWithDescendants from an XML element.
-            /// </summary>
-            internal static Aas.MixedConcreteWithDescendants? MixedConcreteWithDescendantsFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "MixedConcreteWithDescendants", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "mixedConcreteWithDescendants")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class MixedConcreteWithDescendants " +
-                        $"with element name mixedConcreteWithDescendants, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.MixedConcreteWithDescendants? result = (
-                    MixedConcreteWithDescendantsFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.MixedConcreteWithDescendants? MixedConcreteWithDescendantsFromElement
 
             /// <summary>
             /// Deserialize an instance of class MixedConcreteWithDescendantsChild from a sequence of XML elements.
@@ -2105,7 +1263,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.MixedConcreteWithDescendantsChild? MixedConcreteWithDescendantsChildFromSequence(
+            internal static Aas.MixedConcreteWithDescendantsChild MixedConcreteWithDescendantsChildFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -2124,163 +1282,58 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class MixedConcreteWithDescendantsChild, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class MixedConcreteWithDescendantsChild, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someBaseProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSomeBaseProperty = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeBaseProperty of an instance of class MixedConcreteWithDescendantsChild, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeBaseProperty = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeBaseProperty of an instance of class MixedConcreteWithDescendantsChild " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someBaseProperty"));
-                                        return null;
-                                    }
-                                }
+                                theSomeBaseProperty = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "someChildProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSomeChildProperty = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeChildProperty of an instance of class MixedConcreteWithDescendantsChild, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeChildProperty = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeChildProperty of an instance of class MixedConcreteWithDescendantsChild " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someChildProperty"));
-                                        return null;
-                                    }
-                                }
+                                theSomeChildProperty = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class MixedConcreteWithDescendantsChild, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteWithDescendantsChild " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteWithDescendantsChild " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteWithDescendantsChild " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -2289,7 +1342,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeBaseProperty has not been given " +
                         "in the XML representation of an instance of class MixedConcreteWithDescendantsChild");
-                    return null;
+                    return default!;
                 }
 
                 if (theSomeChildProperty == null)
@@ -2297,7 +1350,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeChildProperty has not been given " +
                         "in the XML representation of an instance of class MixedConcreteWithDescendantsChild");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.MixedConcreteWithDescendantsChild(
@@ -2310,54 +1363,6 @@ namespace dummy
             }  // internal static Aas.MixedConcreteWithDescendantsChild? MixedConcreteWithDescendantsChildFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class MixedConcreteWithDescendantsChild from an XML element.
-            /// </summary>
-            internal static Aas.MixedConcreteWithDescendantsChild? MixedConcreteWithDescendantsChildFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "MixedConcreteWithDescendantsChild", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "mixedConcreteWithDescendantsChild")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class MixedConcreteWithDescendantsChild " +
-                        $"with element name mixedConcreteWithDescendantsChild, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.MixedConcreteWithDescendantsChild? result = (
-                    MixedConcreteWithDescendantsChildFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.MixedConcreteWithDescendantsChild? MixedConcreteWithDescendantsChildFromElement
-
-            /// <summary>
             /// Deserialize an instance of class MixedConcreteLeaf from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -2365,7 +1370,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.MixedConcreteLeaf? MixedConcreteLeafFromSequence(
+            internal static Aas.MixedConcreteLeaf MixedConcreteLeafFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -2383,127 +1388,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class MixedConcreteLeaf, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class MixedConcreteLeaf, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "uniqueToConcreteLeaf":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theUniqueToConcreteLeaf = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property UniqueToConcreteLeaf of an instance of class MixedConcreteLeaf, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theUniqueToConcreteLeaf = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property UniqueToConcreteLeaf of an instance of class MixedConcreteLeaf " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "uniqueToConcreteLeaf"));
-                                        return null;
-                                    }
-                                }
+                                theUniqueToConcreteLeaf = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class MixedConcreteLeaf, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteLeaf " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteLeaf " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class MixedConcreteLeaf " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -2512,7 +1444,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property UniqueToConcreteLeaf has not been given " +
                         "in the XML representation of an instance of class MixedConcreteLeaf");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.MixedConcreteLeaf(
@@ -2522,54 +1454,6 @@ namespace dummy
             }  // internal static Aas.MixedConcreteLeaf? MixedConcreteLeafFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class MixedConcreteLeaf from an XML element.
-            /// </summary>
-            internal static Aas.MixedConcreteLeaf? MixedConcreteLeafFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "MixedConcreteLeaf", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "mixedConcreteLeaf")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class MixedConcreteLeaf " +
-                        $"with element name mixedConcreteLeaf, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.MixedConcreteLeaf? result = (
-                    MixedConcreteLeafFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.MixedConcreteLeaf? MixedConcreteLeafFromElement
-
-            /// <summary>
             /// Deserialize an instance of class ModelTypedFirst from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -2577,7 +1461,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.ModelTypedFirst? ModelTypedFirstFromSequence(
+            internal static Aas.ModelTypedFirst ModelTypedFirstFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -2595,127 +1479,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class ModelTypedFirst, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class ModelTypedFirst, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSomeProperty = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeProperty of an instance of class ModelTypedFirst, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeProperty = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeProperty of an instance of class ModelTypedFirst " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someProperty"));
-                                        return null;
-                                    }
-                                }
+                                theSomeProperty = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class ModelTypedFirst, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ModelTypedFirst " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ModelTypedFirst " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ModelTypedFirst " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -2724,7 +1535,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeProperty has not been given " +
                         "in the XML representation of an instance of class ModelTypedFirst");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.ModelTypedFirst(
@@ -2734,54 +1545,6 @@ namespace dummy
             }  // internal static Aas.ModelTypedFirst? ModelTypedFirstFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class ModelTypedFirst from an XML element.
-            /// </summary>
-            internal static Aas.ModelTypedFirst? ModelTypedFirstFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "ModelTypedFirst", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "modelTypedFirst")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class ModelTypedFirst " +
-                        $"with element name modelTypedFirst, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.ModelTypedFirst? result = (
-                    ModelTypedFirstFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.ModelTypedFirst? ModelTypedFirstFromElement
-
-            /// <summary>
             /// Deserialize an instance of class ModelTypedSecond from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -2789,7 +1552,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.ModelTypedSecond? ModelTypedSecondFromSequence(
+            internal static Aas.ModelTypedSecond ModelTypedSecondFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -2807,127 +1570,54 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class ModelTypedSecond, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class ModelTypedSecond, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "someProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    theSomeProperty = "";
-                                }
-                                else
-                                {
-                                    if (reader.EOF)
-                                    {
-                                        error = new Reporting.Error(
-                                            "Expected an XML content representing " +
-                                            "the property SomeProperty of an instance of class ModelTypedSecond, " +
-                                            "but reached the end-of-file");
-                                        return null;
-                                    }
-
-                                    try
-                                    {
-                                        theSomeProperty = reader.ReadContentAsString();
-                                    }
-                                    catch (System.Exception exception)
-                                            when (exception is System.FormatException
-                                                || exception is System.Xml.XmlException)
-                                    {
-                                        error = new Reporting.Error(
-                                            "The property SomeProperty of an instance of class ModelTypedSecond " +
-                                            $"could not be de-serialized: {exception.Message}");
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "someProperty"));
-                                        return null;
-                                    }
-                                }
+                                theSomeProperty = ReadString(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class ModelTypedSecond, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ModelTypedSecond " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ModelTypedSecond " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class ModelTypedSecond " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -2936,7 +1626,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property SomeProperty has not been given " +
                         "in the XML representation of an instance of class ModelTypedSecond");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.ModelTypedSecond(
@@ -2946,54 +1636,6 @@ namespace dummy
             }  // internal static Aas.ModelTypedSecond? ModelTypedSecondFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class ModelTypedSecond from an XML element.
-            /// </summary>
-            internal static Aas.ModelTypedSecond? ModelTypedSecondFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "ModelTypedSecond", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "modelTypedSecond")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class ModelTypedSecond " +
-                        $"with element name modelTypedSecond, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.ModelTypedSecond? result = (
-                    ModelTypedSecondFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.ModelTypedSecond? ModelTypedSecondFromElement
-
-            /// <summary>
             /// Deserialize an instance of class Something from a sequence of XML elements.
             /// </summary>
             /// <remarks>
@@ -3001,7 +1643,7 @@ namespace dummy
             /// the instance from an empty sequence. That is, the parent element
             /// was a self-closing element.
             /// </remarks>
-            internal static Aas.Something? SomethingFromSequence(
+            internal static Aas.Something SomethingFromSequence(
                 Xml.XmlReader reader,
                 bool isEmptySequence,
                 out Reporting.Error? error)
@@ -3028,502 +1670,90 @@ namespace dummy
                             "Expected an XML element representing " +
                             "a property of an instance of class Something, " +
                             "but reached the end-of-file");
-                        return null;
+                        return default!;
                     }
-                    while (true)
+                    while (TryNextProperty(
+                            reader,
+                            out string elementName,
+                            out bool isEmptyProperty,
+                            out error))
                     {
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (reader.NodeType == Xml.XmlNodeType.EndElement || reader.EOF)
-                        {
-                            break;
-                        }
-
-                        if (reader.NodeType != Xml.XmlNodeType.Element)
-                        {
-                            error = new Reporting.Error(
-                                "Expected an XML start element representing " +
-                                "a property of an instance of class Something, " +
-                                $"but got the node of type {reader.NodeType} " +
-                                $"with the value {reader.Value}");
-                            return null;
-                        }
-
-                        string elementName = TryElementName(
-                            reader, out error);
-                        if (error != null)
-                        {
-                            return null;
-                        }
-
-                        bool isEmptyProperty = reader.IsEmptyElement;
-
-                        // Skip the expected element
-                        reader.Read();
-
                         switch (elementName)
                         {
                             case "structuralProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property StructuralProperty of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property StructuralProperty of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // StructuralUnionFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theStructuralProperty = StructuralUnionFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "structuralProperty"));
-                                    return null;
-                                }
+                                theStructuralProperty = ReadStructuralUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "mixedProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property MixedProperty of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property MixedProperty of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // MixedUnionFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theMixedProperty = MixedUnionFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "mixedProperty"));
-                                    return null;
-                                }
+                                theMixedProperty = ReadMixedUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "modelTypedProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property ModelTypedProperty of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property ModelTypedProperty of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // ModelTypedUnionFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theModelTypedProperty = ModelTypedUnionFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "modelTypedProperty"));
-                                    return null;
-                                }
+                                theModelTypedProperty = ReadModelTypedUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "listStructuralProperty":
-                            {
-                                theListStructuralProperty = new List<StructuralUnion>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theListStructuralProperty = ParseListOfClass<StructuralUnion>(
-                                        reader,
-                                        StructuralUnionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "listStructuralProperty"));
-                                        return null;
-                                    }
-                                }
+                                theListStructuralProperty = ReadListOfStructuralUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "listMixedProperty":
-                            {
-                                theListMixedProperty = new List<MixedUnion>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theListMixedProperty = ParseListOfClass<MixedUnion>(
-                                        reader,
-                                        MixedUnionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "listMixedProperty"));
-                                        return null;
-                                    }
-                                }
+                                theListMixedProperty = ReadListOfMixedUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "listModelTypedProperty":
-                            {
-                                theListModelTypedProperty = new List<ModelTypedUnion>();
-
-                                if (!isEmptyProperty)
-                                {
-                                    theListModelTypedProperty = ParseListOfClass<ModelTypedUnion>(
-                                        reader,
-                                        ModelTypedUnionFromElement,
-                                        out error);
-
-                                    if (error != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                "listModelTypedProperty"));
-                                        return null;
-                                    }
-                                }
+                                theListModelTypedProperty = ReadListOfModelTypedUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "tupleProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        "The property TupleProperty can not be de-serialized " +
-                                        "from a self-closing element since it needs content");
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "tupleProperty"));
-                                    return null;
-                                }
-
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                theTupleProperty = ParseTuple3(
-                                    reader,
-                                    AsTupleItemDeserializer(StructuralUnionFromElement),
-                                    AsTupleItemDeserializer(MixedUnionFromElement),
-                                    AsTupleItemDeserializer(ModelTypedUnionFromElement),
-                                    out error);
-                                if (error != null)
-                                {
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "tupleProperty"));
-                                    return null;
-                                }
+                                theTupleProperty = ReadTupleOfStructuralUnionMixedUnionModelTypedUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "optionalStructuralProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property OptionalStructuralProperty of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property OptionalStructuralProperty of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // StructuralUnionFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theOptionalStructuralProperty = StructuralUnionFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "optionalStructuralProperty"));
-                                    return null;
-                                }
+                                theOptionalStructuralProperty = ReadStructuralUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "optionalMixedProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property OptionalMixedProperty of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property OptionalMixedProperty of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // MixedUnionFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theOptionalMixedProperty = MixedUnionFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "optionalMixedProperty"));
-                                    return null;
-                                }
+                                theOptionalMixedProperty = ReadMixedUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             case "optionalModelTypedProperty":
-                            {
-                                if (isEmptyProperty)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property OptionalModelTypedProperty of an instance of class Something, " +
-                                        "but encountered a self-closing element {elementName}");
-                                    return null;
-                                }
-
-                                // We need to skip the whitespace here in order to be able to look ahead
-                                // the discriminator element shortly.
-                                SkipNoneWhitespaceAndComments(reader);
-
-                                if (reader.EOF)
-                                {
-                                    error = new Reporting.Error(
-                                        $"Expected an XML element within the element {elementName} representing " +
-                                        "the property OptionalModelTypedProperty of an instance of class Something, " +
-                                        "but reached the end-of-file");
-                                    return null;
-                                }
-
-                                // Try to look ahead the discriminator name;
-                                // we need this name only for the error reporting below.
-                                // ModelTypedUnionFromElement will perform more sophisticated
-                                // checks.
-                                string? discriminatorElementName = null;
-                                if (reader.NodeType == Xml.XmlNodeType.Element)
-                                {
-                                    discriminatorElementName = reader.LocalName;
-                                }
-
-                                theOptionalModelTypedProperty = ModelTypedUnionFromElement(
-                                    reader, out error);
-
-                                if (error != null)
-                                {
-                                    if (discriminatorElementName != null)
-                                    {
-                                        error.PrependSegment(
-                                            new Reporting.NameSegment(
-                                                discriminatorElementName));
-                                    }
-
-                                    error.PrependSegment(
-                                        new Reporting.NameSegment(
-                                            "optionalModelTypedProperty"));
-                                    return null;
-                                }
+                                theOptionalModelTypedProperty = ReadModelTypedUnion(
+                                    reader, isEmptyProperty, out error);
                                 break;
-                            }
                             default:
                                 error = new Reporting.Error(
                                     "We expected properties of the class Something, " +
                                     "but got an unexpected element " +
                                     $"with the name {elementName}");
-                                return null;
+                                return default!;
                         }
 
-                        SkipNoneWhitespaceAndComments(reader);
-
-                        if (!isEmptyProperty)
+                        // NOTE (mristin):
+                        // Every property is read in this very loop, so we mark the error with
+                        // the property's own element name here, once, instead of at every
+                        // single case above. For a matched case, elementName *is* that name.
+                        if (error != null)
                         {
-                            // Read the end element
-
-                            if (reader.EOF)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    "but got the end-of-file.");
-                                return null;
-                            }
-                            if (reader.NodeType != Xml.XmlNodeType.EndElement)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the node of type {reader.NodeType} " +
-                                    $"with the value {reader.Value}");
-                                return null;
-                            }
-
-                            string endElementName = TryElementName(
-                                reader, out error);
-                            if (error != null)
-                            {
-                                return null;
-                            }
-
-                            if (endElementName != elementName)
-                            {
-                                error = new Reporting.Error(
-                                    "Expected an XML end element to conclude a property of class Something " +
-                                    $"with the element name {elementName}, " +
-                                    $"but got the end element with the name {reader.Name}");
-                                return null;
-                            }
-                            // Skip the expected end element
-                            reader.Read();
+                            error.PrependSegment(
+                                new Reporting.NameSegment(
+                                    elementName));
+                            return default!;
                         }
+
+                        ConsumeEndElement(
+                            reader, elementName, isEmptyProperty, out error);
+                        if (error != null)
+                        {
+                            return default!;
+                        }
+                    }
+
+                    // NOTE (mristin):
+                    // The loop also ends when the next property could not be read at all,
+                    // which is the only way out of it that is a failure.
+                    if (error != null)
+                    {
+                        return default!;
                     }
                 }
 
@@ -3532,7 +1762,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property StructuralProperty has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theMixedProperty == null)
@@ -3540,7 +1770,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property MixedProperty has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theModelTypedProperty == null)
@@ -3548,7 +1778,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property ModelTypedProperty has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theListStructuralProperty == null)
@@ -3556,7 +1786,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property ListStructuralProperty has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theListMixedProperty == null)
@@ -3564,7 +1794,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property ListMixedProperty has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theListModelTypedProperty == null)
@@ -3572,7 +1802,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property ListModelTypedProperty has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 if (theTupleProperty == null)
@@ -3580,7 +1810,7 @@ namespace dummy
                     error = new Reporting.Error(
                         "The required property TupleProperty has not been given " +
                         "in the XML representation of an instance of class Something");
-                    return null;
+                    return default!;
                 }
 
                 return new Aas.Something(
@@ -3611,314 +1841,161 @@ namespace dummy
             }  // internal static Aas.Something? SomethingFromSequence
 
             /// <summary>
-            /// Deserialize an instance of class Something from an XML element.
-            /// </summary>
-            internal static Aas.Something? SomethingFromElement(
-                Xml.XmlReader reader,
-                out Reporting.Error? error)
-            {
-                error = null;
-
-                string elementName = ReadStartElementOfClass(
-                    reader, "Something", out bool isEmptyElement, out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                if (elementName != "something")
-                {
-                    error = new Reporting.Error(
-                        "Expected an element representing an instance of class Something " +
-                        $"with element name something, but got: {elementName}");
-                    return null;
-                }
-
-                // Skip the element node and go to the content
-                reader.Read();
-
-                Aas.Something? result = (
-                    SomethingFromSequence(
-                        reader, isEmptyElement, out error));
-                if (error != null)
-                {
-                    return null;
-                }
-
-                ConsumeCloseTag(
-                    reader,
-                    elementName,
-                    isEmptyElement,
-                    out error);
-                if (error != null)
-                {
-                    return null;
-                }
-
-                return result;
-            }  // internal static Aas.Something? SomethingFromElement
-
-            /// <summary>
             /// Deserialize an instance of StructuralUnion from an XML element.
             /// </summary>
-            internal static Aas.StructuralUnion? StructuralUnionFromElement(
+            internal static Aas.StructuralUnion StructuralUnionFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
                 {
                     case "structuralFirst":
                     {
-                        Aas.StructuralFirst? instance = StructuralFirstFromElement(
+                        Aas.StructuralFirst instance = StructuralFirstFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.StructuralUnion.FromStructuralFirst(instance);
                     }
                     case "structuralSecond":
                     {
-                        Aas.StructuralSecond? instance = StructuralSecondFromElement(
+                        Aas.StructuralSecond instance = StructuralSecondFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.StructuralUnion.FromStructuralSecond(instance);
                     }
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.StructuralUnion? StructuralUnionFromElement
 
             /// <summary>
             /// Deserialize an instance of MixedUnion from an XML element.
             /// </summary>
-            internal static Aas.MixedUnion? MixedUnionFromElement(
+            internal static Aas.MixedUnion MixedUnionFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
                 {
                     case "mixedAbstractDescendantOne":
                     {
-                        Aas.MixedAbstractDescendantOne? instance = MixedAbstractDescendantOneFromElement(
+                        Aas.MixedAbstractDescendantOne instance = MixedAbstractDescendantOneFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.MixedUnion.FromMixedAbstractDescendantOne(instance);
                     }
                     case "mixedAbstractDescendantTwo":
                     {
-                        Aas.MixedAbstractDescendantTwo? instance = MixedAbstractDescendantTwoFromElement(
+                        Aas.MixedAbstractDescendantTwo instance = MixedAbstractDescendantTwoFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.MixedUnion.FromMixedAbstractDescendantTwo(instance);
                     }
                     case "mixedConcreteWithDescendantsChild":
                     {
-                        Aas.MixedConcreteWithDescendantsChild? instance = MixedConcreteWithDescendantsChildFromElement(
+                        Aas.MixedConcreteWithDescendantsChild instance = MixedConcreteWithDescendantsChildFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.MixedUnion.FromMixedConcreteWithDescendantsChild(instance);
                     }
                     case "mixedConcreteWithDescendants":
                     {
-                        Aas.MixedConcreteWithDescendants? instance = MixedConcreteWithDescendantsFromElement(
+                        Aas.MixedConcreteWithDescendants instance = MixedConcreteWithDescendantsFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.MixedUnion.FromMixedConcreteWithDescendants(instance);
                     }
                     case "mixedConcreteLeaf":
                     {
-                        Aas.MixedConcreteLeaf? instance = MixedConcreteLeafFromElement(
+                        Aas.MixedConcreteLeaf instance = MixedConcreteLeafFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.MixedUnion.FromMixedConcreteLeaf(instance);
                     }
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.MixedUnion? MixedUnionFromElement
 
             /// <summary>
             /// Deserialize an instance of ModelTypedUnion from an XML element.
             /// </summary>
-            internal static Aas.ModelTypedUnion? ModelTypedUnionFromElement(
+            internal static Aas.ModelTypedUnion ModelTypedUnionFromElement(
                 Xml.XmlReader reader,
                 out Reporting.Error? error)
             {
-                error = null;
-
-                SkipNoneWhitespaceAndComments(reader);
-
-                if (reader.EOF)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, but reached end-of-file");
-                    return null;
-                }
-
-                if (reader.NodeType != Xml.XmlNodeType.Element)
-                {
-                    error = new Reporting.Error(
-                        "Expected an XML element, " +
-                        $"but got a node of type {reader.NodeType} " +
-                        $"with value {reader.Value}");
-                    return null;
-                }
-
-                string elementName = TryElementName(
+                string elementName = PeekElementName(
                     reader, out error);
                 if (error != null)
                 {
-                    return null;
+                    return default!;
                 }
 
                 switch (elementName)
                 {
                     case "modelTypedFirst":
                     {
-                        Aas.ModelTypedFirst? instance = ModelTypedFirstFromElement(
+                        Aas.ModelTypedFirst instance = ModelTypedFirstFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.ModelTypedUnion.FromModelTypedFirst(instance);
                     }
                     case "modelTypedSecond":
                     {
-                        Aas.ModelTypedSecond? instance = ModelTypedSecondFromElement(
+                        Aas.ModelTypedSecond instance = ModelTypedSecondFromElement(
                             reader, out error);
                         if (error != null)
                         {
-                            return null;
-                        }
-                        if (instance == null)
-                        {
-                            throw new System.InvalidOperationException(
-                                "Unexpected instance null when error null");
+                            return default!;
                         }
                         return Aas.ModelTypedUnion.FromModelTypedSecond(instance);
                     }
                     default:
                         error = new Reporting.Error(
                             $"Unexpected element with the name {elementName}");
-                        return null;
+                        return default!;
                 }
             }  // internal static Aas.ModelTypedUnion? ModelTypedUnionFromElement
         }  // internal static class DeserializeImplementation
@@ -3983,19 +2060,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.StructuralFirst? result = (
-                    DeserializeImplementation.StructuralFirstFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.StructuralFirst result = DeserializeImplementation.StructuralFirstFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4020,19 +2094,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.StructuralSecond? result = (
-                    DeserializeImplementation.StructuralSecondFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.StructuralSecond result = DeserializeImplementation.StructuralSecondFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4057,19 +2128,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IMixedAbstractMember? result = (
-                    DeserializeImplementation.IMixedAbstractMemberFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IMixedAbstractMember result = DeserializeImplementation.IMixedAbstractMemberFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4094,19 +2162,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.MixedAbstractDescendantOne? result = (
-                    DeserializeImplementation.MixedAbstractDescendantOneFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.MixedAbstractDescendantOne result = DeserializeImplementation.MixedAbstractDescendantOneFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4131,19 +2196,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.MixedAbstractDescendantTwo? result = (
-                    DeserializeImplementation.MixedAbstractDescendantTwoFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.MixedAbstractDescendantTwo result = DeserializeImplementation.MixedAbstractDescendantTwoFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4168,19 +2230,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.IMixedConcreteWithDescendants? result = (
-                    DeserializeImplementation.IMixedConcreteWithDescendantsFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.IMixedConcreteWithDescendants result = DeserializeImplementation.IMixedConcreteWithDescendantsFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4205,19 +2264,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.MixedConcreteWithDescendants? result = (
-                    DeserializeImplementation.MixedConcreteWithDescendantsFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.MixedConcreteWithDescendants result = DeserializeImplementation.MixedConcreteWithDescendantsFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4242,19 +2298,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.MixedConcreteWithDescendantsChild? result = (
-                    DeserializeImplementation.MixedConcreteWithDescendantsChildFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.MixedConcreteWithDescendantsChild result = DeserializeImplementation.MixedConcreteWithDescendantsChildFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4279,19 +2332,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.MixedConcreteLeaf? result = (
-                    DeserializeImplementation.MixedConcreteLeafFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.MixedConcreteLeaf result = DeserializeImplementation.MixedConcreteLeafFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4316,19 +2366,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ModelTypedFirst? result = (
-                    DeserializeImplementation.ModelTypedFirstFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ModelTypedFirst result = DeserializeImplementation.ModelTypedFirstFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4353,19 +2400,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ModelTypedSecond? result = (
-                    DeserializeImplementation.ModelTypedSecondFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ModelTypedSecond result = DeserializeImplementation.ModelTypedSecondFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4390,19 +2434,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.Something? result = (
-                    DeserializeImplementation.SomethingFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.Something result = DeserializeImplementation.SomethingFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4427,19 +2468,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.StructuralUnion? result = (
-                    DeserializeImplementation.StructuralUnionFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.StructuralUnion result = DeserializeImplementation.StructuralUnionFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4464,19 +2502,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.MixedUnion? result = (
-                    DeserializeImplementation.MixedUnionFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.MixedUnion result = DeserializeImplementation.MixedUnionFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
 
             /// <summary>
@@ -4501,19 +2536,16 @@ namespace dummy
                         "to be set at content with MoveToContent");
                 }
 
-                Aas.ModelTypedUnion? result = (
-                    DeserializeImplementation.ModelTypedUnionFromElement(
-                        reader,
-                        out Reporting.Error? error));
+                Aas.ModelTypedUnion result = DeserializeImplementation.ModelTypedUnionFromElement(
+                    reader,
+                    out Reporting.Error? error);
                 if (error != null)
                 {
                     throw new Xmlization.Exception(
                         Reporting.GenerateRelativeXPath(error.PathSegments),
                         error.Cause);
                 }
-                return result
-                    ?? throw new System.InvalidOperationException(
-                        "Unexpected output null when error is null");
+                return result;
             }
         }  // public static class Deserialize
 
@@ -4631,9 +2663,7 @@ namespace dummy
             /// first needs to be wrapped in its own positional <c>v1</c>, <c>v2</c>,
             /// *etc.* element -- this adapter closes over the element name so that
             /// a tuple-typed property does not need to spell out that wrapping (start
-            /// element/write value/end element) at every item, mirroring how
-            /// <see cref="AsTupleItemDeserializer{T}(NamedClassItemDeserializer{T}, string)" />
-            /// avoids the equivalent on the read side.
+            /// element/write value/end element) at every item.
             /// </remarks>
             /// <typeparam name="T">Type of the item to be written</typeparam>
             private delegate void NamedElementSerializer<T>(


### PR DESCRIPTION
The generated ``xmlization.cs`` repeated itself at three levels. Every property of every concrete class inlined its whole reading procedure into its own ``case`` block -- the self-closing check, the end-of-file check, the ``try``/``catch`` around the conversion, an error message naming that property and its class, the ``PrependSegment`` marking the path, and, for a list or a tuple, the loop or the positional ``<v>`` elements on top. Every concrete class then got its own ``...FromElement`` function, and all of those were the same 43 lines with four tokens substituted in. And every ``...FromSequence`` re-emitted the ~70 lines of framing around its property loop, which said nothing about the class it belonged to.

Everything is now read through one composable shape, and the pieces that do not vary are generated once:

    case "category":
        theCategory = ReadString(
            reader, isEmptyProperty, out error);
        break;

The rationale and the design:

* **One shape for every reader.** Reading a property's content, a list item's and a tuple item's are the same operation at different nesting depths, so they are one delegate:

      private delegate T ContentReader<T>(
          Xml.XmlReader reader, bool isEmpty, out Reporting.Error? error);

  Because the shape is uniform a reader can be an argument to another reader, so a list of tuples -- or anything deeper the meta-model may grow -- falls out of the existing pieces instead of needing a generated helper per combination.

* **A plain ``T`` return, not ``T?`` and not ``out T``.** Failure travels in the error alone and the value is then ``default!``, which the caller never reads. ``T?`` would have split the machinery in two, since a nullable return is ``Nullable<T>`` for a value type but a nullable reference otherwise and no unconstrained parameter covers both. ``out T`` would have compiled, but ``out`` is invariant, so a reader of a concrete class could no longer serve as the item reader of an interface-typed list; a return type is covariant in a method-group conversion.

* **Combinators return delegates**, because C# has no partial application: ``AsText``, ``AsEnum``, ``AsList``, ``AsElement`` and ``AsTuple1..N`` each take what varies and return a ``ContentReader``.

* **``AtElement`` is the hinge, and the element name is data.** It binds a name to a ``ContentReader`` and yields an ``ElementReader``, which is what a list and a tuple take for their items -- and also what a class is. A name cannot be a type argument (``v`` in a list, ``v1``, ``v2``, ... by position in a tuple, its own XML name for a class), so it is passed. With the messages phrased in terms of that name, the combinator needs nothing further to say what it expected, which is what lets one combinator serve both a class and a ``<v>`` element.

* **A class's element reader is therefore a binding, not a function.** A class's ``...FromSequence`` already is a ``ContentReader``, so its element reader is ``AtElement(ExtensionFromSequence, "extension")`` and the 43-line function per class is gone. Call sites are unchanged: a field is invoked exactly like the method was.

* **The composed readers live in ``static readonly`` fields.** This is not cosmetic. Composing at the call site allocates a closure on every read -- measured at 152 bytes against zero for the code being replaced, a real regression for a de-serialization library. Composing once costs nothing per read and de-duplicates: 276 properties collapse onto 40 readers.

  Two consequences worth knowing. Field initialisers run in declaration order, so a reader is emitted after everything it composes. And ``ElementReader`` had to become covariant and ``internal``: as a method group a class's reader widened to its interface for free, but a field is a value, and a field may not be less accessible than its type.

* **Looking ahead an element's name is one helper**, ``PeekElementName``, shared by ``AtElement`` and by the thirteen readers that dispatch on a discriminator element -- they only ever needed the name, and consuming nothing is what lets the dispatch hand the whole element on.

* **The property loop keeps only its ``switch``.** ``TryNextProperty`` reads the next property's start tag or reports that the sequence ended, and ``ConsumeEndElement`` -- shared with ``AtElement``, which concludes identically -- consumes the end tag. Only the ``switch`` stays inline, because its branches assign the locals the constructor is called with.

* **The property is marked on the error path once per class, after the ``switch``**, rather than in every case: for a matched case the element name already is the property's XML name.

* **The type in a message comes from ``typeof(T).Name``**, so the shared skeletons do not grow with the number of types in the meta-model.

* **Only what a model reaches is emitted**, gated along the call graph rather than by property kind -- a list of enumerations needs the enumeration combinator even when no property is one. Without that, a small meta-model would pay for helpers it never calls.

For the AAS meta-model, ``xmlization.cs`` goes from 22,572 to 12,471 lines (-44.8%), the per-property blocks from 19.7 to 3.7 lines on average, and the read side loses 38 generated functions along with four helpers.